### PR TITLE
feat: update Rust tests to use smaller docker container

### DIFF
--- a/multidim-interop/impl/rust/v0.49/Makefile
+++ b/multidim-interop/impl/rust/v0.49/Makefile
@@ -1,5 +1,5 @@
 image_name := rust-v0.49
-commitSha := 582c84043050eb0dd6e52d1bd0527175181d41cb
+commitSha := 45e3f9c61ad6de18e3e28ca2810a65668d6bba8d
 
 all: image.json
 

--- a/multidim-interop/impl/rust/v0.50/Makefile
+++ b/multidim-interop/impl/rust/v0.50/Makefile
@@ -1,5 +1,5 @@
 image_name := rust-v0.50
-commitSha := beb66b5832384d9b813fcbf1f0fa01e6a64a9c5f
+commitSha := 97071b9a8e0dbd2d2526400169eaa30f317e9d62
 
 all: image.json
 

--- a/multidim-interop/impl/rust/v0.51/Makefile
+++ b/multidim-interop/impl/rust/v0.51/Makefile
@@ -1,5 +1,5 @@
 image_name := rust-v0.51
-commitSha := 0d5cac0cb595702567e50221fed9ae525b4c6f20
+commitSha := 8c26c617b94d992c5fbd91efc73049c838740df1
 
 all: image.json
 


### PR DESCRIPTION
This is the follow-up PR to https://github.com/libp2p/rust-libp2p/issues/3881. We update the hash to the merge commits of the 3 backport PRs for these versions:

- https://github.com/libp2p/rust-libp2p/pull/3943
- https://github.com/libp2p/rust-libp2p/pull/3944
- https://github.com/libp2p/rust-libp2p/pull/3945

With this patch, the final docker image that needs to be downloaded is only 50MB.