### PR TITLE
Switch to redis:7-alpine

### DIFF
--- a/multidim-interop/src/generator.ts
+++ b/multidim-interop/src/generator.ts
@@ -161,7 +161,7 @@ function buildSpec(containerImages: { [key: string]: string }, { name, dialerID,
                 }
             },
             redis: {
-                image: "redis/redis-stack",
+                image: "redis:7-alpine",
                 environment: {
                     REDIS_ARGS: "--loglevel warning"
                 }


### PR DESCRIPTION
It's 10x smaller at 30MiB vs >500 MiB. We don't need or want the full "redis-stack" (comparison: https://redis.io/download/)