### PR TITLE
fix(perf/https): request downloadBytes instead of uploadBytes

### DIFF
--- a/perf/impl/https/v0.1/main.go
+++ b/perf/impl/https/v0.1/main.go
@@ -77,7 +77,7 @@ func runClient(serverAddr string, uploadBytes, downloadBytes uint64) (time.Durat
 	}
 
 	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, uploadBytes)
+	binary.BigEndian.PutUint64(b, downloadBytes)
 
 	req, err := http.NewRequest(
 		http.MethodPost,


### PR DESCRIPTION
Small follow-up to https://github.com/libp2p/test-plans/pull/184.