### PR TITLE
fix(perf/go-libp2p): close write after sending in client

### DIFF
--- a/perf/impl/go-libp2p/v0.27/perf.go
+++ b/perf/impl/go-libp2p/v0.27/perf.go
@@ -73,6 +73,7 @@ func (ps *PerfService) RunPerf(ctx context.Context, p peer.ID, bytesToSend uint6
 	if err := sendBytes(s, bytesToSend); err != nil {
 		return 0, 0, err
 	}
+	s.CloseWrite()
 	sendDuration := time.Since(sendStart)
 
 	recvStart := time.Now()


### PR DESCRIPTION
Follow up to https://github.com/libp2p/test-plans/pull/184.