### PR TITLE
Fix race in ping test case for Go

### DIFF
--- a/ping/go/compat/libp2p.v0.11.go
+++ b/ping/go/compat/libp2p.v0.11.go
@@ -6,11 +6,10 @@ package compat
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p/config"
 
@@ -40,29 +39,13 @@ func getSecurityByName(secureChannel string) libp2p.Option {
 }
 
 type ConnEventsSub struct {
-	sub event.Subscription
 }
 
 func SubscribeToConnectedEvents(host host.Host) (ConnEventsSub, error) {
-	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
-	if err != nil {
-		return ConnEventsSub{}, err
-	}
-
-	return ConnEventsSub{
-		sub: sub,
-	}, nil
-
+	return ConnEventsSub{}, nil
 }
 
 func (s *ConnEventsSub) WaitForNConnectedEvents(n int) {
-	connectedPeers := 0
-	for e := range s.sub.Out() {
-		if e.(event.EvtPeerConnectednessChanged).Connectedness == network.Connected {
-			connectedPeers++
-		}
-		if connectedPeers == n {
-			return
-		}
-	}
+	// We can't subscribe to events here. Let's just do a timeout.
+	time.Sleep(5 * time.Second)
 }

--- a/ping/go/compat/libp2p.v0.11.go
+++ b/ping/go/compat/libp2p.v0.11.go
@@ -43,7 +43,7 @@ type ConnEventsSub struct {
 	sub event.Subscription
 }
 
