### PR TITLE
Add ws dialing test in browser

### DIFF
--- a/multidim-interop/js/v0.41/test/ping.spec.ts
+++ b/multidim-interop/js/v0.41/test/ping.spec.ts
@@ -6,6 +6,7 @@ import { createLibp2p, Libp2pOptions } from 'libp2p'
 import { webTransport } from '@libp2p/webtransport'
 import { tcp } from '@libp2p/tcp'
 import { webSockets } from '@libp2p/websockets'
+import * as filters from "@libp2p/websockets/filters"
 import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
 import { yamux } from '@chainsafe/libp2p-yamux'
@@ -53,7 +54,7 @@ describe('ping test', () => {
         }
         break
       case 'ws':
-        options.transports = [webSockets()]
+        options.transports = [webSockets({ filter: filters.all })]
         options.addresses = {
           listen: isDialer ? [] : [`/ip4/${IP}/tcp/0/ws`]
         }

--- a/multidim-interop/js/v0.42/test/ping.spec.ts
+++ b/multidim-interop/js/v0.42/test/ping.spec.ts
@@ -6,6 +6,7 @@ import { createLibp2p, Libp2pOptions } from 'libp2p'
 import { webTransport } from '@libp2p/webtransport'
 import { tcp } from '@libp2p/tcp'
 import { webSockets } from '@libp2p/websockets'
+import * as filters from "@libp2p/websockets/filters"
 import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
 import { yamux } from '@chainsafe/libp2p-yamux'
@@ -53,7 +54,7 @@ describe('ping test', () => {
         }
         break
       case 'ws':
-        options.transports = [webSockets()]
+        options.transports = [webSockets({ filter: filters.all })]
         options.addresses = {
           listen: isDialer ? [] : [`/ip4/${IP}/tcp/0/ws`]
         }

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -68,14 +68,14 @@ export const versions: Array<Version> = [
     {
         id: "chromium-js-v0.41.0",
         containerImageID: chromiumJsV041.imageID,
-        transports: [{ name: "webtransport", onlyDial: true }, { name: "webrtc", onlyDial: true }],
+        transports: [{ name: "webtransport", onlyDial: true }, { name: "webrtc", onlyDial: true }, {name: "ws", onlyDial: true}],
         secureChannels: [],
         muxers: []
     },
     {
         id: "chromium-js-v0.42.0",
         containerImageID: chromiumJsV042.imageID,
-        transports: [{ name: "webtransport", onlyDial: true }, { name: "webrtc", onlyDial: true }, { name: "wss", onlyDial: true }],
+        transports: [{ name: "webtransport", onlyDial: true }, { name: "webrtc", onlyDial: true }, { name: "wss", onlyDial: true },  {name: "ws", onlyDial: true}],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"]
     },


### PR DESCRIPTION
This adds a websocket (unsecure) interop test. I'm not sure how useful this is, since in practice you will probably have to use wss. So I'll keep this as a draft for now.