### PR TITLE
Add go-libp2p v0.25.1

### DIFF
--- a/multidim-interop/go/v0.25/.gitignore
+++ b/multidim-interop/go/v0.25/.gitignore
@@ -1,0 +1,4 @@
+go-libp2p-*.zip
+go-libp2p-*
+go-libp2p-*/*
+image.json

--- a/multidim-interop/go/v0.25/Makefile
+++ b/multidim-interop/go/v0.25/Makefile
@@ -1,0 +1,20 @@
+image_name := go-v0.25
+commitSha := 5741b6c9bbcc1185bdf94d816dca966b37ce61ff
+
+all: image.json
+
+image.json: go-libp2p-${commitSha}
+	cd go-libp2p-${commitSha} && IMAGE_NAME=${image_name} ../../../dockerBuildWrapper.sh -f test-plans/PingDockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+go-libp2p-${commitSha}: go-libp2p-${commitSha}.zip
+	unzip -o go-libp2p-${commitSha}.zip
+
+go-libp2p-${commitSha}.zip:
+	wget -O $@ "https://github.com/libp2p/go-libp2p/archive/${commitSha}.zip"
+
+clean:
+	rm image.json
+	rm go-libp2p-*.zip
+	rm -rf go-libp2p-*

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -1,3 +1,4 @@
+import gov025 from "./go/v0.25/image.json"
 import gov024 from "./go/v0.24/image.json"
 import gov023 from "./go/v0.23/image.json"
 import gov022 from "./go/v0.22/image.json"
@@ -36,6 +37,13 @@ export const versions: Array<Version> = [
         transports: [{ name: "webtransport", onlyDial: true }, { name: "webrtc", onlyDial: true }],
         secureChannels: [],
         muxers: []
+    },
+    {
+        id: "go-v0.25.1",
+        containerImageID: gov025.imageID,
+        transports: ["tcp", "ws", "quic", "quic-v1", "webtransport"],
+        secureChannels: ["tls", "noise"],
+        muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.24.2",


### PR DESCRIPTION
go-libp2p v0.25.1 is released. Lets add it to the tests.

This is almost identical to the rust test (checkout from repo and build the defined image)