-func SubscribeToConnectedEvents() (ConnEventsSub, error) {
+func SubscribeToConnectedEvents(host host.Host) (ConnEventsSub, error) {
 	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
 	if err != nil {
 		return ConnEventsSub{}, err

--- a/ping/go/compat/libp2p.v0.11.go
+++ b/ping/go/compat/libp2p.v0.11.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p/config"
 
@@ -35,4 +37,32 @@ func getSecurityByName(secureChannel string) libp2p.Option {
 		return libp2p.Security(tls.ID, tls.New)
 	}
 	panic(fmt.Sprintf("unknown secure channel: %s", secureChannel))
+}
+
+type ConnEventsSub struct {
+	sub event.Subscription
+}
+
+func SubscribeToConnectedEvents() (ConnEventsSub, error) {
+	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
+	if err != nil {
+		return ConnEventsSub{}, err
+	}
+
+	return ConnEventsSub{
+		sub: sub,
+	}, nil
+
+}
+
+func (s *ConnEventsSub) WaitForNConnectedEvents(n int) {
+	connectedPeers := 0
+	for e := range s.sub.Out() {
+		if e.(event.EvtPeerConnectednessChanged).Connectedness == network.Connected {
+			connectedPeers++
+		}
+		if connectedPeers == n {
+			return
+		}
+	}
 }

--- a/ping/go/compat/libp2p.v0.17.go
+++ b/ping/go/compat/libp2p.v0.17.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p/config"
 
@@ -34,4 +36,32 @@ func getSecurityByName(secureChannel string) libp2p.Option {
 		return libp2p.Security(tls.ID, tls.New)
 	}
 	panic(fmt.Sprintf("unknown secure channel: %s", secureChannel))
+}
+
+type ConnEventsSub struct {
+	sub event.Subscription
+}
+
+func SubscribeToConnectedEvents() (ConnEventsSub, error) {
+	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
+	if err != nil {
+		return ConnEventsSub{}, err
+	}
+
+	return ConnEventsSub{
+		sub: sub,
+	}, nil
+
+}
+
+func (s *ConnEventsSub) WaitForNConnectedEvents(n int) {
+	connectedPeers := 0
+	for e := range s.sub.Out() {
+		if e.(event.EvtPeerConnectednessChanged).Connectedness == network.Connected {
+			connectedPeers++
+		}
+		if connectedPeers == n {
+			return
+		}
+	}
 }

--- a/ping/go/compat/libp2p.v0.17.go
+++ b/ping/go/compat/libp2p.v0.17.go
@@ -42,7 +42,7 @@ type ConnEventsSub struct {
 	sub event.Subscription
 }
 
-func SubscribeToConnectedEvents() (ConnEventsSub, error) {
+func SubscribeToConnectedEvents(host host.Host) (ConnEventsSub, error) {
 	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
 	if err != nil {
 		return ConnEventsSub{}, err

--- a/ping/go/compat/libp2p.v0.20.go
+++ b/ping/go/compat/libp2p.v0.20.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p/config"
-	"github.com/libp2p/go-libp2p/core/event"
 
 	noise "github.com/libp2p/go-libp2p/p2p/security/noise"
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"

--- a/ping/go/compat/libp2p.v0.20.go
+++ b/ping/go/compat/libp2p.v0.20.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p/config"
+	"github.com/libp2p/go-libp2p/core/event"
 
 	noise "github.com/libp2p/go-libp2p/p2p/security/noise"
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
@@ -34,4 +36,32 @@ func getSecurityByName(secureChannel string) libp2p.Option {
 		return libp2p.Security(tls.ID, tls.New)
 	}
 	panic(fmt.Sprintf("unknown secure channel: %s", secureChannel))
+}
+
+type ConnEventsSub struct {
+	sub event.Subscription
+}
+
+func SubscribeToConnectedEvents() (ConnEventsSub, error) {
+	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
+	if err != nil {
+		return ConnEventsSub{}, err
+	}
+
+	return ConnEventsSub{
+		sub: sub,
+	}, nil
+
+}
+
+func (s *ConnEventsSub) WaitForNConnectedEvents(n int) {
+	connectedPeers := 0
+	for e := range s.sub.Out() {
+		if e.(event.EvtPeerConnectednessChanged).Connectedness == network.Connected {
+			connectedPeers++
+		}
+		if connectedPeers == n {
+			return
+		}
+	}
 }

--- a/ping/go/compat/libp2p.v0.20.go
+++ b/ping/go/compat/libp2p.v0.20.go
@@ -42,7 +42,7 @@ type ConnEventsSub struct {
 	sub event.Subscription
 }
 
-func SubscribeToConnectedEvents() (ConnEventsSub, error) {
+func SubscribeToConnectedEvents(host host.Host) (ConnEventsSub, error) {
 	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
 	if err != nil {
 		return ConnEventsSub{}, err

--- a/ping/go/compat/libp2p.v0.22.go
+++ b/ping/go/compat/libp2p.v0.22.go
@@ -32,7 +32,7 @@ type ConnEventsSub struct {
 	sub event.Subscription
 }
 
-func SubscribeToConnectedEvents() (ConnEventsSub, error) {
+func SubscribeToConnectedEvents(host host.Host) (ConnEventsSub, error) {
 	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
 	if err != nil {
 		return ConnEventsSub{}, err

--- a/ping/go/compat/libp2p.v0.22.go
+++ b/ping/go/compat/libp2p.v0.22.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p/config"
+	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 
@@ -24,6 +26,34 @@ func NewLibp2(ctx context.Context, secureChannel string, opts ...config.Option) 
 	return libp2p.New(
 		append(opts, security)...,
 	)
+}
+
+type ConnEventsSub struct {
+	sub event.Subscription
+}
+
+func SubscribeToConnectedEvents() (ConnEventsSub, error) {
+	sub, err := host.EventBus().Subscribe(new(event.EvtPeerConnectednessChanged))
+	if err != nil {
+		return ConnEventsSub{}, err
+	}
+
+	return ConnEventsSub{
+		sub: sub,
+	}, nil
+
+}
+
+func (s *ConnEventsSub) WaitForNConnectedEvents(n int) {
+	connectedPeers := 0
+	for e := range s.sub.Out() {
+		if e.(event.EvtPeerConnectednessChanged).Connectedness == network.Connected {
+			connectedPeers++
+		}
+		if connectedPeers == n {
+			return
+		}
+	}
 }
 
 func getSecurityByName(secureChannel string) libp2p.Option {

--- a/ping/go/compat/libp2p.v0.22.go
+++ b/ping/go/compat/libp2p.v0.22.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p/config"
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	noise "github.com/libp2p/go-libp2p/p2p/security/noise"

--- a/ping/go/main.go
+++ b/ping/go/main.go
@@ -231,6 +231,7 @@ func runPing(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 
 	// Wait for a connection to all peers
 	connectedEvents.WaitForNConnectedEvents(runenv.TestInstanceCount - 1)
+	runenv.RecordMessage("Connected")
 
 	// Wait for all peers to signal that they're done with the connection phase.
 	initCtx.SyncClient.MustSignalAndWait(ctx, "connected", runenv.TestInstanceCount)

--- a/ping/go/main.go
+++ b/ping/go/main.go
@@ -132,6 +132,12 @@ func runPing(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 	// Record our listen addrs.
 	runenv.RecordMessage("my listen addrs: %v", host.Addrs())
 
+	// Subscribe to connectedness events.
+	connectedEvents, err := compat.SubscribeToConnectedEvents()
+	if err != nil {
+		return err
+	}
+
 	// Obtain our own address info, and use the sync service to publish it to a
 	// 'peersTopic' topic, where others will read from.
 	var (
@@ -222,6 +228,9 @@ func runPing(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 	}
 
 	runenv.RecordMessage("done dialling my peers")
+
+	// Wait for a connection to all peers
+	connectedEvents.WaitForNConnectedEvents(runenv.TestInstanceCount - 1)
 
 	// Wait for all peers to signal that they're done with the connection phase.
 	initCtx.SyncClient.MustSignalAndWait(ctx, "connected", runenv.TestInstanceCount)

--- a/ping/go/main.go
+++ b/ping/go/main.go
@@ -133,7 +133,7 @@ func runPing(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 	runenv.RecordMessage("my listen addrs: %v", host.Addrs())
 
 	// Subscribe to connectedness events.
-	connectedEvents, err := compat.SubscribeToConnectedEvents()
+	connectedEvents, err := compat.SubscribeToConnectedEvents(host)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There's a race issue where the local node emits the connected event, even if it doesn't have connections to all peers. This shows up in rust x go tests quite often.

Dealing with the shim layer was quite tough and involved a very slow feedback cycle. A simple `go build` doesn't work so you have to try against testground, which takes a while.