### PR TITLE
ping/_composition/go.toml: disable go custom & master branches

### DIFF
--- a/ping/_compositions/go.toml
+++ b/ping/_compositions/go.toml
@@ -1,12 +1,12 @@
-[master]
-GoVersion = '1.18'
-Modfile = "go.v0.21.mod"
-Selector = 'v0.21'
+# [master]
+# GoVersion = '1.18'
+# Modfile = "go.v0.21.mod"
+# Selector = 'v0.21'
 
-[custom]
-GoVersion = '1.18'
-Modfile = "go.v0.21.mod"
-Selector = 'v0.21'
+# [custom]
+# GoVersion = '1.18'
+# Modfile = "go.v0.21.mod"
+# Selector = 'v0.21'
 
 [[groups]]
 Id = "v0.11"


### PR DESCRIPTION
We disabled interop tests in go-libp2p which means that the go-libp2p team might break the interoperability testing at any time.

That's a problem when it comes to interoperability testing: if we enable interop testing in rust, maintainers will experience random breakage in the CI because of the other repo. We can only play catch-up with the go-side until we re-enable the interop tests there.

This PR disables go's `master` and `custom`  tests until we fix the stability / caching issues and reenable the tests in go-libp2p.

## Related issues & PR

- https://github.com/libp2p/go-libp2p/issues/1670
- https://github.com/libp2p/rust-libp2p/pull/2835

## current go status

The tests started breaking after we moved go-libp2p-core into go-libp2p/core. It breaks every versions at the moment ([work in progress branch](https://github.com/laurentsenta/test-plans/commits/fix/go-libp2p-ping)).



