### PR TITLE
chore(.editorconfig): add insert_final_newline option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,1 @@
+insert_final_newline=true


### PR DESCRIPTION
Instructs editors to insert final newline and thus prevents Git and GitHub to show "No newline at end of file".

See also https://github.com/libp2p/rust-libp2p/pull/3578