### PR TITLE
fix(versions): disable webrtc tests

### DIFF
--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -40,14 +40,14 @@ export const versions: Array<Version> = [
     {
         id: "rust-v0.50.0",
         containerImageID: rustv050.imageID,
-        transports: ["ws", "tcp", "quic-v1", "webrtc"],
+        transports: ["ws", "tcp", "quic-v1"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "rust-v0.51.0",
         containerImageID: rustv051.imageID,
-        transports: ["ws", "tcp", "quic-v1", "webrtc"],
+        transports: ["ws", "tcp", "quic-v1"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
@@ -68,14 +68,14 @@ export const versions: Array<Version> = [
     {
         id: "chromium-js-v0.41.0",
         containerImageID: chromiumJsV041.imageID,
-        transports: [{ name: "webtransport", onlyDial: true }, { name: "webrtc", onlyDial: true }],
+        transports: [{ name: "webtransport", onlyDial: true }],
         secureChannels: [],
         muxers: []
     },
     {
         id: "chromium-js-v0.42.0",
         containerImageID: chromiumJsV042.imageID,
-        transports: [{ name: "webtransport", onlyDial: true }, { name: "webrtc", onlyDial: true }, { name: "wss", onlyDial: true }],
+        transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"]
     },


### PR DESCRIPTION
This commit disables the WebRTC tests for rust-libp2p v0.50.0 and v0.51.0 and chromium-js v0.41.0 and v0.42.0. Neither of these support the new `/webrtc-direct` (see https://github.com/multiformats/multiaddr/pull/150/#issuecomment-1468791586 for context on rename).

The missing support is blocking https://github.com/libp2p/rust-libp2p/pull/3688 namely to upgrade to using `/webrtc-direct`. (Note that this is only blocking CI. Users can already use `/webrtc-direct` with the latest released rust-libp2p.) More concretely the latest rust-libp2p `master` sends a `/webrtc-direct` address as the listener to the dialer. The dialer (i.e. the versions listed above) do not support `/webrtc-direct` and thus fail.

We will backport `/webrtc-direct` support to the rust-libp2p `v0.51.0` interop binary and then re-enable it here. I assume we can not do the same in js-libp2p as it is released as a breaking change. @achingbrain is that correct?

Instead of disabling the versions with missing support for `/webrtc-direct` we could as well patch our interoperability test logic, e.g. send both `/webrtc` and `/webrtc-direct` addresses. For the sake of simplicity, I am proposing simply disabling the versions for now.

@achingbrain @MarcoPolo @thomaseizinger do you have thoughts on this? Would you prefer a patch to the interop test binary logic?

Pull request updating js-libp2p-webrtc to support `/webrtc-direct`: https://github.com/libp2p/js-libp2p-webrtc/pull/100