### PR TITLE
remove private artifacts

### DIFF
--- a/dht/compositions/all-balsam-k8s.toml
+++ b/dht/compositions/all-balsam-k8s.toml
@@ -20,7 +20,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -36,7 +35,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -52,7 +50,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -68,7 +65,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -83,7 +79,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -98,7 +93,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -113,7 +107,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -129,7 +122,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -144,7 +136,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -159,7 +150,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -173,7 +163,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bootstrapper = "true"
       bs_strategy = "6"

--- a/dht/compositions/all-both-k8s.toml
+++ b/dht/compositions/all-both-k8s.toml
@@ -20,7 +20,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -39,7 +38,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -58,7 +56,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -76,7 +73,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -95,7 +91,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -122,7 +117,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:ca78473d669d"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -148,7 +142,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:ca78473d669d"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -175,7 +168,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:ca78473d669d"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -202,7 +194,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:ca78473d669d"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"

--- a/dht/compositions/bootstrap-network-cypress-k8s.toml
+++ b/dht/compositions/bootstrap-network-cypress-k8s.toml
@@ -28,7 +28,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:adaa263d3b51"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -54,7 +53,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:adaa263d3b51"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -80,7 +78,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:adaa263d3b51"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"

--- a/dht/compositions/find-provs-balsam-k8s.toml
+++ b/dht/compositions/find-provs-balsam-k8s.toml
@@ -20,7 +20,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -36,7 +35,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -52,7 +50,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -68,7 +65,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -83,7 +79,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -98,7 +93,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -113,7 +107,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -129,7 +122,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -144,7 +136,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -159,7 +150,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bs_strategy = "6"
       bucket_size = "10"
@@ -173,7 +163,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:018e66855db4"
     [groups.run.test_params]
       bootstrapper = "true"
       bs_strategy = "6"

--- a/dht/compositions/find-provs-both-k8s.toml
+++ b/dht/compositions/find-provs-both-k8s.toml
@@ -20,7 +20,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -39,7 +38,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -58,7 +56,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -76,7 +73,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -95,7 +91,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:701251a63b92"
     [groups.run.test_params]
       bs_strategy = "7"
       bucket_size = "10"
@@ -122,7 +117,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:ca78473d669d"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -148,7 +142,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:ca78473d669d"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -175,7 +168,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:ca78473d669d"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -202,7 +194,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:ca78473d669d"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"

--- a/dht/compositions/find-provs-both-local.toml
+++ b/dht/compositions/find-provs-both-local.toml
@@ -17,7 +17,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "0a67fb8fbbc9"
     [groups.run.test_params]
       bs_strategy = "3"
       bucket_size = "10"
@@ -35,7 +34,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "0a67fb8fbbc9"
     [groups.run.test_params]
       bs_strategy = "3"
       bucket_size = "10"
@@ -53,7 +51,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "0a67fb8fbbc9"
     [groups.run.test_params]
       bs_strategy = "3"
       bucket_size = "10"
@@ -70,7 +67,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "0a67fb8fbbc9"
     [groups.run.test_params]
       bs_strategy = "3"
       bucket_size = "10"
@@ -88,7 +84,6 @@
   [groups.build]
     selectors = ["balsam"]
   [groups.run]
-    artifact = "0a67fb8fbbc9"
     [groups.run.test_params]
       bs_strategy = "3"
       bucket_size = "10"
@@ -114,7 +109,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "f1d89aed47ea"
     [groups.run.test_params]
       alpha = "6"
       bs_strategy = "3"
@@ -138,7 +132,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "f1d89aed47ea"
     [groups.run.test_params]
       alpha = "6"
       bs_strategy = "3"
@@ -163,7 +156,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "f1d89aed47ea"
     [groups.run.test_params]
       alpha = "6"
       bs_strategy = "3"
@@ -188,7 +180,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "f1d89aed47ea"
     [groups.run.test_params]
       alpha = "6"
       bootstrapper = "true"

--- a/dht/compositions/find-provs-cypress-k8s.toml
+++ b/dht/compositions/find-provs-cypress-k8s.toml
@@ -28,7 +28,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:3c690e7169d5"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -54,7 +53,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:3c690e7169d5"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -81,7 +79,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:3c690e7169d5"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -108,7 +105,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:3c690e7169d5"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -135,7 +131,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:3c690e7169d5"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -162,7 +157,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:3c690e7169d5"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"

--- a/dht/compositions/find-provs-k8s.toml
+++ b/dht/compositions/find-provs-k8s.toml
@@ -19,7 +19,6 @@
     percentage = 0.0
   [groups.build]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-dht:07736f7b34c3"
     [groups.run.test_params]
       bucket_size = "4"
       client_mode = "false"
@@ -45,7 +44,6 @@
       module = "github.com/libp2p/go-libp2p-autonat"
       version = "v0.1.2-0.20200204200147-902af8cb7b6a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-dht:d4709f2f74cd"
     [groups.run.test_params]
       bucket_size = "4"
       client_mode = "false"

--- a/dht/compositions/find-provs.toml
+++ b/dht/compositions/find-provs.toml
@@ -16,7 +16,6 @@
     percentage = 0.0
   [groups.build]
   [groups.run]
-    artifact = "d0b0506b5d41"
     [groups.run.test_params]
       bucket_size = "4"
       client_mode = "false"
@@ -42,7 +41,6 @@
       module = "github.com/libp2p/go-libp2p-autonat"
       version = "v0.1.2-0.20200204200147-902af8cb7b6a"
   [groups.run]
-    artifact = "ec4c0ec62a02"
     [groups.run.test_params]
       bucket_size = "4"
       client_mode = "false"

--- a/dht/compositions/gcp-balsam-k8s.toml
+++ b/dht/compositions/gcp-balsam-k8s.toml
@@ -19,7 +19,6 @@
     percentage = 1.0
   [groups.build]
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-dht:7177e811244e"
     [groups.run.test_params]
       bucket_size = "10"
       client_mode = "false"

--- a/dht/compositions/gcp-cypress-k8s.toml
+++ b/dht/compositions/gcp-cypress-k8s.toml
@@ -28,7 +28,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:aa0340067f21"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -54,7 +53,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:aa0340067f21"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"
@@ -82,7 +80,6 @@
       module = "github.com/libp2p/go-libp2p-xor"
       version = "df24f5b04bcbdc0059b27989163a6090f4f6dc7a"
   [groups.run]
-    artifact = "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-us-east-1-dht:aa0340067f21"
     [groups.run.test_params]
       alpha = "6"
       beta = "3"


### PR DESCRIPTION
This PR is addressing an issue described at https://github.com/libp2p/test-plans/issues/10 - seems like we are keeping private artifacts as part of our public composition files.

Generally we shouldn't need artifacts any more, since we have improved a lot the building and pushing of images in the last few releases of Testground. I believe artifacts were used heavily by @aschmahmann while Testground didn't have good support for caching and was making redundant pushes to remote registries.

cc @Drengot-p2p