### PR TITLE
Bring back zig-libp2p

### DIFF
--- a/multidim-interop/Makefile
+++ b/multidim-interop/Makefile
@@ -2,8 +2,9 @@ GO_SUBDIRS := $(wildcard impl/go/*/.)
 JS_SUBDIRS := $(wildcard impl/js/*/.)
 RUST_SUBDIRS := $(wildcard impl/rust/*/.)
 NIM_SUBDIRS := $(wildcard impl/nim/*/.)
+ZIG_SUBDIRS := $(wildcard impl/zig/*/.)
 
-all: $(GO_SUBDIRS) $(JS_SUBDIRS) $(RUST_SUBDIRS) $(NIM_SUBDIRS)
+all: $(GO_SUBDIRS) $(JS_SUBDIRS) $(RUST_SUBDIRS) $(NIM_SUBDIRS) $(ZIG_SUBDIRS)
 $(JS_SUBDIRS):
 	$(MAKE) -C $@
 $(GO_SUBDIRS):
@@ -12,6 +13,8 @@ $(RUST_SUBDIRS):
 	$(MAKE) -C $@
 $(NIM_SUBDIRS):
 	$(MAKE) -C $@
+$(ZIG_SUBDIRS):
+	$(MAKE) -C $@
 
 
-.PHONY: $(GO_SUBDIRS) $(JS_SUBDIRS) $(RUST_SUBDIRS) $(NIM_SUBDIRS) all
+.PHONY: $(GO_SUBDIRS) $(JS_SUBDIRS) $(RUST_SUBDIRS) $(NIM_SUBDIRS) $(ZIG_SUBDIRS) all

--- a/multidim-interop/helpers/cache.ts
+++ b/multidim-interop/helpers/cache.ts
@@ -106,10 +106,10 @@ switch (modeStr) {
                     console.log("Building any remaining things from image.json")
                     // We're building using -o image.json. This tells make to
                     // not bother building image.json or anything it depends on.
-                    child_process.execSync(`make -o image.json`, { cwd: implFolder })
+                    child_process.execSync(`make -o image.json`, { cwd: implFolder, stdio: 'inherit' })
                 } else {
                     console.log("No cache, building from scratch")
-                    child_process.execSync(`make`, { cwd: implFolder })
+                    child_process.execSync(`make`, { cwd: implFolder, stdio: "inherit" })
                 }
             }
         }

--- a/multidim-interop/impl/zig/.gitignore
+++ b/multidim-interop/impl/zig/.gitignore
@@ -1,0 +1,1 @@
+zig-libp2p-*

--- a/multidim-interop/impl/zig/v0.0.1/Makefile
+++ b/multidim-interop/impl/zig/v0.0.1/Makefile
@@ -1,5 +1,5 @@
 image_name := zig-v0.0.1
-commitSha := c187e80784a610f333a91bcbdea85994453af8c1
+commitSha := 42bc07c0266bc6ebd6a3946f6785f14ae394c336
 
 all: image.json print-cpu-info
 

--- a/multidim-interop/impl/zig/v0.0.1/Makefile
+++ b/multidim-interop/impl/zig/v0.0.1/Makefile
@@ -1,0 +1,14 @@
+image_name := zig-v0.0.1
+commitSha := 7435381b698bf282d088a64de1b24f5767bb9a4a
+
+all: image.json
+
+image.json:
+	wget -O zig-libp2p-${commitSha}.zip "https://github.com/marcopolo/zig-libp2p/archive/${commitSha}.zip"
+	unzip -o zig-libp2p-${commitSha}.zip
+	cd zig-libp2p-${commitSha} && docker build -t ${image_name} -f interop/Dockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+clean:
+	rm -rf image.json zig-libp2p-*.zip zig-libp2p-*

--- a/multidim-interop/impl/zig/v0.0.1/Makefile
+++ b/multidim-interop/impl/zig/v0.0.1/Makefile
@@ -1,5 +1,5 @@
 image_name := zig-v0.0.1
-commitSha := 42bc07c0266bc6ebd6a3946f6785f14ae394c336
+commitSha := d6c7afe0d02bf8a314547acdf0483653a9b84bea
 
 all: image.json print-cpu-info
 

--- a/multidim-interop/impl/zig/v0.0.1/Makefile
+++ b/multidim-interop/impl/zig/v0.0.1/Makefile
@@ -1,7 +1,10 @@
 image_name := zig-v0.0.1
-commitSha := 7435381b698bf282d088a64de1b24f5767bb9a4a
+commitSha := c187e80784a610f333a91bcbdea85994453af8c1
 
-all: image.json
+all: image.json print-cpu-info
+
+print-cpu-info: image.json
+	docker run --rm --entrypoint /app/zig/bin/zig ${image_name} build-exe --show-builtin
 
 image.json:
 	wget -O zig-libp2p-${commitSha}.zip "https://github.com/marcopolo/zig-libp2p/archive/${commitSha}.zip"
@@ -12,3 +15,5 @@ image.json:
 
 clean:
 	rm -rf image.json zig-libp2p-*.zip zig-libp2p-*
+
+.PHONY: all clean print-cpu-info

--- a/multidim-interop/impl/zig/v0.0.1/Makefile
+++ b/multidim-interop/impl/zig/v0.0.1/Makefile
@@ -4,7 +4,7 @@ commitSha := c187e80784a610f333a91bcbdea85994453af8c1
 all: image.json print-cpu-info
 
 print-cpu-info: image.json
-	docker run --rm --entrypoint /app/zig/bin/zig ${image_name} build-exe --show-builtin
+	docker run --rm --entrypoint /app/zig/bin/zig $$(jq -r .imageID image.json) build-exe --show-builtin
 
 image.json:
 	wget -O zig-libp2p-${commitSha}.zip "https://github.com/marcopolo/zig-libp2p/archive/${commitSha}.zip"

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -11,6 +11,7 @@ import jsV042 from "./impl/js/v0.42/node-image.json"
 import nimv10 from "./impl/nim/v1.0/image.json"
 import chromiumJsV041 from "./impl/js/v0.41/chromium-image.json"
 import chromiumJsV042 from "./impl/js/v0.42/chromium-image.json"
+import zigv001 from "./impl/zig/v0.0.1/image.json"
 
 export type Version = {
     id: string,
@@ -113,5 +114,12 @@ export const versions: Array<Version> = [
         transports: ["tcp", "ws"],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
+    },
+    {
+        id: "zig-v0.0.1",
+        containerImageID: zigv001.imageID,
+        transports: ["quic-v1"],
+        secureChannels: [],
+        muxers: [],
     },
 ]


### PR DESCRIPTION
closes #169. Two commits, the first reverts, the second prints some cpu info to help debug this issue if we see it again (I haven't changed how the libraries are compiled, but they should be using the clang defaults).