### PR TITLE
ping/rust: Don't set PR ref for master build

### DIFF
--- a/ping/_compositions/rust-cross-versions.toml
+++ b/ping/_compositions/rust-cross-versions.toml
@@ -25,7 +25,7 @@
 
     [groups.build_config.build_args]
       BINARY_NAME = '{{ .BinaryName }}'
-      GIT_REF = '{{ $.Env.GitReference }}'
+      GIT_REF = "master"
   {{ end }}
 
   {{ if $.Env.GitReference }}


### PR DESCRIPTION
When building the `master` image we would previously mistakingly set the ref to the PR commit hash.

This surfaced when testing a pull request from a fork. `master` would be pointed at the forks HEAD commit hash, but not the fork URL. Thus the build could not find the commit and would fail. See https://github.com/libp2p/rust-libp2p/pull/3154

I would consider this a hotfix. Long term it would be great to be able to support pull requests that target other branches than `master`.

What do folks think? Does the above make sense?