### PR TITLE
ping/rust: remove the master dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ When a new version of libp2p is released, we want to make it permanent in the `p
 When a new version of libp2p is released, we want to make it permanent in the `ping/rust` test folder.
 
 1. In the `ping/_compositions/rust.toml` file,
-    - Copy the `[master]` section and turn it into a item in the `[[groups]]` array
-    - Update the `[master]` section with the new master version
+    - Copy the latest `[[groups]]` section and update it's `Id` and `CargoFeature` name.
 2. In the `ping/rust` folder,
-    - `Cargo.toml`: update the feature flags `libp2pvxxx` to fix the released version and add the new `master`
-    - `src/main.rs`: Update the `mod libp2p` definition with the new master
+    - `Cargo.toml`: create the feature flags `libp2pvxxx` with the released version,
+    - `src/main.rs`: Update the `mod libp2p` definition with the new version,
     - Run `cargo update` if needed. Try to build with `cargo build --features libp2pvxxx`
 3. Run the test on your machine
-    - Do once, from the test-plans root: import the test-plans with `testground plan import ./ --name libp2p`
+    - Do once, from the test-plans root: import the test-plans with `testground plan import --from ./ --name libp2p`
     - Run the test with `testground run composition -f ping/_compositions/rust-cross-versions.toml --wait`
 
 ## License

--- a/ping/_compositions/go-rust-interop-latest.toml
+++ b/ping/_compositions/go-rust-interop-latest.toml
@@ -93,7 +93,7 @@
         CARGO_FEATURES = '{{ .CargoFeatures }}'
         CARGO_REMOVE = '{{ .CargoFeatures }}'
         CARGO_PATCH = """
-          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "{{ .Version }}", optional = true}
+          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], optional = true}
           """
   {{ end }}
   {{ end }}

--- a/ping/_compositions/go-rust-interop.toml
+++ b/ping/_compositions/go-rust-interop.toml
@@ -133,7 +133,7 @@
         CARGO_FEATURES = '{{ .CargoFeatures }}'
         CARGO_REMOVE = '{{ .CargoFeatures }}'
         CARGO_PATCH = """
-          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "{{ .Version }}", optional = true}
+          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], optional = true}
           """
   {{ end }}
   {{ end }}

--- a/ping/_compositions/rust-cross-versions.toml
+++ b/ping/_compositions/rust-cross-versions.toml
@@ -37,7 +37,7 @@
         CARGO_FEATURES = '{{ .CargoFeatures }}'
         CARGO_REMOVE = '{{ .CargoFeatures }}'
         CARGO_PATCH = """
-          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "{{ .Version }}", optional = true}
+          {{ .CargoFeatures }} = {package = "libp2p", git = "https://{{ or $.Env.GitTarget "github.com/libp2p/rust-libp2p" }}", rev = "{{ $.Env.GitReference }}", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], optional = true}
           """
     {{ end }}
   {{ end }}

--- a/ping/_compositions/rust.toml
+++ b/ping/_compositions/rust.toml
@@ -1,10 +1,8 @@
 [master]
-Version = '0.48.0'
-CargoFeatures = 'libp2pv0480'
+CargoFeatures = 'libp2pmaster'
 
 [custom]
-Version = '0.48.0'
-CargoFeatures = 'libp2pv0480'
+CargoFeatures = 'libp2pmaster'
 
 [[groups]]
 Id = "v0.47.0"

--- a/ping/rust/Cargo.toml
+++ b/ping/rust/Cargo.toml
@@ -24,4 +24,5 @@ libp2pv0440 = {package = "libp2p", default_features = false, features = [ "webso
 libp2pv0450 = {package = "libp2p", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "0.45.0", optional = true}
 libp2pv0460 = {package = "libp2p", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "0.46.0", optional = true}
 libp2pv0470 = {package = "libp2p", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "0.47.0", optional = true}
-libp2pv0480 = {package = "libp2p", git = "https://github.com/libp2p/rust-libp2p", branch = "master", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], version = "0.48.0", optional = true}
+
+libp2pmaster = {package = "libp2p", git = "https://github.com/libp2p/rust-libp2p", branch = "master", default_features = false, features = [ "websocket", "mplex", "yamux", "tcp-async-io", "ping", "noise", "dns-async-std" ], optional = true}

--- a/ping/rust/Cargo.toml
+++ b/ping/rust/Cargo.toml
@@ -13,7 +13,7 @@ rand = "0.8"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 soketto = "0.7.1"
-testground = {git = "https://github.com/testground/sdk-rust", branch = "master", version = "0.4.0"}
+testground = {git = "https://github.com/testground/sdk-rust", rev = "94a9a72796f94cc7ca786a5f019d07f328c76d4b", version = "0.4.0"}
 thiserror = "1"
 tokio = { version = "1", default-features = false, features = ["sync", "rt-multi-thread", "macros", "net"] }
 tokio-stream = { version = "0.1", default-features = false, features = [] }

--- a/ping/rust/src/main.rs
+++ b/ping/rust/src/main.rs
@@ -11,8 +11,8 @@ use testground::network_conf::{
 };
 
 pub mod libp2p {
-    #[cfg(all(feature = "libp2pv0480",))]
-    pub use libp2pv0480::*;
+    #[cfg(all(feature = "libp2pmaster",))]
+    pub use libp2pmaster::*;
 
     #[cfg(all(feature = "libp2pv0470",))]
     pub use libp2pv0470::*;


### PR DESCRIPTION
Fixes #43 

Problem definition:
- We want to give the `rust-libp2p` repository the ability to build and test their `master` branch (which is also used when testing fork and PRs).
- We want to protect other client-repositories (such as `go-libp2p`) from failure due to unchecked changes in the `rust-libp2p` repository.

The case we've seen with #43:

- A release happens in `rust-libp2p`,
- The version is bumped in the `master` branch
- Now the line `libp2pv0480 = { git= ... branch = master, version = 0.48.0}` breaks because the version cannot be found.

This is a valid change (the `rust-libp2p` didn't break the interop contract, they "just" updated versions) which broke the `go-libp2p` repository.

## Root cause

The way we implement compatibility/features flags with rust has two constraints:

- we can't use "official" dependencies rewrites because rust libp2p uses feature flags. combining the two is not supported in cargo.
- even though a composition might build and use only versions `rust-1` and `rust-2`, the `Cargo.toml`, which contains every version, including `master`, has to be valid.
