### PR TITLE
interop: Improve logging level of tests

### DIFF
--- a/multidim-interop/rust/src/lib.rs
+++ b/multidim-interop/rust/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{env, str::FromStr, time::Duration};
 
 use anyhow::{Context, Result};
-use env_logger::Env;
+use env_logger::{Env, Target};
 use log::info;
 use redis::{AsyncCommands, Client as Rclient};
 use strum::EnumString;
@@ -78,7 +78,9 @@ where
     let mut conn = client.get_async_connection().await?;
 
     info!("Running ping test: {}", swarm.local_peer_id());
-    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+        .target(Target::Stdout)
+        .init();
 
     info!(
         "Test instance, listening for incoming connections on: {:?}.",

--- a/multidim-interop/rust/src/lib.rs
+++ b/multidim-interop/rust/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{env, str::FromStr, time::Duration};
 
 use anyhow::{Context, Result};
-use env_logger::{Env, Target};
+use env_logger::Env;
 use log::info;
 use redis::{AsyncCommands, Client as Rclient};
 use strum::EnumString;
@@ -78,9 +78,7 @@ where
     let mut conn = client.get_async_connection().await?;
 
     info!("Running ping test: {}", swarm.local_peer_id());
-    env_logger::Builder::from_env(Env::default().default_filter_or("info"))
-        .target(Target::Stdout)
-        .init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     info!(
         "Test instance, listening for incoming connections on: {:?}.",

--- a/multidim-interop/src/generator.ts
+++ b/multidim-interop/src/generator.ts
@@ -139,7 +139,12 @@ function buildSpec(containerImages: { [key: string]: string }, { name, dialerID,
                     ip: "0.0.0.0",
                 }
             },
-            redis: { image: "redis/redis-stack", }
+            redis: {
+                image: "redis/redis-stack",
+                environment: {
+                    REDIS_ARGS: "--loglevel warning"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
By reducing the `redis` container logs to warning, and changing the target of the `rust` ping test to stdout instead of stderr.