### PR TITLE
ping/rust: Run cargo update

### DIFF
--- a/ping/rust/Cargo.lock
+++ b/ping/rust/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da5b41ee986eed3f524c380e6d64965aea573882a8907682ad100f7859305ca"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -123,16 +123,16 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
+checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
+ "async-lock",
  "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
- "once_cell",
  "parking",
  "polling",
  "slab",
@@ -143,11 +143,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -290,9 +291,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -373,9 +374,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 
 [[package]]
 name = "cfg-if"
@@ -430,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -466,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
 dependencies = [
  "cc",
 ]
@@ -591,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -601,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -615,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
@@ -966,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -1066,9 +1067,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1277,9 +1278,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libp2p"
@@ -1452,7 +1453,7 @@ dependencies = [
  "libp2p-ping 0.40.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-swarm 0.40.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-swarm-derive 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-tcp 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-tcp 0.37.0",
  "libp2p-websocket 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-yamux 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiaddr",
@@ -1464,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.50.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "bytes",
  "futures",
@@ -1481,7 +1482,7 @@ dependencies = [
  "libp2p-ping 0.40.1 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
  "libp2p-swarm 0.40.1 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
  "libp2p-swarm-derive 0.30.1 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
- "libp2p-tcp 0.37.0 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
+ "libp2p-tcp 0.38.0",
  "libp2p-websocket 0.39.0 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
  "libp2p-yamux 0.41.0 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
  "multiaddr",
@@ -1697,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.37.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1819,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.37.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "async-std-resolver 0.22.0",
  "futures",
@@ -1833,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.41.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -1924,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.10.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "libp2p-core 0.37.0 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
  "libp2p-ping 0.40.1 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
@@ -2043,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.37.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2192,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.40.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.1",
@@ -2309,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.40.1"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2444,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.40.1"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "either",
  "fnv",
@@ -2505,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.30.1"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "heck 0.4.0",
  "quote",
@@ -2615,8 +2616,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.37.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+version = "0.38.0"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "async-io",
  "futures",
@@ -2744,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.39.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "either",
  "futures",
@@ -2841,7 +2842,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.41.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "futures",
  "libp2p-core 0.37.0 (git+https://github.com/libp2p/rust-libp2p?branch=master)",
@@ -2932,14 +2933,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3024,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.12.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "bytes",
  "futures",
@@ -3148,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -3160,9 +3161,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "owning_ref"
@@ -3199,7 +3200,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3284,15 +3285,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polling"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -3846,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?branch=master#56a4a946c68567be6b40b9394206b0bc09b14c48"
+source = "git+https://github.com/libp2p/rust-libp2p?branch=master#b42f28630e2a7a04642c95aa8e7f4deea823f901"
 dependencies = [
  "futures",
  "pin-project 1.0.12",
@@ -3883,18 +3884,18 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4225,9 +4226,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -4757,19 +4758,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
@@ -4797,12 +4785,6 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
@@ -4812,12 +4794,6 @@ name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4833,12 +4809,6 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
@@ -4848,12 +4818,6 @@ name = "windows_x86_64_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4872,12 +4836,6 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"


### PR DESCRIPTION
Updates dependency. In the hope to resolve conflict from https://github.com/libp2p/rust-libp2p/pull/2972/.