### PR TITLE
feat(rust): Add v0.51

### DIFF
--- a/multidim-interop/rust/v0.51/Makefile
+++ b/multidim-interop/rust/v0.51/Makefile
@@ -1,0 +1,20 @@
+image_name := rust-v0.51
+commitSha := 1a9cf4f7760724032b729c43165716c7ecd842ad
+
+all: image.json
+
+image.json: rust-libp2p-${commitSha}
+	cd rust-libp2p-${commitSha} && IMAGE_NAME=${image_name} ../../../dockerBuildWrapper.sh -f interop-tests/Dockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+rust-libp2p-${commitSha}: rust-libp2p-${commitSha}.zip
+	unzip -o rust-libp2p-${commitSha}.zip
+
+rust-libp2p-${commitSha}.zip:
+	wget -O $@ "https://github.com/libp2p/rust-libp2p/archive/${commitSha}.zip"
+
+clean:
+	rm image.json
+	rm rust-libp2p-*.zip
+	rm -rf rust-libp2p-*

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -5,6 +5,7 @@ import gov022 from "./go/v0.22/image.json"
 import rustv048 from "./rust/v0.48/image.json"
 import rustv049 from "./rust/v0.49/image.json"
 import rustv050 from "./rust/v0.50/image.json"
+import rustv051 from "./rust/v0.51/image.json"
 import jsV041 from "./js/v0.41/node-image.json"
 import jsV042 from "./js/v0.42/node-image.json"
 import nimv10 from "./nim/v1.0/image.json"
@@ -39,6 +40,13 @@ export const versions: Array<Version> = [
     {
         id: "rust-v0.50.0",
         containerImageID: rustv050.imageID,
+        transports: ["ws", "tcp", "quic-v1", "webrtc"],
+        secureChannels: ["tls", "noise"],
+        muxers: ["mplex", "yamux"],
+    },
+    {
+        id: "rust-v0.51.0",
+        containerImageID: rustv051.imageID,
         transports: ["ws", "tcp", "quic-v1", "webrtc"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],


### PR DESCRIPTION
With the latest rust-libp2p
[v0.51.0](https://github.com/libp2p/rust-libp2p/releases/tag/v0.51.0) release, one can now test the `v0.51` family in the interop tests.