### PR TITLE
feat(ping/rust): bump Rust version of docker image to 1.65

### DIFF
--- a/ping/rust/Dockerfile
+++ b/ping/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.62-bullseye as builder
+FROM rust:1.65-bullseye as builder
 WORKDIR /usr/src/testplan
 
 RUN apt-get update && apt-get install -y cmake protobuf-compiler


### PR DESCRIPTION
Otherwise the tests for https://github.com/libp2p/rust-libp2p/pull/3239 don't run.