### PR TITLE
fix(interop): rename `webrtc` to `webrtc-direct`

### DIFF
--- a/multidim-interop/impl/go/v0.24/main.go
+++ b/multidim-interop/impl/go/v0.24/main.go
@@ -117,6 +117,8 @@ func main() {
 	case "webtransport":
 		fallthrough
 	case "webrtc":
+		fallthrough
+	case "webrtc-direct":
 		skipMuxer = true
 		skipSecureChannel = true
 	}

--- a/multidim-interop/impl/rust/v0.51/Makefile
+++ b/multidim-interop/impl/rust/v0.51/Makefile
@@ -1,5 +1,5 @@
 image_name := rust-v0.51
-commitSha := 1a9cf4f7760724032b729c43165716c7ecd842ad
+commitSha := 3c5940aeadb9ed8527b6f7aa158797359085293d
 
 all: image.json
 

--- a/multidim-interop/impl/rust/v0.51/Makefile
+++ b/multidim-interop/impl/rust/v0.51/Makefile
@@ -1,5 +1,5 @@
 image_name := rust-v0.51
-commitSha := 3c5940aeadb9ed8527b6f7aa158797359085293d
+commitSha := 0d5cac0cb595702567e50221fed9ae525b4c6f20
 
 all: image.json
 

--- a/multidim-interop/src/generator.ts
+++ b/multidim-interop/src/generator.ts
@@ -61,7 +61,7 @@ export async function buildTestSpecs(versions: Array<Version>): Promise<Array<Co
                      AND ma.muxer == mb.muxer
                      -- quic only uses its own muxer/securechannel
                      AND a.transport != "webtransport"
-                     AND a.transport != "webrtc"
+                     AND a.transport != "webrtc-direct"
                      AND a.transport != "quic"
                      AND a.transport != "quic-v1";`);
     const quicQueryResults =
@@ -85,13 +85,13 @@ export async function buildTestSpecs(versions: Array<Version>): Promise<Array<Co
                      AND NOT b.onlyDial
                      -- Only webtransport transports
                      AND a.transport == "webtransport";`);
-    const webrtcQueryResults =
+    const webrtcDirectQueryResults =
         await db.all(`SELECT DISTINCT a.id as id1, b.id as id2, a.transport
                      FROM transports a, transports b
                      WHERE a.transport == b.transport
                      AND NOT b.onlyDial
-                     -- Only webrtc transports
-                     AND a.transport == "webrtc";`);
+                     -- Only webrtc-direct transports
+                     AND a.transport == "webrtc-direct";`);
     await db.close();
 
     const testSpecs = queryResults.map((test): ComposeSpecification => (
@@ -115,7 +115,7 @@ export async function buildTestSpecs(versions: Array<Version>): Promise<Array<Co
                 transport: test.transport,
                 extraEnv: buildExtraEnv(timeoutOverride, test.id1, test.id2)
             })))
-        .concat(webrtcQueryResults
+        .concat(webrtcDirectQueryResults
             .map((test): ComposeSpecification => buildSpec(containerImages, {
                 name: `${test.id1} x ${test.id2} (${test.transport})`,
                 dialerID: test.id1,

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -47,7 +47,7 @@ export const versions: Array<Version> = [
     {
         id: "rust-v0.51.0",
         containerImageID: rustv051.imageID,
-        transports: ["ws", "tcp", "quic-v1"],
+        transports: ["ws", "tcp", "quic-v1", "webrtc-direct"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },


### PR DESCRIPTION
See https://github.com/multiformats/multiaddr/pull/150#issuecomment-1468791586 for context on discussion.

- Renames the `webrtc` transport identifier to `webrtc-direct`.
- Re-enables `webrtc-direct` support for rust-libp2p v0.51. Previously disabled in https://github.com/libp2p/test-plans/pull/160. See https://github.com/libp2p/rust-libp2p/pull/3781 for corresponding change on the rust-libp2p side.
- Leaves JS v0.41 and v0.42 untouched. To be done in a follow-up alongside JS dependency updates.