### PR TITLE
fix(aws): Only set bucket var when creds are available

### DIFF
--- a/.github/actions/run-interop-ping-test/action.yml
+++ b/.github/actions/run-interop-ping-test/action.yml
@@ -28,7 +28,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
+    - if: inputs.s3-access-key-id != '' && inputs.s3-secret-access-key != ''
+      run: |
         echo "AWS_BUCKET=${{ inputs.s3-cache-bucket }}" >> $GITHUB_ENV
         echo "AWS_REGION=${{ inputs.aws-region }}" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
The `dockerBuildWrapper` script enables caching based on the `AWS_BUCKET` environment variable. When calling the `libp2p ping interop test` with a bucket name but no AWS credentials, this leads to the script enabling caching even though the workflow does not have access to AWS.

With this commit the environment variable `AWS_BUCKET` is only set when credentials are available and thus the `dockerBuildWrapper` script does not enable caching then workflow does nothave access to AWS.

Not deeply familiar with the setup. Let me know in case there are cleaner solutions.

See also https://github.com/libp2p/rust-libp2p/pull/3462 and the corresponding failure on its first commit.