### PR TITLE
Rename `build-without-cache` to `build-without-secrets`

### DIFF
--- a/.github/workflows/multidim-interop.yml
+++ b/.github/workflows/multidim-interop.yml
@@ -17,11 +17,11 @@ jobs:
           s3-cache-bucket: libp2p-by-tf-aws-bootstrap
           s3-access-key-id: ${{ vars.S3_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
-  build-without-cache:
+  build-without-secrets:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # Purposely not using cache to replicate how forks will behave.
+      # Purposely not using secrets to replicate how forks will behave.
       - uses: ./.github/actions/run-interop-ping-test
         with:
           # It's okay to not run the tests, we only care to check if the tests build without cache.


### PR DESCRIPTION
This workflow uses the public cache. It just can't update it. The goal of this workflow is to see how public forks behave. The name is a vestige from when we didn't have a public cache. But the original goal was always to see how public forks and external repos would behave.