### PR TITLE
fix(ping/rust): Implemented 0.50 changes

### DIFF
--- a/ping/rust/Cargo.toml
+++ b/ping/rust/Cargo.toml
@@ -31,5 +31,5 @@ libp2pv0490 = { package = "libp2p", version = "0.49.0", features = ["websocket",
 [dependencies."libp2pv0500"]
 package = "libp2p"
 git = "https://github.com/libp2p/rust-libp2p"
-rev = "368705a1465c4322948d14ee46d42475c472ca1e" # This should usually point to a commit on master.
+tag = "v0.50.0"
 features = ["websocket", "mplex", "yamux", "tcp", "ping", "noise", "dns", "async-std", "rsa", "macros"]

--- a/ping/rust/src/bin/testplan_0500.rs
+++ b/ping/rust/src/bin/testplan_0500.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());
 
-    let swarm = OrphanRuleWorkaround(Swarm::with_tokio_executor(
+    let swarm = OrphanRuleWorkaround(Swarm::with_async_std_executor(
         development_transport(local_key).await?,
         Behaviour {
             keep_alive: keep_alive::Behaviour,

--- a/ping/rust/src/bin/testplan_0500.rs
+++ b/ping/rust/src/bin/testplan_0500.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());
 
-    let swarm = OrphanRuleWorkaround(Swarm::new(
+    let swarm = OrphanRuleWorkaround(Swarm::with_async_std_executor(
         development_transport(local_key).await?,
         Behaviour {
             keep_alive: keep_alive::Behaviour,

--- a/ping/rust/src/bin/testplan_0500.rs
+++ b/ping/rust/src/bin/testplan_0500.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());
 
-    let swarm = OrphanRuleWorkaround(Swarm::with_async_std_executor(
+    let swarm = OrphanRuleWorkaround(Swarm::with_tokio_executor(
         development_transport(local_key).await?,
         Behaviour {
             keep_alive: keep_alive::Behaviour,


### PR DESCRIPTION
As requested by @thomaseizinger, this changes the test plans to take the removed APIs into account. See libp2p/rust-libp2p#3170 for details.