### PR TITLE
Don't include muxer and secure channel for webrtc

### DIFF
--- a/multidim-interop/src/generator.ts
+++ b/multidim-interop/src/generator.ts
@@ -62,6 +62,7 @@ export async function buildTestSpecs(versions: Array<Version>): Promise<Array<Co
                      -- quic only uses its own muxer/securechannel
                      AND a.transport != "webtransport"
                      AND a.transport != "webrtc-direct"
+                     AND a.transport != "webrtc"
                      AND a.transport != "quic"
                      AND a.transport != "quic-v1";`);
     const quicQueryResults =

--- a/multidim-interop/src/generator.ts
+++ b/multidim-interop/src/generator.ts
@@ -85,6 +85,13 @@ export async function buildTestSpecs(versions: Array<Version>): Promise<Array<Co
                      AND NOT b.onlyDial
                      -- Only webtransport transports
                      AND a.transport == "webtransport";`);
+    const webrtcQueryResults =
+        await db.all(`SELECT DISTINCT a.id as id1, b.id as id2, a.transport
+                     FROM transports a, transports b
+                     WHERE a.transport == b.transport
+                     AND NOT b.onlyDial
+                     -- Only webrtc transports
+                     AND a.transport == "webrtc";`);
     const webrtcDirectQueryResults =
         await db.all(`SELECT DISTINCT a.id as id1, b.id as id2, a.transport
                      FROM transports a, transports b
@@ -108,14 +115,8 @@ export async function buildTestSpecs(versions: Array<Version>): Promise<Array<Co
         quicQueryResults
             .concat(quicV1QueryResults)
             .concat(webtransportQueryResults)
-            .map((test): ComposeSpecification => buildSpec(containerImages, {
-                name: `${test.id1} x ${test.id2} (${test.transport})`,
-                dialerID: test.id1,
-                listenerID: test.id2,
-                transport: test.transport,
-                extraEnv: buildExtraEnv(timeoutOverride, test.id1, test.id2)
-            })))
-        .concat(webrtcDirectQueryResults
+            .concat(webrtcDirectQueryResults)
+            .concat(webrtcQueryResults)
             .map((test): ComposeSpecification => buildSpec(containerImages, {
                 name: `${test.id1} x ${test.id2} (${test.transport})`,
                 dialerID: test.id1,


### PR DESCRIPTION
As with quic, webtransport, and webrtc-direct.