### PR TITLE
Add js-libp2p v0.45.0

### DIFF
--- a/multidim-interop/impl/js/.gitignore
+++ b/multidim-interop/impl/js/.gitignore
@@ -1,1 +1,4 @@
 *image.json
+js-libp2p-*.zip
+js-libp2p-*
+js-libp2p-*/*

--- a/multidim-interop/impl/js/v0.45/BrowserDockerfile
+++ b/multidim-interop/impl/js/v0.45/BrowserDockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+# Copied since we won't have the repo to use if expanding from cache.
+
+# Workaround: https://github.com/docker/cli/issues/996
+ARG BASE_IMAGE=node-js-libp2p-head
+FROM ${BASE_IMAGE} as js-libp2p-base
+
+FROM mcr.microsoft.com/playwright
+
+
+COPY --from=js-libp2p-base /app/ /app/
+WORKDIR /app/interop
+RUN ./node_modules/.bin/playwright install
+ARG BROWSER=chromium # Options: chromium, firefox, webkit
+ENV BROWSER=$BROWSER
+
+ENTRYPOINT npm test -- --build false --types false -t browser -- --browser $BROWSER

--- a/multidim-interop/impl/js/v0.45/Dockerfile
+++ b/multidim-interop/impl/js/v0.45/Dockerfile
@@ -1,0 +1,11 @@
+# Here because we want to fetch the node_modules within docker so that it's
+# installed on the same platform the test is run. Otherwise tools like `esbuild` will fail to run
+FROM node:18
+WORKDIR /app
+COPY . .
+RUN npm i && npm run build
+
+WORKDIR /app/interop
+RUN npm i && npm run build
+
+ENTRYPOINT [ "npm", "test", "--", "--build", "false", "--types", "false", "-t", "node" ]

--- a/multidim-interop/impl/js/v0.45/Makefile
+++ b/multidim-interop/impl/js/v0.45/Makefile
@@ -1,0 +1,30 @@
+image_name := js-v0.45
+commitSha := 41641f1a7656aa654234f6f849b1749786867121
+
+# TODO Enable webkit once https://github.com/libp2p/js-libp2p/pull/1627 is in
+all: image.json chromium-image.json firefox-image.json
+
+chromium-image.json: image.json BrowserDockerfile
+	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=chromium -t chromium-${image_name} .
+	docker image inspect chromium-${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+firefox-image.json: image.json BrowserDockerfile
+	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=firefox -t firefox-${image_name} .
+	docker image inspect firefox-${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+image.json: js-libp2p-${commitSha}
+	cd js-libp2p-${commitSha} && docker build -t ${image_name} -f ../Dockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+js-libp2p-${commitSha}:
+	wget -O js-libp2p-${commitSha}.zip "https://github.com/libp2p/js-libp2p/archive/${commitSha}.zip"
+	unzip -o js-libp2p-${commitSha}.zip
+	unzip -o js-libp2p-${commitSha}.zip
+
+clean:
+	rm -rf image.json js-libp2p-*.zip js-libp2p-* *-image.json
+
+.PHONY: all clean browser-images

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -11,10 +11,13 @@ import rustv051 from "./impl/rust/v0.51/image.json"
 import jsV041 from "./impl/js/v0.41/node-image.json"
 import jsV042 from "./impl/js/v0.42/node-image.json"
 import jsV044 from "./impl/js/v0.44/node-image.json"
+import jsV045 from "./impl/js/v0.45/image.json"
 import nimv10 from "./impl/nim/v1.0/image.json"
 import chromiumJsV041 from "./impl/js/v0.41/chromium-image.json"
 import chromiumJsV042 from "./impl/js/v0.42/chromium-image.json"
 import chromiumJsV044 from "./impl/js/v0.44/chromium-image.json"
+import chromiumJsV045 from "./impl/js/v0.45/chromium-image.json"
+import firefoxJsV045 from "./impl/js/v0.45/firefox-image.json"
 import zigv001 from "./impl/zig/v0.0.1/image.json"
 
 export type Version = {
@@ -78,6 +81,13 @@ export const versions: Array<Version> = [
         muxers: ["mplex", "yamux"],
     },
     {
+        id: "js-v0.45.0",
+        containerImageID: jsV045.imageID,
+        transports: ["tcp", "ws", { name: "wss", onlyDial: true }],
+        secureChannels: ["noise"],
+        muxers: ["mplex", "yamux"],
+    },
+    {
         id: "chromium-js-v0.41.0",
         containerImageID: chromiumJsV041.imageID,
         transports: [{ name: "webtransport", onlyDial: true }],
@@ -95,6 +105,21 @@ export const versions: Array<Version> = [
         id: "chromium-js-v0.44.0",
         containerImageID: chromiumJsV044.imageID,
         transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }, { name: "webrtc-direct", onlyDial: true }],
+        secureChannels: ["noise"],
+        muxers: ["mplex", "yamux"],
+    },
+    // TODO enable webrtc direct for v0.45
+    {
+        id: "chromium-js-v0.45.0",
+        containerImageID: chromiumJsV045.imageID,
+        transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }],
+        secureChannels: ["noise"],
+        muxers: ["mplex", "yamux"],
+    },
+    {
+        id: "firefox-js-v0.45.0",
+        containerImageID: firefoxJsV045.imageID,
+        transports: [{ name: "wss", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },


### PR DESCRIPTION
Uses the new in-repo test to test js-libp2p. 

Note some of the build steps are copied here because we actually want a slightly different build setup. We want to support running `make` and it building in a reproducible way on both MacOS and Linux. In the js-libp2p repo, we fetch node_modules in the CI context (not docker) to get a slight speed up. Here we do `npm i` within the docker build process.

This won't slow us down here however because we can cache these builds. That's not the case in the js-libp2p head builds when you're always building a new head.