### PR TITLE
.github/workflows: use write-artifacts and prevent rebuild

### DIFF
--- a/.github/actions/setup-testground/action.yml
+++ b/.github/actions/setup-testground/action.yml
@@ -19,8 +19,13 @@ runs:
       if: ${{ inputs.testground_ref == 'edge' }}
       shell: bash
       run: |
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/testground/testground/master/install.sh)"
-
+        for i in 1 2 3; do
+          echo "=== Attempt $i ==="
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/testground/testground/master/install.sh)" && \
+            exit 0
+          sleep 10
+        done
+        exit 1
     # Custom setup (slower) when we use a different testground_ref
     - name: Checkout testground
       if: ${{ inputs.testground_ref != 'edge' }}

--- a/.github/workflows/run-composition.yml
+++ b/.github/workflows/run-composition.yml
@@ -36,6 +36,7 @@ jobs:
       TEST_PLAN_REPO: ${{ inputs.test_repository || 'libp2p/test-plans' }}
       TEST_PLAN_BRANCH: ${{ inputs.test_ref || 'master' }}
       TESTGROUND_ENDPOINT: ${{ inputs.testground_endpoint }}
+      COMPOSITION_FILE: ${{ inputs.composition_file }}
     defaults:
       run:
         shell: bash
@@ -67,7 +68,8 @@ jobs:
           for i in 1 2 3; do
             echo "=== Attempt $i ==="
             testground build composition                        \
-              -f ${{ inputs.composition_file }}                 \
+              -f "${COMPOSITION_FILE}"                          \
+              --write-artifacts                                 \
               --wait && exit 0;
             sleep 10
           done
@@ -81,7 +83,7 @@ jobs:
         timeout-minutes: 6
         run: |
           testground run composition                          \
-            -f ${{ inputs.composition_file }}                 \
+            -f "${COMPOSITION_FILE}"                          \
             --metadata-repo "${GITHUB_REPOSITORY}"            \
             --metadata-branch "${GITHUB_REF#refs/heads/}"     \
             --metadata-commit "${GITHUB_SHA}"                 \
@@ -98,5 +100,6 @@ jobs:
           path: |
             ~/testground/
             ~/test-plans/result.tgz
+            ${{env.COMPOSITION_FILE}}
             testground.*
             test-plans/*.out

--- a/.github/workflows/run-composition.yml
+++ b/.github/workflows/run-composition.yml
@@ -63,7 +63,7 @@ jobs:
           echo "::set-output name=custom_git_sha::${SHA}"
       - name: Build the composition file
         working-directory: ./test-plans
-        timeout-minutes: 30
+        timeout-minutes: 40
         run: |
           for i in 1 2 3; do
             echo "=== Attempt $i ==="


### PR DESCRIPTION
fixes #39 

Use the `write-artifacts` option during the build.
With this option, Testground replaces the composition file with the one produced by the build step (template generation applied, build artifact set).

With this we:
- Never rebuild the containers, even on Docker cache miss,
- Can save the generated composition (templating applied) as a useful debug artifact

## Tasks

- [x] merge https://github.com/testground/testground/pull/1444
- [x] drop the debug commit