### PR TITLE
chore: Add go-libp2p v0.27.1 and v0.26.4, update zig-libp2p

### DIFF
--- a/multidim-interop/impl/go/v0.27/Makefile
+++ b/multidim-interop/impl/go/v0.27/Makefile
@@ -1,5 +1,5 @@
-image_name := go-v0.26
-commitSha := 8313917571fec7d26813ff437013fde6f48659f7
+image_name := go-v0.27
+commitSha := c3096923a0964abf8a606e0b9576e4d7e700dc57
 
 all: image.json
 

--- a/multidim-interop/impl/zig/v0.0.1/Makefile
+++ b/multidim-interop/impl/zig/v0.0.1/Makefile
@@ -1,5 +1,5 @@
 image_name := zig-v0.0.1
-commitSha := f06e86e06f70cfbd027c981d0e455d9fa5964016
+commitSha := d4a679ee48acae25b5c55c91918f89dec1b78e85
 
 all: image.json print-cpu-info
 

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -1,3 +1,5 @@
+import gov027 from "./impl/go/v0.27/image.json"
+import gov026 from "./impl/go/v0.26/image.json"
 import gov025 from "./impl/go/v0.25/image.json"
 import gov024 from "./impl/go/v0.24/image.json"
 import gov023 from "./impl/go/v0.23/image.json"
@@ -79,6 +81,20 @@ export const versions: Array<Version> = [
         transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"]
+    },
+    {
+        id: "go-v0.27.1",
+        containerImageID: gov027.imageID,
+        transports: ["tcp", "ws", "quic", "quic-v1", "webtransport"],
+        secureChannels: ["tls", "noise"],
+        muxers: ["mplex", "yamux"],
+    },
+    {
+        id: "go-v0.26.4",
+        containerImageID: gov026.imageID,
+        transports: ["tcp", "ws", "quic", "quic-v1", "webtransport"],
+        secureChannels: ["tls", "noise"],
+        muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.25.1",


### PR DESCRIPTION
closes https://github.com/libp2p/test-plans/issues/176