### PR TITLE
Run `cargo update` before build

### DIFF
--- a/ping/rust/Dockerfile
+++ b/ping/rust/Dockerfile
@@ -37,6 +37,7 @@ RUN mv /tmp/Cargo.toml /tmp/Cargo.lock ./plan
 ARG CARGO_FEATURES=""
 
 RUN cd ./plan/ && \
+        cargo update && \
         cargo build --release --features="${CARGO_FEATURES}"
 
 FROM debian:bullseye-slim


### PR DESCRIPTION
I am hoping that this resolves the issue in https://github.com/libp2p/rust-libp2p/pull/2972.

What I think is happening here is that we can't resolve a dependency because some patch-versions of dependencies are outdated.