### PR TITLE
ping/_compositions/*: fix rust version rewrite

### DIFF
--- a/ping/_compositions/go-rust-interop-latest.toml
+++ b/ping/_compositions/go-rust-interop-latest.toml
@@ -105,7 +105,7 @@
         CARGO_FEATURES = '{{ .CargoFeatures }}'
         CARGO_REMOVE = '{{ .CargoFeatures }}'
         CARGO_PATCH = """
-          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "0.47.0", optional = true}
+          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "{{ .Version }}", optional = true}
           """
   {{ end }}
   {{ end }}

--- a/ping/_compositions/go-rust-interop.toml
+++ b/ping/_compositions/go-rust-interop.toml
@@ -133,7 +133,7 @@
         CARGO_FEATURES = '{{ .CargoFeatures }}'
         CARGO_REMOVE = '{{ .CargoFeatures }}'
         CARGO_PATCH = """
-          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "0.47.0", optional = true}
+          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "{{ .Version }}", optional = true}
           """
   {{ end }}
   {{ end }}

--- a/ping/_compositions/rust-cross-versions.toml
+++ b/ping/_compositions/rust-cross-versions.toml
@@ -37,7 +37,7 @@
         CARGO_FEATURES = '{{ .CargoFeatures }}'
         CARGO_REMOVE = '{{ .CargoFeatures }}'
         CARGO_PATCH = """
-          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "0.47.0", optional = true}
+          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "{{ .Version }}", optional = true}
           """
     {{ end }}
   {{ end }}

--- a/ping/_compositions/rust.toml
+++ b/ping/_compositions/rust.toml
@@ -1,7 +1,9 @@
 [master]
+Version = '0.48.0'
 CargoFeatures = 'libp2pv0480'
 
 [custom]
+Version = '0.48.0'
 CargoFeatures = 'libp2pv0480'
 
 [[groups]]


### PR DESCRIPTION
Recent builds break because there is a version `0.47.0` in one of our rewrite strings,
 
- Demo run with a custom branch: https://github.com/libp2p/test-plans/runs/8087223516?check_suite_focus=true
