### PR TITLE
refactor(perf): expose single latency measurement 

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -51,7 +51,9 @@ _WARNING_: Running the perf tests might take a while.
           - Logging MUST go to stderr.
           - Measurement output is printed to stdout as JSON in the form of:
             ```json
-            {"connectionEstablishedSeconds":0.246442851,"uploadSeconds":0.000002077,"downloadSeconds":0.060712241}
+            {"latency": 0.246442851}
             ```
+             Note that the measurement includes the time to (1) establish the
+             connection, (2) upload the bytes and (3) download the bytes.
 2. In `impl/Makefile` include your implementation in the `all` target.
 3. Reference implementation in `runner/src/versions.ts`.

--- a/perf/README.md
+++ b/perf/README.md
@@ -53,7 +53,7 @@ _WARNING_: Running the perf tests might take a while.
             ```json
             {"latency": 0.246442851}
             ```
-             Note that the measurement includes the time to (1) establish the
-             connection, (2) upload the bytes and (3) download the bytes.
+            Note that the measurement includes the time to (1) establish the
+            connection, (2) upload the bytes and (3) download the bytes.
 2. In `impl/Makefile` include your implementation in the `all` target.
 3. Reference implementation in `runner/src/versions.ts`.

--- a/perf/impl/go-libp2p/v0.27/main.go
+++ b/perf/impl/go-libp2p/v0.27/main.go
@@ -82,17 +82,14 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to dial peer: %s", err)
 	}
-	connectionEstablished := time.Since(start)
 
-	upload, download, err := perf.RunPerf(context.Background(), serverInfo.ID, uint64(*uploadBytes), uint64(*downloadBytes))
+	err = perf.RunPerf(context.Background(), serverInfo.ID, uint64(*uploadBytes), uint64(*downloadBytes))
 	if err != nil {
 		log.Fatalf("failed to execute perf: %s", err)
 	}
 
 	jsonB, err := json.Marshal(Result{
-		ConnectionEstablishedSeconds: connectionEstablished.Seconds(),
-		UploadSeconds:                upload.Seconds(),
-		DownloadSeconds:              download.Seconds(),
+		Latency: time.Since(start).Seconds(),
 	})
 	if err != nil {
 		log.Fatalf("failed to marshal perf result: %s", err)
@@ -102,9 +99,7 @@ func main() {
 }
 
 type Result struct {
-	ConnectionEstablishedSeconds float64 `json:"connectionEstablishedSeconds"`
-	UploadSeconds                float64 `json:"uploadSeconds"`
-	DownloadSeconds              float64 `json:"downloadSeconds"`
+	Latency float64 `json:"latency"`
 }
 
 type simpleReader struct {

--- a/perf/impl/quic-go/v0.34/Makefile
+++ b/perf/impl/quic-go/v0.34/Makefile
@@ -1,4 +1,4 @@
-commitSha := 82a80f5174ba4f84f99cdbbf119b0bfe1e1f971b
+commitSha := a5cd126c97b6d8d8328141bfa84cc57e74ebc57c
 
 all: perf
 
@@ -10,7 +10,7 @@ perf-${commitSha}: perf-${commitSha}.zip
 	unzip -o perf-${commitSha}.zip
 
 perf-${commitSha}.zip:
-	wget -O $@ "https://github.com/mxinden/perf/archive/${commitSha}.zip"
+	wget -O $@ "https://github.com/quic-go/perf/archive/${commitSha}.zip"
 
 clean:
 	rm perf-*.zip

--- a/perf/impl/quic-go/v0.34/Makefile
+++ b/perf/impl/quic-go/v0.34/Makefile
@@ -1,4 +1,4 @@
-commitSha := bdfafffc8b7ec786ff41ea245f24920930eec720
+commitSha := 82a80f5174ba4f84f99cdbbf119b0bfe1e1f971b
 
 all: perf
 
@@ -10,7 +10,7 @@ perf-${commitSha}: perf-${commitSha}.zip
 	unzip -o perf-${commitSha}.zip
 
 perf-${commitSha}.zip:
-	wget -O $@ "https://github.com/quic-go/perf/archive/${commitSha}.zip"
+	wget -O $@ "https://github.com/mxinden/perf/archive/${commitSha}.zip"
 
 clean:
 	rm perf-*.zip

--- a/perf/impl/rust-libp2p-quinn/v0.52/Makefile
+++ b/perf/impl/rust-libp2p-quinn/v0.52/Makefile
@@ -1,4 +1,4 @@
-commitSha := 84d29b34b19aef161a8583daffb9f63a385a613b
+commitSha := 3287f079a8faf5e633a85edae2e76bf490ef1e51
 
 all: perf
 

--- a/perf/impl/rust-libp2p/v0.52/Makefile
+++ b/perf/impl/rust-libp2p/v0.52/Makefile
@@ -1,4 +1,4 @@
-commitSha := ed14630672b66958d1da52ecbff03004f0c057c0
+commitSha := 69bd90efe5530455c77404609ba6c242fecc719e
 
 all: perf
 

--- a/perf/impl/rust-libp2p/v0.52/Makefile
+++ b/perf/impl/rust-libp2p/v0.52/Makefile
@@ -1,4 +1,4 @@
-commitSha := 69bd90efe5530455c77404609ba6c242fecc719e
+commitSha := 73dbde1519f71aa8d76f4c5fa018860ddcd2a8ea
 
 all: perf
 

--- a/perf/runner/benchmark-results.json
+++ b/perf/runner/benchmark-results.json
@@ -7,29 +7,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.073739261,
-              "uploadSeconds": 1.034909205,
-              "downloadSeconds": 5.4e-8
+              "latency": 1.076291736
             },
             {
-              "connectionEstablishedSeconds": 0.065523777,
-              "uploadSeconds": 1.03785779,
-              "downloadSeconds": 6.1e-8
+              "latency": 1.054123943
             },
             {
-              "connectionEstablishedSeconds": 0.077134478,
-              "uploadSeconds": 0.983448006,
-              "downloadSeconds": 5.2e-8
+              "latency": 1.050200065
             },
             {
-              "connectionEstablishedSeconds": 0.061662401,
-              "uploadSeconds": 0.959455533,
-              "downloadSeconds": 5.9e-8
+              "latency": 1.041819505
             },
             {
-              "connectionEstablishedSeconds": 0.063195255,
-              "uploadSeconds": 0.983809188,
-              "downloadSeconds": 5.3e-8
+              "latency": 1.057797816
             }
           ],
           "implementation": "quic-go",
@@ -39,19 +29,19 @@
         {
           "result": [
             {
-              "latency": 43.924302292
+              "latency": 44.16534811
             },
             {
-              "latency": 47.74663813
+              "latency": 45.695923529
             },
             {
-              "latency": 47.826907517
+              "latency": 46.254273865
             },
             {
-              "latency": 49.029876446
+              "latency": 45.14780706
             },
             {
-              "latency": 44.971544535
+              "latency": 43.581983029
             }
           ],
           "implementation": "rust-libp2p",
@@ -61,19 +51,19 @@
         {
           "result": [
             {
-              "latency": 11.343525339
+              "latency": 15.019096329
             },
             {
-              "latency": 6.911762881
+              "latency": 7.116648387
             },
             {
-              "latency": 12.609361633
+              "latency": 15.388309106
             },
             {
-              "latency": 7.581082749
+              "latency": 14.228255102
             },
             {
-              "latency": 12.106078233
+              "latency": 16.918129636
             }
           ],
           "implementation": "rust-libp2p",
@@ -83,19 +73,19 @@
         {
           "result": [
             {
-              "latency": 1.48390983
+              "latency": 1.494282053
             },
             {
-              "latency": 1.451956286
+              "latency": 1.4723175560000001
             },
             {
-              "latency": 1.463895122
+              "latency": 1.414392724
             },
             {
-              "latency": 1.547614427
+              "latency": 1.528559929
             },
             {
-              "latency": 1.413163368
+              "latency": 1.454336788
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -105,19 +95,19 @@
         {
           "result": [
             {
-              "latency": 2.848549437
+              "latency": 2.703742719
             },
             {
-              "latency": 2.711526003
+              "latency": 2.730379033
             },
             {
-              "latency": 2.895369826
+              "latency": 2.837615297
             },
             {
-              "latency": 2.851659218
+              "latency": 2.804376235
             },
             {
-              "latency": 2.658472437
+              "latency": 2.672181984
             }
           ],
           "implementation": "https",
@@ -127,19 +117,19 @@
         {
           "result": [
             {
-              "latency": 3.12648972
+              "latency": 3.496662055
             },
             {
-              "latency": 3.371825872
+              "latency": 3.307046005
             },
             {
-              "latency": 3.261648222
+              "latency": 3.46973589
             },
             {
-              "latency": 3.239118407
+              "latency": 3.180000734
             },
             {
-              "latency": 3.232566064
+              "latency": 3.24012571
             }
           ],
           "implementation": "go-libp2p",
@@ -149,19 +139,19 @@
         {
           "result": [
             {
-              "latency": 1.5502225859999998
+              "latency": 1.501449945
             },
             {
-              "latency": 1.537627771
+              "latency": 1.4143393
             },
             {
-              "latency": 1.48474078
+              "latency": 1.42933566
             },
             {
-              "latency": 1.481374735
+              "latency": 1.484004778
             },
             {
-              "latency": 1.477803009
+              "latency": 1.5304768370000001
             }
           ],
           "implementation": "go-libp2p",
@@ -181,29 +171,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.065055737,
-              "uploadSeconds": 4.8e-7,
-              "downloadSeconds": 1.06632234
+              "latency": 1.189993868
             },
             {
-              "connectionEstablishedSeconds": 0.065932756,
-              "uploadSeconds": 5.69e-7,
-              "downloadSeconds": 1.094419139
+              "latency": 1.146422362
             },
             {
-              "connectionEstablishedSeconds": 0.065730553,
-              "uploadSeconds": 4.84e-7,
-              "downloadSeconds": 1.078618119
+              "latency": 1.116911238
             },
             {
-              "connectionEstablishedSeconds": 0.062481732,
-              "uploadSeconds": 5.53e-7,
-              "downloadSeconds": 1.027141057
+              "latency": 1.138824115
             },
             {
-              "connectionEstablishedSeconds": 0.067021001,
-              "uploadSeconds": 5.3e-7,
-              "downloadSeconds": 1.107657318
+              "latency": 1.148605318
             }
           ],
           "implementation": "quic-go",
@@ -213,19 +193,19 @@
         {
           "result": [
             {
-              "latency": 43.946048827
+              "latency": 46.375497756
             },
             {
-              "latency": 47.398444561
+              "latency": 45.08127772
             },
             {
-              "latency": 46.734388492
+              "latency": 47.330392228
             },
             {
-              "latency": 45.557861667
+              "latency": 45.595953236
             },
             {
-              "latency": 47.748554966
+              "latency": 45.609456533
             }
           ],
           "implementation": "rust-libp2p",
@@ -235,19 +215,19 @@
         {
           "result": [
             {
-              "latency": 10.904454992
+              "latency": 12.051492852
             },
             {
-              "latency": 16.474956111
+              "latency": 13.478499355
             },
             {
-              "latency": 15.693422551
+              "latency": 16.047649583
             },
             {
-              "latency": 14.618747683
+              "latency": 12.588987083
             },
             {
-              "latency": 12.516697744
+              "latency": 17.816787494
             }
           ],
           "implementation": "rust-libp2p",
@@ -257,19 +237,19 @@
         {
           "result": [
             {
-              "latency": 1.495868037
+              "latency": 1.431002173
             },
             {
-              "latency": 1.462521523
+              "latency": 1.452056393
             },
             {
-              "latency": 1.444689061
+              "latency": 1.509078116
             },
             {
-              "latency": 1.496378178
+              "latency": 1.478887671
             },
             {
-              "latency": 1.441893712
+              "latency": 1.462417322
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -279,19 +259,19 @@
         {
           "result": [
             {
-              "latency": 2.840318246
+              "latency": 3.038907166
             },
             {
-              "latency": 2.712228864
+              "latency": 2.824677411
             },
             {
-              "latency": 2.840523228
+              "latency": 2.7438175769999997
             },
             {
-              "latency": 2.726671717
+              "latency": 2.731011736
             },
             {
-              "latency": 2.62770275
+              "latency": 2.774879066
             }
           ],
           "implementation": "https",
@@ -301,19 +281,19 @@
         {
           "result": [
             {
-              "latency": 3.155896034
+              "latency": 3.147791355
             },
             {
-              "latency": 3.531261581
+              "latency": 3.421461513
             },
             {
-              "latency": 3.256629302
+              "latency": 3.266139658
             },
             {
-              "latency": 3.243212416
+              "latency": 3.258962067
             },
             {
-              "latency": 3.0779007800000002
+              "latency": 3.199516925
             }
           ],
           "implementation": "go-libp2p",
@@ -323,19 +303,19 @@
         {
           "result": [
             {
-              "latency": 1.482987271
+              "latency": 1.491891099
             },
             {
-              "latency": 1.445906693
+              "latency": 1.489047447
             },
             {
-              "latency": 1.412701657
+              "latency": 1.454172726
             },
             {
-              "latency": 1.5209862680000001
+              "latency": 1.459982982
             },
             {
-              "latency": 1.471951628
+              "latency": 1.460719245
             }
           ],
           "implementation": "go-libp2p",
@@ -355,504 +335,304 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.066477738,
-              "uploadSeconds": 9.13e-7,
-              "downloadSeconds": 0.064279773
+              "latency": 0.128778316
             },
             {
-              "connectionEstablishedSeconds": 0.063384989,
-              "uploadSeconds": 0.000001945,
-              "downloadSeconds": 0.061576815
+              "latency": 0.127469537
             },
             {
-              "connectionEstablishedSeconds": 0.061145928,
-              "uploadSeconds": 0.000001868,
-              "downloadSeconds": 0.059469068
+              "latency": 0.131561963
             },
             {
-              "connectionEstablishedSeconds": 0.062942029,
-              "uploadSeconds": 8.31e-7,
-              "downloadSeconds": 0.061218983
+              "latency": 0.129618787
             },
             {
-              "connectionEstablishedSeconds": 0.064997377,
-              "uploadSeconds": 6.62e-7,
-              "downloadSeconds": 0.063325405
+              "latency": 0.121589047
             },
             {
-              "connectionEstablishedSeconds": 0.063041542,
-              "uploadSeconds": 0.000001815,
-              "downloadSeconds": 0.06138463
+              "latency": 0.120087889
             },
             {
-              "connectionEstablishedSeconds": 0.062411302,
-              "uploadSeconds": 0.000002064,
-              "downloadSeconds": 0.060813701
+              "latency": 0.129238066
             },
             {
-              "connectionEstablishedSeconds": 0.064948654,
-              "uploadSeconds": 0.000001944,
-              "downloadSeconds": 0.063252918
+              "latency": 0.128154375
             },
             {
-              "connectionEstablishedSeconds": 0.063368626,
-              "uploadSeconds": 6.52e-7,
-              "downloadSeconds": 0.061717348
+              "latency": 0.122632899
             },
             {
-              "connectionEstablishedSeconds": 0.064612749,
-              "uploadSeconds": 0.00000194,
-              "downloadSeconds": 0.062961718
+              "latency": 0.128841497
             },
             {
-              "connectionEstablishedSeconds": 0.065265762,
-              "uploadSeconds": 0.000001766,
-              "downloadSeconds": 0.063603035
+              "latency": 0.129398769
             },
             {
-              "connectionEstablishedSeconds": 0.063799059,
-              "uploadSeconds": 7.79e-7,
-              "downloadSeconds": 0.062343968
+              "latency": 0.127577694
             },
             {
-              "connectionEstablishedSeconds": 0.063932116,
-              "uploadSeconds": 7.48e-7,
-              "downloadSeconds": 0.062255098
+              "latency": 0.130814101
             },
             {
-              "connectionEstablishedSeconds": 0.065841626,
-              "uploadSeconds": 0.000001811,
-              "downloadSeconds": 0.064048202
+              "latency": 0.127332431
             },
             {
-              "connectionEstablishedSeconds": 0.065301591,
-              "uploadSeconds": 7.4e-7,
-              "downloadSeconds": 0.063640797
+              "latency": 0.122099479
             },
             {
-              "connectionEstablishedSeconds": 0.066088716,
-              "uploadSeconds": 8.22e-7,
-              "downloadSeconds": 0.064488602
+              "latency": 0.127720132
             },
             {
-              "connectionEstablishedSeconds": 0.063453803,
-              "uploadSeconds": 6.67e-7,
-              "downloadSeconds": 0.061766168
+              "latency": 0.128957147
             },
             {
-              "connectionEstablishedSeconds": 0.067533886,
-              "uploadSeconds": 0.000001827,
-              "downloadSeconds": 0.064261728
+              "latency": 0.125100613
             },
             {
-              "connectionEstablishedSeconds": 0.065824063,
-              "uploadSeconds": 0.000001908,
-              "downloadSeconds": 0.064185538
+              "latency": 0.126716213
             },
             {
-              "connectionEstablishedSeconds": 0.064414247,
-              "uploadSeconds": 0.000001777,
-              "downloadSeconds": 0.062788112
+              "latency": 0.127232762
             },
             {
-              "connectionEstablishedSeconds": 0.063145715,
-              "uploadSeconds": 0.000001837,
-              "downloadSeconds": 0.061507258
+              "latency": 0.127697753
             },
             {
-              "connectionEstablishedSeconds": 0.064571773,
-              "uploadSeconds": 0.00000176,
-              "downloadSeconds": 0.062921305
+              "latency": 0.124250773
             },
             {
-              "connectionEstablishedSeconds": 0.064329536,
-              "uploadSeconds": 7.7e-7,
-              "downloadSeconds": 0.062733902
+              "latency": 0.125667603
             },
             {
-              "connectionEstablishedSeconds": 0.063574457,
-              "uploadSeconds": 6.55e-7,
-              "downloadSeconds": 0.061928445
+              "latency": 0.123547899
             },
             {
-              "connectionEstablishedSeconds": 0.063684941,
-              "uploadSeconds": 0.000001814,
-              "downloadSeconds": 0.062144699
+              "latency": 0.126130999
             },
             {
-              "connectionEstablishedSeconds": 0.065248651,
-              "uploadSeconds": 0.000001761,
-              "downloadSeconds": 0.063635889
+              "latency": 0.118363609
             },
             {
-              "connectionEstablishedSeconds": 0.062888987,
-              "uploadSeconds": 0.000001766,
-              "downloadSeconds": 0.061333808
+              "latency": 0.127593263
             },
             {
-              "connectionEstablishedSeconds": 0.062495181,
-              "uploadSeconds": 0.000001727,
-              "downloadSeconds": 0.060910486
+              "latency": 0.12252807
             },
             {
-              "connectionEstablishedSeconds": 0.061005789,
-              "uploadSeconds": 7.09e-7,
-              "downloadSeconds": 0.059455919
+              "latency": 0.120965223
             },
             {
-              "connectionEstablishedSeconds": 0.064478585,
-              "uploadSeconds": 0.000001737,
-              "downloadSeconds": 0.06281553
+              "latency": 0.131540436
             },
             {
-              "connectionEstablishedSeconds": 0.062454254,
-              "uploadSeconds": 0.000001867,
-              "downloadSeconds": 0.060819645
+              "latency": 0.126413356
             },
             {
-              "connectionEstablishedSeconds": 0.065255324,
-              "uploadSeconds": 0.000001756,
-              "downloadSeconds": 0.063602326
+              "latency": 0.127671877
             },
             {
-              "connectionEstablishedSeconds": 0.062055576,
-              "uploadSeconds": 7.44e-7,
-              "downloadSeconds": 0.060455686
+              "latency": 0.121485181
             },
             {
-              "connectionEstablishedSeconds": 0.066634361,
-              "uploadSeconds": 0.000001745,
-              "downloadSeconds": 0.064154614
+              "latency": 0.123425921
             },
             {
-              "connectionEstablishedSeconds": 0.065356468,
-              "uploadSeconds": 0.000001718,
-              "downloadSeconds": 0.063758737
+              "latency": 0.123083684
             },
             {
-              "connectionEstablishedSeconds": 0.063229657,
-              "uploadSeconds": 0.000001786,
-              "downloadSeconds": 0.061511939
+              "latency": 0.119423222
             },
             {
-              "connectionEstablishedSeconds": 0.061751818,
-              "uploadSeconds": 6.77e-7,
-              "downloadSeconds": 0.060130236
+              "latency": 0.12741316
             },
             {
-              "connectionEstablishedSeconds": 0.064834215,
-              "uploadSeconds": 7.52e-7,
-              "downloadSeconds": 0.063223928
+              "latency": 0.120603398
             },
             {
-              "connectionEstablishedSeconds": 0.065323919,
-              "uploadSeconds": 0.000001766,
-              "downloadSeconds": 0.063761162
+              "latency": 0.130413205
             },
             {
-              "connectionEstablishedSeconds": 0.064654637,
-              "uploadSeconds": 6.61e-7,
-              "downloadSeconds": 0.06307213
+              "latency": 0.129347356
             },
             {
-              "connectionEstablishedSeconds": 0.061151181,
-              "uploadSeconds": 0.000002048,
-              "downloadSeconds": 0.059393933
+              "latency": 0.128436254
             },
             {
-              "connectionEstablishedSeconds": 0.066678722,
-              "uploadSeconds": 0.000001843,
-              "downloadSeconds": 0.065026017
+              "latency": 0.125031583
             },
             {
-              "connectionEstablishedSeconds": 0.061621551,
-              "uploadSeconds": 0.000001801,
-              "downloadSeconds": 0.059896765
+              "latency": 0.123462743
             },
             {
-              "connectionEstablishedSeconds": 0.065268154,
-              "uploadSeconds": 0.000001698,
-              "downloadSeconds": 0.063545918
+              "latency": 0.124576027
             },
             {
-              "connectionEstablishedSeconds": 0.064312612,
-              "uploadSeconds": 7.46e-7,
-              "downloadSeconds": 0.062722097
+              "latency": 0.125252087
             },
             {
-              "connectionEstablishedSeconds": 0.064034255,
-              "uploadSeconds": 0.000001838,
-              "downloadSeconds": 0.062325111
+              "latency": 0.126904966
             },
             {
-              "connectionEstablishedSeconds": 0.06502196,
-              "uploadSeconds": 0.000001751,
-              "downloadSeconds": 0.062502688
+              "latency": 0.121406829
             },
             {
-              "connectionEstablishedSeconds": 0.066040776,
-              "uploadSeconds": 0.000001795,
-              "downloadSeconds": 0.064447869
+              "latency": 0.126998465
             },
             {
-              "connectionEstablishedSeconds": 0.061958007,
-              "uploadSeconds": 0.000001712,
-              "downloadSeconds": 0.060529294
+              "latency": 0.129123316
             },
             {
-              "connectionEstablishedSeconds": 0.062529329,
-              "uploadSeconds": 7.46e-7,
-              "downloadSeconds": 0.060860608
+              "latency": 0.129215614
             },
             {
-              "connectionEstablishedSeconds": 0.064877895,
-              "uploadSeconds": 0.000001842,
-              "downloadSeconds": 0.06340455
+              "latency": 0.125167593
             },
             {
-              "connectionEstablishedSeconds": 0.062968037,
-              "uploadSeconds": 0.000001806,
-              "downloadSeconds": 0.06133636
+              "latency": 0.128404373
             },
             {
-              "connectionEstablishedSeconds": 0.062629803,
-              "uploadSeconds": 0.000001859,
-              "downloadSeconds": 0.06085844
+              "latency": 0.129171708
             },
             {
-              "connectionEstablishedSeconds": 0.062286495,
-              "uploadSeconds": 7.62e-7,
-              "downloadSeconds": 0.060687572
+              "latency": 0.121965573
             },
             {
-              "connectionEstablishedSeconds": 0.061797799,
-              "uploadSeconds": 0.000001768,
-              "downloadSeconds": 0.060149257
+              "latency": 0.124967033
             },
             {
-              "connectionEstablishedSeconds": 0.065891438,
-              "uploadSeconds": 7.61e-7,
-              "downloadSeconds": 0.064306904
+              "latency": 0.127878265
             },
             {
-              "connectionEstablishedSeconds": 0.06226347,
-              "uploadSeconds": 0.000001774,
-              "downloadSeconds": 0.06142646
+              "latency": 0.121986949
             },
             {
-              "connectionEstablishedSeconds": 0.063052821,
-              "uploadSeconds": 0.00000174,
-              "downloadSeconds": 0.061442282
+              "latency": 0.122498511
             },
             {
-              "connectionEstablishedSeconds": 0.065785278,
-              "uploadSeconds": 0.000001783,
-              "downloadSeconds": 0.064155999
+              "latency": 0.127003199
             },
             {
-              "connectionEstablishedSeconds": 0.063619823,
-              "uploadSeconds": 0.000001794,
-              "downloadSeconds": 0.062080533
+              "latency": 0.124850559
             },
             {
-              "connectionEstablishedSeconds": 0.064504737,
-              "uploadSeconds": 0.000001699,
-              "downloadSeconds": 0.062789832
+              "latency": 0.126491896
             },
             {
-              "connectionEstablishedSeconds": 0.066131541,
-              "uploadSeconds": 0.000001854,
-              "downloadSeconds": 0.064514268
+              "latency": 0.122218999
             },
             {
-              "connectionEstablishedSeconds": 0.061934264,
-              "uploadSeconds": 0.000001727,
-              "downloadSeconds": 0.060205341
+              "latency": 0.123493427
             },
             {
-              "connectionEstablishedSeconds": 0.061799629,
-              "uploadSeconds": 0.000001802,
-              "downloadSeconds": 0.060281556
+              "latency": 0.128767318
             },
             {
-              "connectionEstablishedSeconds": 0.062666625,
-              "uploadSeconds": 0.000001704,
-              "downloadSeconds": 0.060979079
+              "latency": 0.130736413
             },
             {
-              "connectionEstablishedSeconds": 0.064806916,
-              "uploadSeconds": 0.000001819,
-              "downloadSeconds": 0.063166144
+              "latency": 0.130598075
             },
             {
-              "connectionEstablishedSeconds": 0.062246318,
-              "uploadSeconds": 6.92e-7,
-              "downloadSeconds": 0.060729196
+              "latency": 0.123158153
             },
             {
-              "connectionEstablishedSeconds": 0.061268258,
-              "uploadSeconds": 7.6e-7,
-              "downloadSeconds": 0.059645958
+              "latency": 0.130519919
             },
             {
-              "connectionEstablishedSeconds": 0.062319598,
-              "uploadSeconds": 0.000001863,
-              "downloadSeconds": 0.061273583
+              "latency": 0.129149146
             },
             {
-              "connectionEstablishedSeconds": 0.066712762,
-              "uploadSeconds": 7.39e-7,
-              "downloadSeconds": 0.065062983
+              "latency": 0.127126663
             },
             {
-              "connectionEstablishedSeconds": 0.064125282,
-              "uploadSeconds": 0.000001711,
-              "downloadSeconds": 0.062471341
+              "latency": 0.131662174
             },
             {
-              "connectionEstablishedSeconds": 0.062314829,
-              "uploadSeconds": 7.52e-7,
-              "downloadSeconds": 0.060759741
+              "latency": 0.123208875
             },
             {
-              "connectionEstablishedSeconds": 0.061910734,
-              "uploadSeconds": 0.00000177,
-              "downloadSeconds": 0.060320397
+              "latency": 0.128711221
             },
             {
-              "connectionEstablishedSeconds": 0.064269073,
-              "uploadSeconds": 0.000001741,
-              "downloadSeconds": 0.062720996
+              "latency": 0.123587744
             },
             {
-              "connectionEstablishedSeconds": 0.063583025,
-              "uploadSeconds": 0.000001747,
-              "downloadSeconds": 0.061804342
+              "latency": 0.124567763
             },
             {
-              "connectionEstablishedSeconds": 0.065872113,
-              "uploadSeconds": 0.000001807,
-              "downloadSeconds": 0.064194406
+              "latency": 0.125842806
             },
             {
-              "connectionEstablishedSeconds": 0.066311907,
-              "uploadSeconds": 0.000001782,
-              "downloadSeconds": 0.064670437
+              "latency": 0.131417373
             },
             {
-              "connectionEstablishedSeconds": 0.066168252,
-              "uploadSeconds": 0.000001899,
-              "downloadSeconds": 0.064468189
+              "latency": 0.128938279
             },
             {
-              "connectionEstablishedSeconds": 0.062754644,
-              "uploadSeconds": 0.000001798,
-              "downloadSeconds": 0.061120241
+              "latency": 0.123769083
             },
             {
-              "connectionEstablishedSeconds": 0.062455648,
-              "uploadSeconds": 7.38e-7,
-              "downloadSeconds": 0.060839206
+              "latency": 0.121339546
             },
             {
-              "connectionEstablishedSeconds": 0.063806339,
-              "uploadSeconds": 0.00000179,
-              "downloadSeconds": 0.06216697
+              "latency": 0.129764257
             },
             {
-              "connectionEstablishedSeconds": 0.064597413,
-              "uploadSeconds": 0.00000173,
-              "downloadSeconds": 0.062937481
+              "latency": 0.124688569
             },
             {
-              "connectionEstablishedSeconds": 0.062850815,
-              "uploadSeconds": 6.97e-7,
-              "downloadSeconds": 0.061280022
+              "latency": 0.130251241
             },
             {
-              "connectionEstablishedSeconds": 0.064407337,
-              "uploadSeconds": 0.000001778,
-              "downloadSeconds": 0.062887685
+              "latency": 0.127405207
             },
             {
-              "connectionEstablishedSeconds": 0.062786629,
-              "uploadSeconds": 0.000001772,
-              "downloadSeconds": 0.062066669
+              "latency": 0.120138297
             },
             {
-              "connectionEstablishedSeconds": 0.061890579,
-              "uploadSeconds": 0.000001729,
-              "downloadSeconds": 0.060166971
+              "latency": 0.123446696
             },
             {
-              "connectionEstablishedSeconds": 0.062408563,
-              "uploadSeconds": 0.000001801,
-              "downloadSeconds": 0.060810089
+              "latency": 0.123607508
             },
             {
-              "connectionEstablishedSeconds": 0.062490624,
-              "uploadSeconds": 9.15e-7,
-              "downloadSeconds": 0.060857065
+              "latency": 0.132104626
             },
             {
-              "connectionEstablishedSeconds": 0.06523268,
-              "uploadSeconds": 0.000001826,
-              "downloadSeconds": 0.063717055
+              "latency": 0.127348688
             },
             {
-              "connectionEstablishedSeconds": 0.063790145,
-              "uploadSeconds": 0.000001761,
-              "downloadSeconds": 0.062229234
+              "latency": 0.122169618
             },
             {
-              "connectionEstablishedSeconds": 0.060365532,
-              "uploadSeconds": 0.000001775,
-              "downloadSeconds": 0.058712024
+              "latency": 0.120313531
             },
             {
-              "connectionEstablishedSeconds": 0.064417197,
-              "uploadSeconds": 0.000001763,
-              "downloadSeconds": 0.062880639
+              "latency": 0.124832798
             },
             {
-              "connectionEstablishedSeconds": 0.063397122,
-              "uploadSeconds": 0.000001746,
-              "downloadSeconds": 0.061765186
+              "latency": 0.124513629
             },
             {
-              "connectionEstablishedSeconds": 0.066704004,
-              "uploadSeconds": 0.000001707,
-              "downloadSeconds": 0.065128395
+              "latency": 0.124865312
             },
             {
-              "connectionEstablishedSeconds": 0.064486371,
-              "uploadSeconds": 0.000001713,
-              "downloadSeconds": 0.062865375
+              "latency": 0.125800435
             },
             {
-              "connectionEstablishedSeconds": 0.064802805,
-              "uploadSeconds": 7.2e-7,
-              "downloadSeconds": 0.063277579
+              "latency": 0.129231798
             },
             {
-              "connectionEstablishedSeconds": 0.063924621,
-              "uploadSeconds": 0.000001697,
-              "downloadSeconds": 0.062248425
+              "latency": 0.122101501
             },
             {
-              "connectionEstablishedSeconds": 0.065993297,
-              "uploadSeconds": 0.000001752,
-              "downloadSeconds": 0.064359758
+              "latency": 0.12246849
             },
             {
-              "connectionEstablishedSeconds": 0.064030815,
-              "uploadSeconds": 7.17e-7,
-              "downloadSeconds": 0.062482167
+              "latency": 0.118254725
             },
             {
-              "connectionEstablishedSeconds": 0.062975846,
-              "uploadSeconds": 6.98e-7,
-              "downloadSeconds": 0.061397444
+              "latency": 0.129137945
             }
           ],
           "implementation": "quic-go",
@@ -862,304 +642,304 @@
         {
           "result": [
             {
-              "latency": 0.184132654
+              "latency": 0.194451835
             },
             {
-              "latency": 0.194068936
+              "latency": 0.186451174
             },
             {
-              "latency": 0.191915091
+              "latency": 0.193438491
             },
             {
-              "latency": 0.184928078
+              "latency": 0.190564768
             },
             {
-              "latency": 0.183934167
+              "latency": 0.187831091
             },
             {
-              "latency": 0.184182073
+              "latency": 0.182534244
             },
             {
-              "latency": 0.192029766
+              "latency": 0.18337949
             },
             {
-              "latency": 0.190439227
+              "latency": 0.190037528
             },
             {
-              "latency": 0.194579933
+              "latency": 0.194479668
             },
             {
-              "latency": 0.18786885
+              "latency": 0.178294527
             },
             {
-              "latency": 0.182042588
+              "latency": 0.188886096
             },
             {
-              "latency": 0.195974107
+              "latency": 0.189220322
             },
             {
-              "latency": 0.193752757
+              "latency": 0.180851106
             },
             {
-              "latency": 0.19580449
+              "latency": 0.184920659
             },
             {
-              "latency": 0.189173311
+              "latency": 0.184796303
             },
             {
-              "latency": 0.186218502
+              "latency": 0.194234811
             },
             {
-              "latency": 0.185516962
+              "latency": 0.194405267
             },
             {
-              "latency": 0.193657657
+              "latency": 0.192226653
             },
             {
-              "latency": 0.190656587
+              "latency": 0.185539979
             },
             {
-              "latency": 0.185120937
+              "latency": 0.196452274
             },
             {
-              "latency": 0.189140803
+              "latency": 0.189949096
             },
             {
-              "latency": 0.185150775
+              "latency": 0.195212551
             },
             {
-              "latency": 0.190844677
+              "latency": 0.189861751
             },
             {
-              "latency": 0.187113354
+              "latency": 0.179555303
             },
             {
-              "latency": 0.187236342
+              "latency": 0.180013864
             },
             {
-              "latency": 0.186080189
+              "latency": 0.190173924
             },
             {
-              "latency": 0.195096425
+              "latency": 0.194005551
             },
             {
-              "latency": 0.188929417
+              "latency": 0.190004745
             },
             {
-              "latency": 0.18796103
+              "latency": 0.193823196
             },
             {
-              "latency": 0.185178755
+              "latency": 0.19171575
             },
             {
-              "latency": 0.187649523
+              "latency": 0.180711271
             },
             {
-              "latency": 0.182106208
+              "latency": 0.191806515
             },
             {
-              "latency": 0.194297538
+              "latency": 0.193719375
             },
             {
-              "latency": 0.184068868
+              "latency": 0.18798901
             },
             {
-              "latency": 0.175417602
+              "latency": 0.184585025
             },
             {
-              "latency": 0.191739911
+              "latency": 0.18013775
             },
             {
-              "latency": 0.18783925
+              "latency": 0.182118414
             },
             {
-              "latency": 0.190802342
+              "latency": 0.187322986
             },
             {
-              "latency": 0.185588224
+              "latency": 0.192263869
             },
             {
-              "latency": 0.18831657
+              "latency": 0.189206943
             },
             {
-              "latency": 0.192850426
+              "latency": 0.182054991
             },
             {
-              "latency": 0.180095663
+              "latency": 0.191965517
             },
             {
-              "latency": 0.183457111
+              "latency": 0.192388417
             },
             {
-              "latency": 0.189265544
+              "latency": 0.187836666
             },
             {
-              "latency": 0.19230742
+              "latency": 0.192673837
             },
             {
-              "latency": 0.184436256
+              "latency": 0.190358423
             },
             {
-              "latency": 0.187160278
+              "latency": 0.178843271
             },
             {
-              "latency": 0.185060163
+              "latency": 0.190329395
             },
             {
-              "latency": 0.184699135
+              "latency": 0.188767856
             },
             {
-              "latency": 0.183075881
+              "latency": 0.193039113
             },
             {
-              "latency": 0.183561349
+              "latency": 0.189378861
             },
             {
-              "latency": 0.178109643
+              "latency": 0.180581338
             },
             {
-              "latency": 0.181829569
+              "latency": 0.190311719
             },
             {
-              "latency": 0.191897922
+              "latency": 0.190238506
             },
             {
-              "latency": 0.194005334
+              "latency": 0.1900226
             },
             {
-              "latency": 0.188489837
+              "latency": 0.18997099
             },
             {
-              "latency": 0.193578448
+              "latency": 0.18736788
             },
             {
-              "latency": 0.187929267
+              "latency": 0.175769002
             },
             {
-              "latency": 0.184922944
+              "latency": 0.175167531
             },
             {
-              "latency": 0.187795281
+              "latency": 0.181570747
             },
             {
-              "latency": 0.193773021
+              "latency": 0.191929862
             },
             {
-              "latency": 0.184383381
+              "latency": 0.189411135
             },
             {
-              "latency": 0.189312312
+              "latency": 0.192853281
             },
             {
-              "latency": 0.187711496
+              "latency": 0.192835651
             },
             {
-              "latency": 0.193925291
+              "latency": 0.193717575
             },
             {
-              "latency": 0.193784964
+              "latency": 0.182864022
             },
             {
-              "latency": 0.188667647
+              "latency": 0.19361636
             },
             {
-              "latency": 0.189342273
+              "latency": 0.193591332
             },
             {
-              "latency": 0.191128992
+              "latency": 0.180649164
             },
             {
-              "latency": 0.193775777
+              "latency": 0.189260578
             },
             {
-              "latency": 0.191684423
+              "latency": 0.193246694
             },
             {
-              "latency": 0.190111321
+              "latency": 0.187795838
             },
             {
-              "latency": 0.19164226
+              "latency": 0.179139719
             },
             {
-              "latency": 0.18577541
+              "latency": 0.185541725
             },
             {
-              "latency": 0.184102904
+              "latency": 0.192129952
             },
             {
-              "latency": 0.185752668
+              "latency": 0.185659853
             },
             {
-              "latency": 0.177264736
+              "latency": 0.196146717
             },
             {
-              "latency": 0.176941932
+              "latency": 0.191922301
             },
             {
-              "latency": 0.185505702
+              "latency": 0.19164444
             },
             {
-              "latency": 0.183782463
+              "latency": 0.187682375
             },
             {
-              "latency": 0.190740287
+              "latency": 0.185163314
             },
             {
-              "latency": 0.191248024
+              "latency": 0.183345077
             },
             {
-              "latency": 0.175630487
+              "latency": 0.185399162
             },
             {
-              "latency": 0.184778715
+              "latency": 0.180919665
             },
             {
-              "latency": 0.187699975
+              "latency": 0.189076171
             },
             {
-              "latency": 0.191732926
+              "latency": 0.188332826
             },
             {
-              "latency": 0.184517763
+              "latency": 0.187848309
             },
             {
-              "latency": 0.195033722
+              "latency": 0.181638079
             },
             {
-              "latency": 0.18866025
+              "latency": 0.186504867
             },
             {
-              "latency": 0.194798044
+              "latency": 0.186598922
             },
             {
-              "latency": 0.193389921
+              "latency": 0.187723356
             },
             {
-              "latency": 0.181712061
+              "latency": 0.189050685
             },
             {
-              "latency": 0.194496672
+              "latency": 0.191821807
             },
             {
-              "latency": 0.190505569
+              "latency": 0.185332018
             },
             {
-              "latency": 0.185409032
+              "latency": 0.194105184
             },
             {
-              "latency": 0.186205174
+              "latency": 0.187772729
             },
             {
-              "latency": 0.183118094
+              "latency": 0.18611103
             },
             {
-              "latency": 0.185340769
+              "latency": 0.192435064
             },
             {
-              "latency": 0.188765951
+              "latency": 0.185084407
             },
             {
-              "latency": 0.193192734
+              "latency": 0.19300613
             }
           ],
           "implementation": "rust-libp2p",
@@ -1169,304 +949,304 @@
         {
           "result": [
             {
-              "latency": 0.125777968
+              "latency": 0.132473722
             },
             {
-              "latency": 0.128307512
+              "latency": 0.123907839
             },
             {
-              "latency": 0.127544746
+              "latency": 0.123883659
             },
             {
-              "latency": 0.122402397
+              "latency": 0.127584568
             },
             {
-              "latency": 0.128747625
+              "latency": 0.130431119
             },
             {
-              "latency": 0.123212638
+              "latency": 0.12941286
             },
             {
-              "latency": 0.128605619
+              "latency": 0.132304419
             },
             {
-              "latency": 0.126204388
+              "latency": 0.129690487
             },
             {
-              "latency": 0.121963042
+              "latency": 0.127371591
             },
             {
-              "latency": 0.127325479
+              "latency": 0.126363515
             },
             {
-              "latency": 0.132017483
+              "latency": 0.122298816
             },
             {
-              "latency": 0.128399938
+              "latency": 0.127523061
             },
             {
-              "latency": 0.129433893
+              "latency": 0.126499856
             },
             {
-              "latency": 0.121579533
+              "latency": 0.129228008
             },
             {
-              "latency": 0.129274894
+              "latency": 0.131050145
             },
             {
-              "latency": 0.123804813
+              "latency": 0.122523645
             },
             {
-              "latency": 0.125359927
+              "latency": 0.129565031
             },
             {
-              "latency": 0.127449846
+              "latency": 0.128277824
             },
             {
-              "latency": 0.125559231
+              "latency": 0.130131171
             },
             {
-              "latency": 0.129395209
+              "latency": 0.121801737
             },
             {
-              "latency": 0.128843447
+              "latency": 0.129169755
             },
             {
-              "latency": 0.126127485
+              "latency": 0.129957882
             },
             {
-              "latency": 0.126612377
+              "latency": 0.121018887
             },
             {
-              "latency": 0.119243227
+              "latency": 0.119571043
             },
             {
-              "latency": 0.12322938
+              "latency": 0.125826218
             },
             {
-              "latency": 0.123665717
+              "latency": 0.126335034
             },
             {
-              "latency": 0.12427905
+              "latency": 0.130856212
             },
             {
-              "latency": 0.131403776
+              "latency": 0.127233231
             },
             {
-              "latency": 0.119572069
+              "latency": 0.127985903
             },
             {
-              "latency": 0.125500863
+              "latency": 0.124884129
             },
             {
-              "latency": 0.127419779
+              "latency": 0.121464
             },
             {
-              "latency": 0.126610934
+              "latency": 0.127073324
             },
             {
-              "latency": 0.124426014
+              "latency": 0.124166892
             },
             {
-              "latency": 0.12868814
+              "latency": 0.127758126
             },
             {
-              "latency": 0.118254702
+              "latency": 0.128962933
             },
             {
-              "latency": 0.124258382
+              "latency": 0.126441492
             },
             {
-              "latency": 0.131919118
+              "latency": 0.124466931
             },
             {
-              "latency": 0.127277312
+              "latency": 0.130062954
             },
             {
-              "latency": 0.126236011
+              "latency": 0.127704648
             },
             {
-              "latency": 0.124394349
+              "latency": 0.124660515
             },
             {
-              "latency": 0.12443177
+              "latency": 0.126121013
             },
             {
-              "latency": 0.122816709
+              "latency": 0.123013337
             },
             {
-              "latency": 0.130763296
+              "latency": 0.127792705
             },
             {
-              "latency": 0.122420805
+              "latency": 0.129753899
             },
             {
-              "latency": 0.129442081
+              "latency": 0.122129055
             },
             {
-              "latency": 0.124228893
+              "latency": 0.123229192
             },
             {
-              "latency": 0.126475667
+              "latency": 0.126501385
             },
             {
-              "latency": 0.129426322
+              "latency": 0.126055576
             },
             {
-              "latency": 0.128563104
+              "latency": 0.122623908
             },
             {
-              "latency": 0.129833668
+              "latency": 0.127836704
             },
             {
-              "latency": 0.12555755
+              "latency": 0.128006421
             },
             {
-              "latency": 0.128004788
+              "latency": 0.129010036
             },
             {
-              "latency": 0.129274112
+              "latency": 0.121786081
             },
             {
-              "latency": 0.126944688
+              "latency": 0.130556038
             },
             {
-              "latency": 0.121298884
+              "latency": 0.129327295
             },
             {
-              "latency": 0.119382693
+              "latency": 0.127269595
             },
             {
-              "latency": 0.125480662
+              "latency": 0.120584624
             },
             {
-              "latency": 0.123206752
+              "latency": 0.127407605
             },
             {
-              "latency": 0.121188501
+              "latency": 0.132209438
             },
             {
-              "latency": 0.124577036
+              "latency": 0.126888193
             },
             {
-              "latency": 0.120140975
+              "latency": 0.124783315
             },
             {
-              "latency": 0.124274923
+              "latency": 0.126951769
             },
             {
-              "latency": 0.124345149
+              "latency": 0.125702211
             },
             {
-              "latency": 0.130448889
+              "latency": 0.130318831
             },
             {
-              "latency": 0.125562158
+              "latency": 0.12911532
             },
             {
-              "latency": 0.125679497
+              "latency": 0.128259457
             },
             {
-              "latency": 0.130337557
+              "latency": 0.123542554
             },
             {
-              "latency": 0.125082166
+              "latency": 0.127796734
             },
             {
-              "latency": 0.119229966
+              "latency": 0.130587252
             },
             {
-              "latency": 0.130524917
+              "latency": 0.127228686
             },
             {
-              "latency": 0.129044001
+              "latency": 0.125676443
             },
             {
-              "latency": 0.120590611
+              "latency": 0.131576634
             },
             {
-              "latency": 0.12352362
+              "latency": 0.124277581
             },
             {
-              "latency": 0.126382508
+              "latency": 0.129109379
             },
             {
-              "latency": 0.125797204
+              "latency": 0.127632488
             },
             {
-              "latency": 0.126544318
+              "latency": 0.130513684
             },
             {
-              "latency": 0.121320157
+              "latency": 0.123783327
             },
             {
-              "latency": 0.123327912
+              "latency": 0.126000158
             },
             {
-              "latency": 0.130680105
+              "latency": 0.128634206
             },
             {
-              "latency": 0.125024032
+              "latency": 0.129204082
             },
             {
-              "latency": 0.130920126
+              "latency": 0.129297543
             },
             {
-              "latency": 0.128272278
+              "latency": 0.125235293
             },
             {
-              "latency": 0.124534074
+              "latency": 0.130794466
             },
             {
-              "latency": 0.128728945
+              "latency": 0.125732436
             },
             {
-              "latency": 0.127538361
+              "latency": 0.12190303
             },
             {
-              "latency": 0.130405102
+              "latency": 0.129105473
             },
             {
-              "latency": 0.127636921
+              "latency": 0.126836548
             },
             {
-              "latency": 0.12912564
+              "latency": 0.128431996
             },
             {
-              "latency": 0.123547132
+              "latency": 0.129480684
             },
             {
-              "latency": 0.124658027
+              "latency": 0.128740291
             },
             {
-              "latency": 0.120190847
+              "latency": 0.129401259
             },
             {
-              "latency": 0.122444408
+              "latency": 0.125434555
             },
             {
-              "latency": 0.123913223
+              "latency": 0.12911872
             },
             {
-              "latency": 0.125410338
+              "latency": 0.125560768
             },
             {
-              "latency": 0.127199426
+              "latency": 0.120354713
             },
             {
-              "latency": 0.120169365
+              "latency": 0.123648391
             },
             {
-              "latency": 0.128054344
+              "latency": 0.12950968
             },
             {
-              "latency": 0.127913262
+              "latency": 0.125939919
             },
             {
-              "latency": 0.128675879
+              "latency": 0.122573392
             },
             {
-              "latency": 0.128183154
+              "latency": 0.122343263
             }
           ],
           "implementation": "rust-libp2p",
@@ -1476,304 +1256,304 @@
         {
           "result": [
             {
-              "latency": 0.123009715
+              "latency": 0.132982741
             },
             {
-              "latency": 0.125303542
+              "latency": 0.120039262
             },
             {
-              "latency": 0.125447547
+              "latency": 0.12331894
             },
             {
-              "latency": 0.124743468
+              "latency": 0.127802802
             },
             {
-              "latency": 0.122889889
+              "latency": 0.124956771
             },
             {
-              "latency": 0.123582121
+              "latency": 0.125928828
             },
             {
-              "latency": 0.128946825
+              "latency": 0.128977437
             },
             {
-              "latency": 0.126276622
+              "latency": 0.129853212
             },
             {
-              "latency": 0.129613931
+              "latency": 0.128628306
             },
             {
-              "latency": 0.121296503
+              "latency": 0.123053472
             },
             {
-              "latency": 0.125443063
+              "latency": 0.124259507
             },
             {
-              "latency": 0.126228718
+              "latency": 0.124676891
             },
             {
-              "latency": 0.125643139
+              "latency": 0.127004035
             },
             {
-              "latency": 0.124991346
+              "latency": 0.128784202
             },
             {
-              "latency": 0.13255148
+              "latency": 0.128030182
             },
             {
-              "latency": 0.12602645
+              "latency": 0.127765475
             },
             {
-              "latency": 0.125632463
+              "latency": 0.129510112
             },
             {
-              "latency": 0.130966744
+              "latency": 0.121169853
             },
             {
-              "latency": 0.12773041
+              "latency": 0.128672583
             },
             {
-              "latency": 0.125446888
+              "latency": 0.128438711
             },
             {
-              "latency": 0.132567675
+              "latency": 0.130829935
             },
             {
-              "latency": 0.130911048
+              "latency": 0.127941703
             },
             {
-              "latency": 0.125630409
+              "latency": 0.124612603
             },
             {
-              "latency": 0.128439978
+              "latency": 0.12903103
             },
             {
-              "latency": 0.126255169
+              "latency": 0.128902837
             },
             {
-              "latency": 0.129537998
+              "latency": 0.132204804
             },
             {
-              "latency": 0.123738751
+              "latency": 0.127708521
             },
             {
-              "latency": 0.128765568
+              "latency": 0.124726022
             },
             {
-              "latency": 0.129124072
+              "latency": 0.12779992
             },
             {
-              "latency": 0.128546892
+              "latency": 0.125644837
             },
             {
-              "latency": 0.126928585
+              "latency": 0.132090723
             },
             {
-              "latency": 0.124300298
+              "latency": 0.12641923
             },
             {
-              "latency": 0.123540521
+              "latency": 0.123609485
             },
             {
-              "latency": 0.128840944
+              "latency": 0.127542777
             },
             {
-              "latency": 0.126553297
+              "latency": 0.130249325
             },
             {
-              "latency": 0.12957911
+              "latency": 0.11871774
             },
             {
-              "latency": 0.127501387
+              "latency": 0.130873923
             },
             {
-              "latency": 0.128468983
+              "latency": 0.131143898
             },
             {
-              "latency": 0.123684096
+              "latency": 0.126906674
             },
             {
-              "latency": 0.119435728
+              "latency": 0.128430274
             },
             {
-              "latency": 0.130333639
+              "latency": 0.126165267
             },
             {
-              "latency": 0.124900602
+              "latency": 0.128249568
             },
             {
-              "latency": 0.130070071
+              "latency": 0.126736323
             },
             {
-              "latency": 0.127693458
+              "latency": 0.129403641
             },
             {
-              "latency": 0.129003245
+              "latency": 0.128606683
             },
             {
-              "latency": 0.132047538
+              "latency": 0.126262637
             },
             {
-              "latency": 0.12461281
+              "latency": 0.125719285
             },
             {
-              "latency": 0.127948798
+              "latency": 0.121633628
             },
             {
-              "latency": 0.125516213
+              "latency": 0.126707951
             },
             {
-              "latency": 0.125860936
+              "latency": 0.124797375
             },
             {
-              "latency": 0.124831679
+              "latency": 0.127685473
             },
             {
-              "latency": 0.122833095
+              "latency": 0.124450102
             },
             {
-              "latency": 0.130561063
+              "latency": 0.125804493
             },
             {
-              "latency": 0.131093567
+              "latency": 0.129022753
             },
             {
-              "latency": 0.127323963
+              "latency": 0.130932983
             },
             {
-              "latency": 0.124479805
+              "latency": 0.124832814
             },
             {
-              "latency": 0.126513746
+              "latency": 0.128441849
             },
             {
-              "latency": 0.130026632
+              "latency": 0.127484862
             },
             {
-              "latency": 0.130066528
+              "latency": 0.127550448
             },
             {
-              "latency": 0.122845331
+              "latency": 0.123603179
             },
             {
-              "latency": 0.124507854
+              "latency": 0.1293483
             },
             {
-              "latency": 0.130884729
+              "latency": 0.131064809
             },
             {
-              "latency": 0.120988883
+              "latency": 0.127198234
             },
             {
-              "latency": 0.125774698
+              "latency": 0.12810162
             },
             {
-              "latency": 0.126484946
+              "latency": 0.123543716
             },
             {
-              "latency": 0.126468707
+              "latency": 0.130604059
             },
             {
-              "latency": 0.123656736
+              "latency": 0.128108102
             },
             {
-              "latency": 0.132574109
+              "latency": 0.124091915
             },
             {
-              "latency": 0.121921803
+              "latency": 0.127515558
             },
             {
-              "latency": 0.128035923
+              "latency": 0.131941105
             },
             {
-              "latency": 0.130713875
+              "latency": 0.12380863
             },
             {
-              "latency": 0.127916236
+              "latency": 0.125942241
             },
             {
-              "latency": 0.126354233
+              "latency": 0.127220743
             },
             {
-              "latency": 0.12551248
+              "latency": 0.13012345
             },
             {
-              "latency": 0.125169279
+              "latency": 0.12277998
             },
             {
-              "latency": 0.126407875
+              "latency": 0.123558504
             },
             {
-              "latency": 0.127732602
+              "latency": 0.129004583
             },
             {
-              "latency": 0.122444346
+              "latency": 0.120927219
             },
             {
-              "latency": 0.125910469
+              "latency": 0.130499269
             },
             {
-              "latency": 0.126633221
+              "latency": 0.131927074
             },
             {
-              "latency": 0.123138109
+              "latency": 0.123872696
             },
             {
-              "latency": 0.127190048
+              "latency": 0.126444181
             },
             {
-              "latency": 0.125373263
+              "latency": 0.126735474
             },
             {
-              "latency": 0.130775642
+              "latency": 0.118941103
             },
             {
-              "latency": 0.126479922
+              "latency": 0.126020058
             },
             {
-              "latency": 0.123469529
+              "latency": 0.121667638
             },
             {
-              "latency": 0.127197619
+              "latency": 0.128334338
             },
             {
-              "latency": 0.12796889
+              "latency": 0.128180825
             },
             {
-              "latency": 0.12870022
+              "latency": 0.127820918
             },
             {
-              "latency": 0.122779333
+              "latency": 0.130636587
             },
             {
-              "latency": 0.129133343
+              "latency": 0.125535494
             },
             {
-              "latency": 0.128028004
+              "latency": 0.12402695
             },
             {
-              "latency": 0.12549691
+              "latency": 0.129733582
             },
             {
-              "latency": 0.125466561
+              "latency": 0.130914024
             },
             {
-              "latency": 0.131906053
+              "latency": 0.129755091
             },
             {
-              "latency": 0.121921702
+              "latency": 0.124036562
             },
             {
-              "latency": 0.12959066
+              "latency": 0.125101143
             },
             {
-              "latency": 0.127225396
+              "latency": 0.125727743
             },
             {
-              "latency": 0.11967506
+              "latency": 0.123882753
             },
             {
-              "latency": 0.123612348
+              "latency": 0.120636983
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -1783,304 +1563,304 @@
         {
           "result": [
             {
-              "latency": 0.185961485
+              "latency": 0.186125696
             },
             {
-              "latency": 0.188375741
+              "latency": 0.193250325
             },
             {
-              "latency": 0.190612922
+              "latency": 0.185964855
             },
             {
-              "latency": 0.190957367
+              "latency": 0.193867584
             },
             {
-              "latency": 0.193958657
+              "latency": 0.193941329
             },
             {
-              "latency": 0.183547678
+              "latency": 0.176674272
             },
             {
-              "latency": 0.184320209
+              "latency": 0.190724684
             },
             {
-              "latency": 0.188832759
+              "latency": 0.19519593
             },
             {
-              "latency": 0.182914815
+              "latency": 0.180019999
             },
             {
-              "latency": 0.185030383
+              "latency": 0.183562506
             },
             {
-              "latency": 0.193356891
+              "latency": 0.189823227
             },
             {
-              "latency": 0.190457075
+              "latency": 0.18405577
             },
             {
-              "latency": 0.185981253
+              "latency": 0.18493169
             },
             {
-              "latency": 0.191331879
+              "latency": 0.177044087
             },
             {
-              "latency": 0.182717303
+              "latency": 0.187134092
             },
             {
-              "latency": 0.186655694
+              "latency": 0.188591711
             },
             {
-              "latency": 0.18842115
+              "latency": 0.184366198
             },
             {
-              "latency": 0.189984872
+              "latency": 0.185794476
             },
             {
-              "latency": 0.183096242
+              "latency": 0.187004954
             },
             {
-              "latency": 0.185881694
+              "latency": 0.18914213
             },
             {
-              "latency": 0.185340571
+              "latency": 0.189644751
             },
             {
-              "latency": 0.18461522
+              "latency": 0.189928517
             },
             {
-              "latency": 0.186025353
+              "latency": 0.191496238
             },
             {
-              "latency": 0.189214854
+              "latency": 0.183023641
             },
             {
-              "latency": 0.190976998
+              "latency": 0.194129703
             },
             {
-              "latency": 0.191156926
+              "latency": 0.17998652
             },
             {
-              "latency": 0.188917358
+              "latency": 0.180727405
             },
             {
-              "latency": 0.179752705
+              "latency": 0.181391702
             },
             {
-              "latency": 0.184555396
+              "latency": 0.191511831
             },
             {
-              "latency": 0.183720716
+              "latency": 0.185509152
             },
             {
-              "latency": 0.195191566
+              "latency": 0.187078731
             },
             {
-              "latency": 0.185168084
+              "latency": 0.191933372
             },
             {
-              "latency": 0.193332951
+              "latency": 0.189498499
             },
             {
-              "latency": 0.183290752
+              "latency": 0.192412675
             },
             {
-              "latency": 0.184111927
+              "latency": 0.180940503
             },
             {
-              "latency": 0.188479487
+              "latency": 0.189006545
             },
             {
-              "latency": 0.188744324
+              "latency": 0.191555153
             },
             {
-              "latency": 0.191527443
+              "latency": 0.180675049
             },
             {
-              "latency": 0.182386011
+              "latency": 0.191179167
             },
             {
-              "latency": 0.185881535
+              "latency": 0.183964293
             },
             {
-              "latency": 0.18291621
+              "latency": 0.18407678
             },
             {
-              "latency": 0.187003834
+              "latency": 0.180040156
             },
             {
-              "latency": 0.178580196
+              "latency": 0.182903184
             },
             {
-              "latency": 0.182966457
+              "latency": 0.191253657
             },
             {
-              "latency": 0.19156239
+              "latency": 0.184018242
             },
             {
-              "latency": 0.1802248
+              "latency": 0.189415129
             },
             {
-              "latency": 0.190849347
+              "latency": 0.188437639
             },
             {
-              "latency": 0.192672815
+              "latency": 0.188172973
             },
             {
-              "latency": 0.187506079
+              "latency": 0.191325137
             },
             {
-              "latency": 0.176972689
+              "latency": 0.183988608
             },
             {
-              "latency": 0.189345238
+              "latency": 0.17878703
             },
             {
-              "latency": 0.185527481
+              "latency": 0.191425188
             },
             {
-              "latency": 0.191707959
+              "latency": 0.194040285
             },
             {
-              "latency": 0.187159697
+              "latency": 0.178680372
             },
             {
-              "latency": 0.192613505
+              "latency": 0.182980123
             },
             {
-              "latency": 0.185720473
+              "latency": 0.184576482
             },
             {
-              "latency": 0.18177996
+              "latency": 0.189634115
             },
             {
-              "latency": 0.181090506
+              "latency": 0.185244352
             },
             {
-              "latency": 0.183976665
+              "latency": 0.184475783
             },
             {
-              "latency": 0.192820029
+              "latency": 0.185240399
             },
             {
-              "latency": 0.193548702
+              "latency": 0.183127664
             },
             {
-              "latency": 0.178046098
+              "latency": 0.186619498
             },
             {
-              "latency": 0.187386167
+              "latency": 0.189170996
             },
             {
-              "latency": 0.184856735
+              "latency": 0.18097901
             },
             {
-              "latency": 0.181595157
+              "latency": 0.185719833
             },
             {
-              "latency": 0.184597279
+              "latency": 0.183939276
             },
             {
-              "latency": 0.191130816
+              "latency": 0.185534372
             },
             {
-              "latency": 0.187089569
+              "latency": 0.190195576
             },
             {
-              "latency": 0.187772461
+              "latency": 0.190227328
             },
             {
-              "latency": 0.19046177
+              "latency": 0.179358115
             },
             {
-              "latency": 0.186334128
+              "latency": 0.189939701
             },
             {
-              "latency": 0.184603884
+              "latency": 0.191620701
             },
             {
-              "latency": 0.1935887
+              "latency": 0.190432082
             },
             {
-              "latency": 0.188782643
+              "latency": 0.189711716
             },
             {
-              "latency": 0.189003157
+              "latency": 0.191393569
             },
             {
-              "latency": 0.191010376
+              "latency": 0.186676361
             },
             {
-              "latency": 0.191431241
+              "latency": 0.187128108
             },
             {
-              "latency": 0.186968898
+              "latency": 0.19163339
             },
             {
-              "latency": 0.191125795
+              "latency": 0.190444934
             },
             {
-              "latency": 0.183442057
+              "latency": 0.191894003
             },
             {
-              "latency": 0.195882124
+              "latency": 0.193703399
             },
             {
-              "latency": 0.184102748
+              "latency": 0.186724084
             },
             {
-              "latency": 0.186756025
+              "latency": 0.182533103
             },
             {
-              "latency": 0.187291222
+              "latency": 0.191307252
             },
             {
-              "latency": 0.175203264
+              "latency": 0.19439515
             },
             {
-              "latency": 0.176218714
+              "latency": 0.182694701
             },
             {
-              "latency": 0.195973862
+              "latency": 0.192908215
             },
             {
-              "latency": 0.18419611
+              "latency": 0.188891329
             },
             {
-              "latency": 0.190925537
+              "latency": 0.18689351
             },
             {
-              "latency": 0.188930836
+              "latency": 0.194006596
             },
             {
-              "latency": 0.196213305
+              "latency": 0.188805502
             },
             {
-              "latency": 0.187859907
+              "latency": 0.192716938
             },
             {
-              "latency": 0.18496212
+              "latency": 0.186011507
             },
             {
-              "latency": 0.187973095
+              "latency": 0.187493413
             },
             {
-              "latency": 0.187376657
+              "latency": 0.185759809
             },
             {
-              "latency": 0.180131081
+              "latency": 0.188207822
             },
             {
-              "latency": 0.188552894
+              "latency": 0.174226319
             },
             {
-              "latency": 0.189526143
+              "latency": 0.183135039
             },
             {
-              "latency": 0.180011438
+              "latency": 0.188057533
             },
             {
-              "latency": 0.189606794
+              "latency": 0.190845358
             }
           ],
           "implementation": "https",
@@ -2090,304 +1870,304 @@
         {
           "result": [
             {
-              "latency": 0.371673364
+              "latency": 0.381345476
             },
             {
-              "latency": 0.310527868
+              "latency": 0.310011261
             },
             {
-              "latency": 0.309783624
+              "latency": 0.317913746
             },
             {
-              "latency": 0.390526476
+              "latency": 0.323272544
             },
             {
-              "latency": 0.309294922
+              "latency": 0.325687199
             },
             {
-              "latency": 0.320893325
+              "latency": 0.320573025
             },
             {
-              "latency": 0.315424144
+              "latency": 0.313464596
             },
             {
-              "latency": 0.324311415
+              "latency": 0.370251777
             },
             {
-              "latency": 0.374898917
+              "latency": 0.378091945
             },
             {
-              "latency": 0.370672619
+              "latency": 0.319399785
             },
             {
-              "latency": 0.31457677
+              "latency": 0.301834857
             },
             {
-              "latency": 0.389143043
+              "latency": 0.308979855
             },
             {
-              "latency": 0.311358109
+              "latency": 0.365884228
             },
             {
-              "latency": 0.37827599
+              "latency": 0.367893885
             },
             {
-              "latency": 0.311336431
+              "latency": 0.369976706
             },
             {
-              "latency": 0.316977723
+              "latency": 0.372506986
             },
             {
-              "latency": 0.320063546
+              "latency": 0.324844364
             },
             {
-              "latency": 0.306109548
+              "latency": 0.320817126
             },
             {
-              "latency": 0.378276207
+              "latency": 0.314459952
             },
             {
-              "latency": 0.29973811
+              "latency": 0.306336014
             },
             {
-              "latency": 0.31010851
+              "latency": 0.379710604
             },
             {
-              "latency": 0.379182714
+              "latency": 0.385618294
             },
             {
-              "latency": 0.307516103
+              "latency": 0.368690487
             },
             {
-              "latency": 0.316331042
+              "latency": 0.374676726
             },
             {
-              "latency": 0.31866157
+              "latency": 0.307193992
             },
             {
-              "latency": 0.310953094
+              "latency": 0.326221013
             },
             {
-              "latency": 0.308377534
+              "latency": 0.299707419
             },
             {
-              "latency": 0.30688395
+              "latency": 0.310218207
             },
             {
-              "latency": 0.309395132
+              "latency": 0.382603071
             },
             {
-              "latency": 0.314995966
+              "latency": 0.314321228
             },
             {
-              "latency": 0.357796605
+              "latency": 0.319414389
             },
             {
-              "latency": 0.316310205
+              "latency": 0.375599452
             },
             {
-              "latency": 0.307071256
+              "latency": 0.384297199
             },
             {
-              "latency": 0.3119234
+              "latency": 0.321740903
             },
             {
-              "latency": 0.310987794
+              "latency": 0.359745621
             },
             {
-              "latency": 0.317234556
+              "latency": 0.373883766
             },
             {
-              "latency": 0.298399712
+              "latency": 0.327330737
             },
             {
-              "latency": 0.326935269
+              "latency": 0.378808013
             },
             {
-              "latency": 0.320704366
+              "latency": 0.304814796
             },
             {
-              "latency": 0.320087989
+              "latency": 0.3091126
             },
             {
-              "latency": 0.323290207
+              "latency": 0.313902152
             },
             {
-              "latency": 0.365360326
+              "latency": 0.364586316
             },
             {
-              "latency": 0.307250184
+              "latency": 0.314528068
             },
             {
-              "latency": 0.371798191
+              "latency": 0.315348514
             },
             {
-              "latency": 0.308768596
+              "latency": 0.389889588
             },
             {
-              "latency": 0.388180711
+              "latency": 0.323187201
             },
             {
-              "latency": 0.325229648
+              "latency": 0.324784963
             },
             {
-              "latency": 0.359241619
+              "latency": 0.314591965
             },
             {
-              "latency": 0.373853866
+              "latency": 0.351267005
             },
             {
-              "latency": 0.316128988
+              "latency": 0.320534706
             },
             {
-              "latency": 0.363671409
+              "latency": 0.368794151
             },
             {
-              "latency": 0.364167016
+              "latency": 0.373100058
             },
             {
-              "latency": 0.321862292
+              "latency": 0.308748147
             },
             {
-              "latency": 0.378195501
+              "latency": 0.376614136
             },
             {
-              "latency": 0.305405033
+              "latency": 0.312456194
             },
             {
-              "latency": 0.383036021
+              "latency": 0.325722553
             },
             {
-              "latency": 0.322979748
+              "latency": 0.390807912
             },
             {
-              "latency": 0.385531653
+              "latency": 0.355294057
             },
             {
-              "latency": 0.376895007
+              "latency": 0.390622256
             },
             {
-              "latency": 0.370288002
+              "latency": 0.306195931
             },
             {
-              "latency": 0.370799304
+              "latency": 0.304690134
             },
             {
-              "latency": 0.367503576
+              "latency": 0.309909989
             },
             {
-              "latency": 0.30317632
+              "latency": 0.31619949
             },
             {
-              "latency": 0.306185982
+              "latency": 0.382414554
             },
             {
-              "latency": 0.309685666
+              "latency": 0.360632248
             },
             {
-              "latency": 0.319031544
+              "latency": 0.309611042
             },
             {
-              "latency": 0.322063518
+              "latency": 0.304919525
             },
             {
-              "latency": 0.320676913
+              "latency": 0.319058779
             },
             {
-              "latency": 0.311714831
+              "latency": 0.36637229
             },
             {
-              "latency": 0.388734707
+              "latency": 0.37605942
             },
             {
-              "latency": 0.371604758
+              "latency": 0.38276463
             },
             {
-              "latency": 0.382371194
+              "latency": 0.360984833
             },
             {
-              "latency": 0.304823606
+              "latency": 0.308069556
             },
             {
-              "latency": 0.30671412
+              "latency": 0.379511297
             },
             {
-              "latency": 0.316717461
+              "latency": 0.305277423
             },
             {
-              "latency": 0.317143564
+              "latency": 0.378561533
             },
             {
-              "latency": 0.325290747
+              "latency": 0.298489139
             },
             {
-              "latency": 0.319788498
+              "latency": 0.36619677
             },
             {
-              "latency": 0.321180212
+              "latency": 0.294356067
             },
             {
-              "latency": 0.312451854
+              "latency": 0.320096416
             },
             {
-              "latency": 0.308637822
+              "latency": 0.305988316
             },
             {
-              "latency": 0.306170505
+              "latency": 0.312524791
             },
             {
-              "latency": 0.321725459
+              "latency": 0.317066632
             },
             {
-              "latency": 0.367621984
+              "latency": 0.371120667
             },
             {
-              "latency": 0.378936172
+              "latency": 0.313505867
             },
             {
-              "latency": 0.319996168
+              "latency": 0.31490379
             },
             {
-              "latency": 0.319607042
+              "latency": 0.309255169
             },
             {
-              "latency": 0.350467783
+              "latency": 0.315183889
             },
             {
-              "latency": 0.32098288
+              "latency": 0.374551557
             },
             {
-              "latency": 0.362787417
+              "latency": 0.310813122
             },
             {
-              "latency": 0.321426164
+              "latency": 0.326105982
             },
             {
-              "latency": 0.314355836
+              "latency": 0.361435493
             },
             {
-              "latency": 0.304564324
+              "latency": 0.384574249
             },
             {
-              "latency": 0.366528476
+              "latency": 0.388043664
             },
             {
-              "latency": 0.308103004
+              "latency": 0.313482988
             },
             {
-              "latency": 0.322845997
+              "latency": 0.310522136
             },
             {
-              "latency": 0.31113667
+              "latency": 0.319512899
             },
             {
-              "latency": 0.309033917
+              "latency": 0.381366334
             },
             {
-              "latency": 0.308894674
+              "latency": 0.307855739
             },
             {
-              "latency": 0.302450241
+              "latency": 0.32477267
             }
           ],
           "implementation": "go-libp2p",
@@ -2397,304 +2177,304 @@
         {
           "result": [
             {
-              "latency": 0.191423399
+              "latency": 0.190272312
             },
             {
-              "latency": 0.187232721
+              "latency": 0.192737986
             },
             {
-              "latency": 0.197214885
+              "latency": 0.178975299
             },
             {
-              "latency": 0.19396671
+              "latency": 0.189846031
             },
             {
-              "latency": 0.189624189
+              "latency": 0.19752571
             },
             {
-              "latency": 0.181780785
+              "latency": 0.194253008
             },
             {
-              "latency": 0.190711272
+              "latency": 0.194017635
             },
             {
-              "latency": 0.190395223
+              "latency": 0.18571502
             },
             {
-              "latency": 0.189552051
+              "latency": 0.189081691
             },
             {
-              "latency": 0.188390608
+              "latency": 0.189678026
             },
             {
-              "latency": 0.188042326
+              "latency": 0.191616926
             },
             {
-              "latency": 0.188101559
+              "latency": 0.197603829
             },
             {
-              "latency": 0.197555288
+              "latency": 0.191199481
             },
             {
-              "latency": 0.193904508
+              "latency": 0.188314244
             },
             {
-              "latency": 0.19383215
+              "latency": 0.1917676
             },
             {
-              "latency": 0.18679819
+              "latency": 0.195318591
             },
             {
-              "latency": 0.199310079
+              "latency": 0.192820369
             },
             {
-              "latency": 0.185368522
+              "latency": 0.189895717
             },
             {
-              "latency": 0.189504245
+              "latency": 0.185209963
             },
             {
-              "latency": 0.186942299
+              "latency": 0.188153369
             },
             {
-              "latency": 0.193537279
+              "latency": 0.189796726
             },
             {
-              "latency": 0.193651144
+              "latency": 0.187092593
             },
             {
-              "latency": 0.195254859
+              "latency": 0.186806678
             },
             {
-              "latency": 0.19423762
+              "latency": 0.196754997
             },
             {
-              "latency": 0.180641462
+              "latency": 0.186781455
             },
             {
-              "latency": 0.188116333
+              "latency": 0.197279633
             },
             {
-              "latency": 0.178897273
+              "latency": 0.18821387
             },
             {
-              "latency": 0.192992983
+              "latency": 0.189552705
             },
             {
-              "latency": 0.187942247
+              "latency": 0.190420264
             },
             {
-              "latency": 0.194576767
+              "latency": 0.196921864
             },
             {
-              "latency": 0.198206578
+              "latency": 0.19977009
             },
             {
-              "latency": 0.183801656
+              "latency": 0.185068748
             },
             {
-              "latency": 0.184989843
+              "latency": 0.188800741
             },
             {
-              "latency": 0.190091812
+              "latency": 0.180653926
             },
             {
-              "latency": 0.193317719
+              "latency": 0.185203665
             },
             {
-              "latency": 0.184813014
+              "latency": 0.182306439
             },
             {
-              "latency": 0.191116859
+              "latency": 0.19250827
             },
             {
-              "latency": 0.196169983
+              "latency": 0.182466566
             },
             {
-              "latency": 0.192780408
+              "latency": 0.193343197
             },
             {
-              "latency": 0.190984244
+              "latency": 0.188437325
             },
             {
-              "latency": 0.188311158
+              "latency": 0.19009732
             },
             {
-              "latency": 0.19737033
+              "latency": 0.188445093
             },
             {
-              "latency": 0.18764759
+              "latency": 0.183592127
             },
             {
-              "latency": 0.191209337
+              "latency": 0.194702645
             },
             {
-              "latency": 0.185406847
+              "latency": 0.193154196
             },
             {
-              "latency": 0.189690787
+              "latency": 0.185560042
             },
             {
-              "latency": 0.195821776
+              "latency": 0.195239293
             },
             {
-              "latency": 0.189028192
+              "latency": 0.19328836
             },
             {
-              "latency": 0.184094108
+              "latency": 0.191927884
             },
             {
-              "latency": 0.195840529
+              "latency": 0.194307721
             },
             {
-              "latency": 0.185976588
+              "latency": 0.19447864
             },
             {
-              "latency": 0.190297659
+              "latency": 0.197637007
             },
             {
-              "latency": 0.19415231
+              "latency": 0.189414051
             },
             {
-              "latency": 0.192300551
+              "latency": 0.195894723
             },
             {
-              "latency": 0.18688974
+              "latency": 0.187635924
             },
             {
-              "latency": 0.194102376
+              "latency": 0.192089868
             },
             {
-              "latency": 0.195331475
+              "latency": 0.192424422
             },
             {
-              "latency": 0.188563114
+              "latency": 0.194069085
             },
             {
-              "latency": 0.185872473
+              "latency": 0.186444823
             },
             {
-              "latency": 0.193032211
+              "latency": 0.195697424
             },
             {
-              "latency": 0.197383593
+              "latency": 0.195952523
             },
             {
-              "latency": 0.192119836
+              "latency": 0.181829764
             },
             {
-              "latency": 0.190889943
+              "latency": 0.193685271
             },
             {
-              "latency": 0.191506037
+              "latency": 0.184199815
             },
             {
-              "latency": 0.188116542
+              "latency": 0.182238278
             },
             {
-              "latency": 0.193149617
+              "latency": 0.193734906
             },
             {
-              "latency": 0.189654227
+              "latency": 0.1860801
             },
             {
-              "latency": 0.197194289
+              "latency": 0.188219237
             },
             {
-              "latency": 0.191735177
+              "latency": 0.197818951
             },
             {
-              "latency": 0.183793229
+              "latency": 0.191524349
             },
             {
-              "latency": 0.187128502
+              "latency": 0.184980103
             },
             {
-              "latency": 0.196642592
+              "latency": 0.194002343
             },
             {
-              "latency": 0.193083162
+              "latency": 0.195224382
             },
             {
-              "latency": 0.197121
+              "latency": 0.192980278
             },
             {
-              "latency": 0.182526146
+              "latency": 0.195033335
             },
             {
-              "latency": 0.190164274
+              "latency": 0.196407794
             },
             {
-              "latency": 0.19301012
+              "latency": 0.19318405
             },
             {
-              "latency": 0.179123759
+              "latency": 0.186733665
             },
             {
-              "latency": 0.193418771
+              "latency": 0.189535605
             },
             {
-              "latency": 0.190907392
+              "latency": 0.180817893
             },
             {
-              "latency": 0.184022255
+              "latency": 0.193884384
             },
             {
-              "latency": 0.189528065
+              "latency": 0.189553823
             },
             {
-              "latency": 0.191589164
+              "latency": 0.190276946
             },
             {
-              "latency": 0.183404734
+              "latency": 0.185924209
             },
             {
-              "latency": 0.188702213
+              "latency": 0.192762612
             },
             {
-              "latency": 0.190665175
+              "latency": 0.189759834
             },
             {
-              "latency": 0.189880429
+              "latency": 0.19220735
             },
             {
-              "latency": 0.186954515
+              "latency": 0.188921209
             },
             {
-              "latency": 0.193558266
+              "latency": 0.191440586
             },
             {
-              "latency": 0.184772402
+              "latency": 0.188858439
             },
             {
-              "latency": 0.192563743
+              "latency": 0.196119346
             },
             {
-              "latency": 0.192481196
+              "latency": 0.185606689
             },
             {
-              "latency": 0.189357055
+              "latency": 0.191237226
             },
             {
-              "latency": 0.187583363
+              "latency": 0.1997391
             },
             {
-              "latency": 0.191091853
+              "latency": 0.194520431
             },
             {
-              "latency": 0.198970715
+              "latency": 0.196019876
             },
             {
-              "latency": 0.198342929
+              "latency": 0.192688577
             },
             {
-              "latency": 0.189725958
+              "latency": 0.188636085
             },
             {
-              "latency": 0.194753097
+              "latency": 0.197256893
             },
             {
-              "latency": 0.18938075
+              "latency": 0.19270415
             }
           ],
           "implementation": "go-libp2p",
@@ -2711,173 +2491,173 @@
   "pings": {
     "unit": "s",
     "results": [
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.060899999999999996,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.060899999999999996,
-      0.0606,
-      0.0606,
-      0.0608,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.06559999999999999,
-      0.0644,
-      0.060899999999999996,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0605,
-      0.0605,
-      0.0605,
-      0.0605,
-      0.0605,
-      0.0605,
-      0.0605,
-      0.0605,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606,
-      0.0606
+      0.0638,
+      0.0649,
+      0.0733,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0626,
+      0.0625,
+      0.0628,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0625,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0625,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0625,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0625,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624,
+      0.0624
     ]
   },
   "iperf": {
     "unit": "bit/s",
     "results": [
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3230000000,
-      3230000000,
-      3230000000,
-      3220000000,
-      3190000000,
-      3180000000,
-      3190000000,
-      3190000000,
-      3200000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3240000000,
-      3250000000,
-      3240000000,
-      3230000000,
-      3200000000,
-      3200000000,
-      3200000000,
-      3200000000,
-      3200000000,
-      3250000000,
-      3250000000,
-      3240000000,
-      3250000000,
-      3250000000,
-      3260000000,
-      3250000000,
-      3260000000,
-      3250000000,
-      3250000000,
-      3250000000,
-      3260000000,
-      3250000000,
-      3250000000,
-      3230000000,
-      2760000000
+      3390000000,
+      3380000000,
+      3380000000,
+      3380000000,
+      3380000000,
+      3380000000,
+      3380000000,
+      3400000000,
+      3400000000,
+      3380000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3390000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3350000000,
+      3340000000,
+      3340000000,
+      3350000000,
+      3350000000,
+      3380000000,
+      3400000000,
+      3400000000,
+      3390000000,
+      3390000000,
+      3400000000,
+      3390000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3390000000,
+      3400000000,
+      3400000000,
+      3330000000,
+      3350000000,
+      3350000000,
+      3340000000,
+      3340000000,
+      3350000000,
+      3390000000,
+      3380000000,
+      3400000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3400000000,
+      3390000000,
+      3390000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3390000000,
+      3380000000,
+      2950000000
     ]
   }
 }

--- a/perf/runner/benchmark-results.json
+++ b/perf/runner/benchmark-results.json
@@ -7,28 +7,28 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.068123765,
-              "uploadSeconds": 0.970456932,
-              "downloadSeconds": 5.3e-8
+              "connectionEstablishedSeconds": 0.073739261,
+              "uploadSeconds": 1.034909205,
+              "downloadSeconds": 5.4e-8
             },
             {
-              "connectionEstablishedSeconds": 0.062713554,
-              "uploadSeconds": 0.975849906,
-              "downloadSeconds": 6.8e-8
+              "connectionEstablishedSeconds": 0.065523777,
+              "uploadSeconds": 1.03785779,
+              "downloadSeconds": 6.1e-8
             },
             {
-              "connectionEstablishedSeconds": 0.065501309,
-              "uploadSeconds": 1.022005129,
-              "downloadSeconds": 6e-8
+              "connectionEstablishedSeconds": 0.077134478,
+              "uploadSeconds": 0.983448006,
+              "downloadSeconds": 5.2e-8
             },
             {
-              "connectionEstablishedSeconds": 0.066928483,
-              "uploadSeconds": 1.041319663,
-              "downloadSeconds": 5.3e-8
+              "connectionEstablishedSeconds": 0.061662401,
+              "uploadSeconds": 0.959455533,
+              "downloadSeconds": 5.9e-8
             },
             {
-              "connectionEstablishedSeconds": 0.064004129,
-              "uploadSeconds": 0.996991871,
+              "connectionEstablishedSeconds": 0.063195255,
+              "uploadSeconds": 0.983809188,
               "downloadSeconds": 5.3e-8
             }
           ],
@@ -39,29 +39,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.131599504,
-              "uploadSeconds": 47.63213805,
-              "downloadSeconds": 0.064913485
+              "latency": 43.924302292
             },
             {
-              "connectionEstablishedSeconds": 0.127136394,
-              "uploadSeconds": 43.618970957,
-              "downloadSeconds": 0.063410859
+              "latency": 47.74663813
             },
             {
-              "connectionEstablishedSeconds": 0.127686874,
-              "uploadSeconds": 44.623888682,
-              "downloadSeconds": 0.063648489
+              "latency": 47.826907517
             },
             {
-              "connectionEstablishedSeconds": 0.128835409,
-              "uploadSeconds": 46.479589264,
-              "downloadSeconds": 0.065293635
+              "latency": 49.029876446
             },
             {
-              "connectionEstablishedSeconds": 0.128399353,
-              "uploadSeconds": 45.799956017,
-              "downloadSeconds": 0.063969977
+              "latency": 44.971544535
             }
           ],
           "implementation": "rust-libp2p",
@@ -71,29 +61,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.064484261,
-              "uploadSeconds": 30.439845709,
-              "downloadSeconds": 0.000163488
+              "latency": 11.343525339
             },
             {
-              "connectionEstablishedSeconds": 0.06265785,
-              "uploadSeconds": 11.516149765,
-              "downloadSeconds": 0.000129193
+              "latency": 6.911762881
             },
             {
-              "connectionEstablishedSeconds": 0.065870575,
-              "uploadSeconds": 16.945701847,
-              "downloadSeconds": 0.000083312
+              "latency": 12.609361633
             },
             {
-              "connectionEstablishedSeconds": 0.066685308,
-              "uploadSeconds": 17.157438746,
-              "downloadSeconds": 0.000134467
+              "latency": 7.581082749
             },
             {
-              "connectionEstablishedSeconds": 0.06508686,
-              "uploadSeconds": 20.362663014,
-              "downloadSeconds": 0.00021038
+              "latency": 12.106078233
             }
           ],
           "implementation": "rust-libp2p",
@@ -103,29 +83,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.068856644,
-              "uploadSeconds": 1.402213112,
-              "downloadSeconds": 0.000085133
+              "latency": 1.48390983
             },
             {
-              "connectionEstablishedSeconds": 0.065518432,
-              "uploadSeconds": 1.445110638,
-              "downloadSeconds": 0.000089192
+              "latency": 1.451956286
             },
             {
-              "connectionEstablishedSeconds": 0.061399509,
-              "uploadSeconds": 1.347394456,
-              "downloadSeconds": 0.000055885
+              "latency": 1.463895122
             },
             {
-              "connectionEstablishedSeconds": 0.063340799,
-              "uploadSeconds": 1.3995380339999999,
-              "downloadSeconds": 0.000043643
+              "latency": 1.547614427
             },
             {
-              "connectionEstablishedSeconds": 0.063240204,
-              "uploadSeconds": 1.393610506,
-              "downloadSeconds": 0.000126388
+              "latency": 1.413163368
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -135,29 +105,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 2.79994608,
-              "downloadSeconds": 0.000001624
+              "latency": 2.848549437
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 2.712869064,
-              "downloadSeconds": 0.000004425
+              "latency": 2.711526003
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 2.7989140260000003,
-              "downloadSeconds": 0.000001659
+              "latency": 2.895369826
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 2.797738943,
-              "downloadSeconds": 0.000003846
+              "latency": 2.851659218
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 2.710649859,
-              "downloadSeconds": 0.000004266
+              "latency": 2.658472437
             }
           ],
           "implementation": "https",
@@ -167,29 +127,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.257897112,
-              "uploadSeconds": 2.898714608,
-              "downloadSeconds": 0.125947478
+              "latency": 3.12648972
             },
             {
-              "connectionEstablishedSeconds": 0.253306448,
-              "uploadSeconds": 2.935159906,
-              "downloadSeconds": 0.124808834
+              "latency": 3.371825872
             },
             {
-              "connectionEstablishedSeconds": 0.257107718,
-              "uploadSeconds": 2.956579177,
-              "downloadSeconds": 0.125826729
+              "latency": 3.261648222
             },
             {
-              "connectionEstablishedSeconds": 0.261447279,
-              "uploadSeconds": 3.073232105,
-              "downloadSeconds": 0.128016533
+              "latency": 3.239118407
             },
             {
-              "connectionEstablishedSeconds": 0.256173976,
-              "uploadSeconds": 3.094974155,
-              "downloadSeconds": 0.126269123
+              "latency": 3.232566064
             }
           ],
           "implementation": "go-libp2p",
@@ -199,29 +149,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.132941292,
-              "uploadSeconds": 1.3138654889999999,
-              "downloadSeconds": 0.063525917
+              "latency": 1.5502225859999998
             },
             {
-              "connectionEstablishedSeconds": 0.130994117,
-              "uploadSeconds": 1.480872529,
-              "downloadSeconds": 0.063031466
+              "latency": 1.537627771
             },
             {
-              "connectionEstablishedSeconds": 0.131776023,
-              "uploadSeconds": 1.303614286,
-              "downloadSeconds": 0.063162675
+              "latency": 1.48474078
             },
             {
-              "connectionEstablishedSeconds": 0.127950072,
-              "uploadSeconds": 1.282649997,
-              "downloadSeconds": 0.062072209
+              "latency": 1.481374735
             },
             {
-              "connectionEstablishedSeconds": 0.132015753,
-              "uploadSeconds": 1.308251399,
-              "downloadSeconds": 0.063331159
+              "latency": 1.477803009
             }
           ],
           "implementation": "go-libp2p",
@@ -241,29 +181,29 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.066565584,
-              "uploadSeconds": 4.14e-7,
-              "downloadSeconds": 1.156675842
+              "connectionEstablishedSeconds": 0.065055737,
+              "uploadSeconds": 4.8e-7,
+              "downloadSeconds": 1.06632234
             },
             {
-              "connectionEstablishedSeconds": 0.064892061,
-              "uploadSeconds": 4.79e-7,
-              "downloadSeconds": 1.069297593
+              "connectionEstablishedSeconds": 0.065932756,
+              "uploadSeconds": 5.69e-7,
+              "downloadSeconds": 1.094419139
             },
             {
-              "connectionEstablishedSeconds": 0.065190888,
-              "uploadSeconds": 5.41e-7,
-              "downloadSeconds": 1.597194709
+              "connectionEstablishedSeconds": 0.065730553,
+              "uploadSeconds": 4.84e-7,
+              "downloadSeconds": 1.078618119
             },
             {
-              "connectionEstablishedSeconds": 0.063803854,
-              "uploadSeconds": 6.02e-7,
-              "downloadSeconds": 1.263743063
+              "connectionEstablishedSeconds": 0.062481732,
+              "uploadSeconds": 5.53e-7,
+              "downloadSeconds": 1.027141057
             },
             {
-              "connectionEstablishedSeconds": 0.064557168,
-              "uploadSeconds": 5.93e-7,
-              "downloadSeconds": 1.063204626
+              "connectionEstablishedSeconds": 0.067021001,
+              "uploadSeconds": 5.3e-7,
+              "downloadSeconds": 1.107657318
             }
           ],
           "implementation": "quic-go",
@@ -273,29 +213,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.118973999,
-              "uploadSeconds": 0.00000237,
-              "downloadSeconds": 43.097832521
+              "latency": 43.946048827
             },
             {
-              "connectionEstablishedSeconds": 0.127215353,
-              "uploadSeconds": 0.000002032,
-              "downloadSeconds": 45.641765158
+              "latency": 47.398444561
             },
             {
-              "connectionEstablishedSeconds": 0.124596278,
-              "uploadSeconds": 0.000002028,
-              "downloadSeconds": 46.368505073
+              "latency": 46.734388492
             },
             {
-              "connectionEstablishedSeconds": 0.128120916,
-              "uploadSeconds": 0.000002222,
-              "downloadSeconds": 47.874739863
+              "latency": 45.557861667
             },
             {
-              "connectionEstablishedSeconds": 0.124931603,
-              "uploadSeconds": 0.000001954,
-              "downloadSeconds": 44.744356376
+              "latency": 47.748554966
             }
           ],
           "implementation": "rust-libp2p",
@@ -305,29 +235,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.064101794,
-              "uploadSeconds": 0.062433886,
-              "downloadSeconds": 14.226532904
+              "latency": 10.904454992
             },
             {
-              "connectionEstablishedSeconds": 0.064768482,
-              "uploadSeconds": 0.063380472,
-              "downloadSeconds": 9.652918476
+              "latency": 16.474956111
             },
             {
-              "connectionEstablishedSeconds": 0.063089269,
-              "uploadSeconds": 0.061641026,
-              "downloadSeconds": 44.248097576
+              "latency": 15.693422551
             },
             {
-              "connectionEstablishedSeconds": 0.065786917,
-              "uploadSeconds": 0.064454129,
-              "downloadSeconds": 7.935120556
+              "latency": 14.618747683
             },
             {
-              "connectionEstablishedSeconds": 0.065490198,
-              "uploadSeconds": 0.064216836,
-              "downloadSeconds": 12.013647805
+              "latency": 12.516697744
             }
           ],
           "implementation": "rust-libp2p",
@@ -337,29 +257,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.065718437,
-              "uploadSeconds": 0.063958589,
-              "downloadSeconds": 1.5755928510000001
+              "latency": 1.495868037
             },
             {
-              "connectionEstablishedSeconds": 0.065243916,
-              "uploadSeconds": 0.063788174,
-              "downloadSeconds": 1.374596511
+              "latency": 1.462521523
             },
             {
-              "connectionEstablishedSeconds": 0.065815979,
-              "uploadSeconds": 0.064431818,
-              "downloadSeconds": 1.406562029
+              "latency": 1.444689061
             },
             {
-              "connectionEstablishedSeconds": 0.064376266,
-              "uploadSeconds": 0.062916412,
-              "downloadSeconds": 1.395864717
+              "latency": 1.496378178
             },
             {
-              "connectionEstablishedSeconds": 0.065978775,
-              "uploadSeconds": 0.064501789,
-              "downloadSeconds": 1.412157431
+              "latency": 1.441893712
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -369,29 +279,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188128181,
-              "downloadSeconds": 2.674302866
+              "latency": 2.840318246
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191556654,
-              "downloadSeconds": 2.862983464
+              "latency": 2.712228864
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.1892993,
-              "downloadSeconds": 2.526412433
+              "latency": 2.840523228
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19302405,
-              "downloadSeconds": 3.278985925
+              "latency": 2.726671717
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.184218404,
-              "downloadSeconds": 2.509003996
+              "latency": 2.62770275
             }
           ],
           "implementation": "https",
@@ -401,29 +301,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.25935759,
-              "uploadSeconds": 0.000044908,
-              "downloadSeconds": 3.076994748
+              "latency": 3.155896034
             },
             {
-              "connectionEstablishedSeconds": 0.252395091,
-              "uploadSeconds": 0.000023151,
-              "downloadSeconds": 5.499522915
+              "latency": 3.531261581
             },
             {
-              "connectionEstablishedSeconds": 0.247996802,
-              "uploadSeconds": 0.000049357,
-              "downloadSeconds": 3.000616134
+              "latency": 3.256629302
             },
             {
-              "connectionEstablishedSeconds": 0.254360687,
-              "uploadSeconds": 0.000014436,
-              "downloadSeconds": 2.998061834
+              "latency": 3.243212416
             },
             {
-              "connectionEstablishedSeconds": 0.248067035,
-              "uploadSeconds": 0.00002827,
-              "downloadSeconds": 8.412003512
+              "latency": 3.0779007800000002
             }
           ],
           "implementation": "go-libp2p",
@@ -433,29 +323,19 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.129844268,
-              "uploadSeconds": 0.000028622,
-              "downloadSeconds": 17.731692926
+              "latency": 1.482987271
             },
             {
-              "connectionEstablishedSeconds": 0.126124365,
-              "uploadSeconds": 0.000011456,
-              "downloadSeconds": 33.438663611
+              "latency": 1.445906693
             },
             {
-              "connectionEstablishedSeconds": 0.125621003,
-              "uploadSeconds": 0.000052524,
-              "downloadSeconds": 1.303201594
+              "latency": 1.412701657
             },
             {
-              "connectionEstablishedSeconds": 0.127493675,
-              "uploadSeconds": 0.000047776,
-              "downloadSeconds": 1.375030162
+              "latency": 1.5209862680000001
             },
             {
-              "connectionEstablishedSeconds": 0.126735688,
-              "uploadSeconds": 0.000032102,
-              "downloadSeconds": 1.33293199
+              "latency": 1.471951628
             }
           ],
           "implementation": "go-libp2p",
@@ -475,504 +355,504 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.065960652,
-              "uploadSeconds": 0.000002015,
-              "downloadSeconds": 0.063855438
+              "connectionEstablishedSeconds": 0.066477738,
+              "uploadSeconds": 9.13e-7,
+              "downloadSeconds": 0.064279773
             },
             {
-              "connectionEstablishedSeconds": 0.065796591,
-              "uploadSeconds": 7.76e-7,
-              "downloadSeconds": 0.06396702
+              "connectionEstablishedSeconds": 0.063384989,
+              "uploadSeconds": 0.000001945,
+              "downloadSeconds": 0.061576815
             },
             {
-              "connectionEstablishedSeconds": 0.063741155,
-              "uploadSeconds": 7.26e-7,
-              "downloadSeconds": 0.061985858
+              "connectionEstablishedSeconds": 0.061145928,
+              "uploadSeconds": 0.000001868,
+              "downloadSeconds": 0.059469068
             },
             {
-              "connectionEstablishedSeconds": 0.063623635,
-              "uploadSeconds": 8.74e-7,
-              "downloadSeconds": 0.061928483
+              "connectionEstablishedSeconds": 0.062942029,
+              "uploadSeconds": 8.31e-7,
+              "downloadSeconds": 0.061218983
             },
             {
-              "connectionEstablishedSeconds": 0.065022228,
-              "uploadSeconds": 8.35e-7,
-              "downloadSeconds": 0.063295054
+              "connectionEstablishedSeconds": 0.064997377,
+              "uploadSeconds": 6.62e-7,
+              "downloadSeconds": 0.063325405
             },
             {
-              "connectionEstablishedSeconds": 0.063489342,
-              "uploadSeconds": 8.91e-7,
-              "downloadSeconds": 0.061834942
+              "connectionEstablishedSeconds": 0.063041542,
+              "uploadSeconds": 0.000001815,
+              "downloadSeconds": 0.06138463
             },
             {
-              "connectionEstablishedSeconds": 0.063839197,
-              "uploadSeconds": 0.000001813,
-              "downloadSeconds": 0.062152462
+              "connectionEstablishedSeconds": 0.062411302,
+              "uploadSeconds": 0.000002064,
+              "downloadSeconds": 0.060813701
             },
             {
-              "connectionEstablishedSeconds": 0.062052708,
-              "uploadSeconds": 0.00000184,
-              "downloadSeconds": 0.060337044
+              "connectionEstablishedSeconds": 0.064948654,
+              "uploadSeconds": 0.000001944,
+              "downloadSeconds": 0.063252918
             },
             {
-              "connectionEstablishedSeconds": 0.06652303,
-              "uploadSeconds": 0.000001925,
-              "downloadSeconds": 0.06475633
+              "connectionEstablishedSeconds": 0.063368626,
+              "uploadSeconds": 6.52e-7,
+              "downloadSeconds": 0.061717348
             },
             {
-              "connectionEstablishedSeconds": 0.064486313,
-              "uploadSeconds": 0.000001878,
-              "downloadSeconds": 0.062974785
+              "connectionEstablishedSeconds": 0.064612749,
+              "uploadSeconds": 0.00000194,
+              "downloadSeconds": 0.062961718
             },
             {
-              "connectionEstablishedSeconds": 0.06602361,
-              "uploadSeconds": 0.000001897,
-              "downloadSeconds": 0.064166513
-            },
-            {
-              "connectionEstablishedSeconds": 0.065900274,
-              "uploadSeconds": 0.00000199,
-              "downloadSeconds": 0.064157587
-            },
-            {
-              "connectionEstablishedSeconds": 0.065483286,
-              "uploadSeconds": 0.000001814,
-              "downloadSeconds": 0.06382869
-            },
-            {
-              "connectionEstablishedSeconds": 0.065826406,
-              "uploadSeconds": 7.81e-7,
-              "downloadSeconds": 0.064117447
-            },
-            {
-              "connectionEstablishedSeconds": 0.063089169,
-              "uploadSeconds": 0.00000184,
-              "downloadSeconds": 0.061341493
-            },
-            {
-              "connectionEstablishedSeconds": 0.063718383,
-              "uploadSeconds": 0.000001888,
-              "downloadSeconds": 0.063655426
-            },
-            {
-              "connectionEstablishedSeconds": 0.066834037,
-              "uploadSeconds": 7.83e-7,
-              "downloadSeconds": 0.065118068
-            },
-            {
-              "connectionEstablishedSeconds": 0.066410017,
-              "uploadSeconds": 7.09e-7,
-              "downloadSeconds": 0.064750831
-            },
-            {
-              "connectionEstablishedSeconds": 0.062099751,
-              "uploadSeconds": 0.000001848,
-              "downloadSeconds": 0.060406111
-            },
-            {
-              "connectionEstablishedSeconds": 0.064540611,
-              "uploadSeconds": 7.44e-7,
-              "downloadSeconds": 0.063029603
-            },
-            {
-              "connectionEstablishedSeconds": 0.062104416,
-              "uploadSeconds": 0.000001775,
-              "downloadSeconds": 0.060452269
-            },
-            {
-              "connectionEstablishedSeconds": 0.065979366,
-              "uploadSeconds": 0.000001828,
-              "downloadSeconds": 0.064631635
-            },
-            {
-              "connectionEstablishedSeconds": 0.064317867,
-              "uploadSeconds": 0.000001728,
-              "downloadSeconds": 0.062680971
-            },
-            {
-              "connectionEstablishedSeconds": 0.066068105,
-              "uploadSeconds": 0.000001847,
-              "downloadSeconds": 0.064407149
-            },
-            {
-              "connectionEstablishedSeconds": 0.066437507,
-              "uploadSeconds": 0.000001732,
-              "downloadSeconds": 0.064739867
-            },
-            {
-              "connectionEstablishedSeconds": 0.063907597,
-              "uploadSeconds": 0.000001816,
-              "downloadSeconds": 0.062924509
-            },
-            {
-              "connectionEstablishedSeconds": 0.064049647,
-              "uploadSeconds": 0.000001732,
-              "downloadSeconds": 0.06234967
-            },
-            {
-              "connectionEstablishedSeconds": 0.063910531,
-              "uploadSeconds": 0.00000186,
-              "downloadSeconds": 0.062329574
-            },
-            {
-              "connectionEstablishedSeconds": 0.065968402,
-              "uploadSeconds": 0.000001923,
-              "downloadSeconds": 0.064255131
-            },
-            {
-              "connectionEstablishedSeconds": 0.063100228,
-              "uploadSeconds": 0.000001812,
-              "downloadSeconds": 0.061423418
-            },
-            {
-              "connectionEstablishedSeconds": 0.066908387,
-              "uploadSeconds": 0.000001842,
-              "downloadSeconds": 0.065233548
-            },
-            {
-              "connectionEstablishedSeconds": 0.066429964,
-              "uploadSeconds": 0.00000185,
-              "downloadSeconds": 0.064721823
-            },
-            {
-              "connectionEstablishedSeconds": 0.064623603,
-              "uploadSeconds": 0.000001847,
-              "downloadSeconds": 0.063768799
-            },
-            {
-              "connectionEstablishedSeconds": 0.064637046,
-              "uploadSeconds": 0.000001848,
-              "downloadSeconds": 0.062864239
-            },
-            {
-              "connectionEstablishedSeconds": 0.066364894,
-              "uploadSeconds": 0.000001886,
-              "downloadSeconds": 0.064992379
-            },
-            {
-              "connectionEstablishedSeconds": 0.066949464,
-              "uploadSeconds": 0.000001917,
-              "downloadSeconds": 0.065019192
-            },
-            {
-              "connectionEstablishedSeconds": 0.064527955,
-              "uploadSeconds": 0.00000189,
-              "downloadSeconds": 0.062822321
-            },
-            {
-              "connectionEstablishedSeconds": 0.065350527,
-              "uploadSeconds": 7.2e-7,
-              "downloadSeconds": 0.063855509
-            },
-            {
-              "connectionEstablishedSeconds": 0.063090567,
-              "uploadSeconds": 0.000001824,
-              "downloadSeconds": 0.061434879
-            },
-            {
-              "connectionEstablishedSeconds": 0.065239703,
-              "uploadSeconds": 0.00000196,
-              "downloadSeconds": 0.063566127
-            },
-            {
-              "connectionEstablishedSeconds": 0.063867134,
-              "uploadSeconds": 0.000001787,
-              "downloadSeconds": 0.062171417
-            },
-            {
-              "connectionEstablishedSeconds": 0.064744197,
-              "uploadSeconds": 0.000001909,
-              "downloadSeconds": 0.063078302
-            },
-            {
-              "connectionEstablishedSeconds": 0.063921323,
-              "uploadSeconds": 0.000001774,
-              "downloadSeconds": 0.062253087
-            },
-            {
-              "connectionEstablishedSeconds": 0.065797461,
-              "uploadSeconds": 0.000001763,
-              "downloadSeconds": 0.064141632
-            },
-            {
-              "connectionEstablishedSeconds": 0.063432254,
-              "uploadSeconds": 7.52e-7,
-              "downloadSeconds": 0.063523257
-            },
-            {
-              "connectionEstablishedSeconds": 0.063448576,
-              "uploadSeconds": 0.000001847,
-              "downloadSeconds": 0.061447665
-            },
-            {
-              "connectionEstablishedSeconds": 0.064840213,
-              "uploadSeconds": 0.000001799,
-              "downloadSeconds": 0.063268648
-            },
-            {
-              "connectionEstablishedSeconds": 0.062984093,
-              "uploadSeconds": 0.000001873,
-              "downloadSeconds": 0.061266251
-            },
-            {
-              "connectionEstablishedSeconds": 0.063835431,
-              "uploadSeconds": 0.000001041,
-              "downloadSeconds": 0.062294655
-            },
-            {
-              "connectionEstablishedSeconds": 0.066513465,
-              "uploadSeconds": 0.000001802,
-              "downloadSeconds": 0.06479643
-            },
-            {
-              "connectionEstablishedSeconds": 0.064597329,
-              "uploadSeconds": 0.000001768,
-              "downloadSeconds": 0.062962919
-            },
-            {
-              "connectionEstablishedSeconds": 0.065778361,
-              "uploadSeconds": 0.00000186,
-              "downloadSeconds": 0.06410771
-            },
-            {
-              "connectionEstablishedSeconds": 0.065951503,
-              "uploadSeconds": 0.000001775,
-              "downloadSeconds": 0.063964319
-            },
-            {
-              "connectionEstablishedSeconds": 0.065201946,
-              "uploadSeconds": 0.000001795,
-              "downloadSeconds": 0.063643639
-            },
-            {
-              "connectionEstablishedSeconds": 0.066076218,
-              "uploadSeconds": 0.000001848,
-              "downloadSeconds": 0.064510646
-            },
-            {
-              "connectionEstablishedSeconds": 0.060682481,
-              "uploadSeconds": 0.000002,
-              "downloadSeconds": 0.059199478
-            },
-            {
-              "connectionEstablishedSeconds": 0.065554049,
-              "uploadSeconds": 0.000001739,
-              "downloadSeconds": 0.06377536
-            },
-            {
-              "connectionEstablishedSeconds": 0.061208203,
-              "uploadSeconds": 0.00000177,
-              "downloadSeconds": 0.059550325
-            },
-            {
-              "connectionEstablishedSeconds": 0.067027502,
-              "uploadSeconds": 0.000001823,
-              "downloadSeconds": 0.065262971
-            },
-            {
-              "connectionEstablishedSeconds": 0.066147698,
-              "uploadSeconds": 0.000001906,
-              "downloadSeconds": 0.064408233
-            },
-            {
-              "connectionEstablishedSeconds": 0.066192563,
-              "uploadSeconds": 0.000001711,
-              "downloadSeconds": 0.064853112
-            },
-            {
-              "connectionEstablishedSeconds": 0.065939828,
+              "connectionEstablishedSeconds": 0.065265762,
               "uploadSeconds": 0.000001766,
-              "downloadSeconds": 0.064260021
+              "downloadSeconds": 0.063603035
             },
             {
-              "connectionEstablishedSeconds": 0.06487606,
-              "uploadSeconds": 0.000001916,
-              "downloadSeconds": 0.063237738
+              "connectionEstablishedSeconds": 0.063799059,
+              "uploadSeconds": 7.79e-7,
+              "downloadSeconds": 0.062343968
             },
             {
-              "connectionEstablishedSeconds": 0.064049202,
-              "uploadSeconds": 0.000001889,
-              "downloadSeconds": 0.062357129
+              "connectionEstablishedSeconds": 0.063932116,
+              "uploadSeconds": 7.48e-7,
+              "downloadSeconds": 0.062255098
             },
             {
-              "connectionEstablishedSeconds": 0.065536679,
-              "uploadSeconds": 0.000001785,
-              "downloadSeconds": 0.064333056
+              "connectionEstablishedSeconds": 0.065841626,
+              "uploadSeconds": 0.000001811,
+              "downloadSeconds": 0.064048202
             },
             {
-              "connectionEstablishedSeconds": 0.063045093,
-              "uploadSeconds": 0.000001888,
-              "downloadSeconds": 0.061440221
+              "connectionEstablishedSeconds": 0.065301591,
+              "uploadSeconds": 7.4e-7,
+              "downloadSeconds": 0.063640797
             },
             {
-              "connectionEstablishedSeconds": 0.06322189,
-              "uploadSeconds": 0.00000193,
-              "downloadSeconds": 0.06153135
+              "connectionEstablishedSeconds": 0.066088716,
+              "uploadSeconds": 8.22e-7,
+              "downloadSeconds": 0.064488602
             },
             {
-              "connectionEstablishedSeconds": 0.06471423,
-              "uploadSeconds": 0.000001819,
-              "downloadSeconds": 0.063194954
+              "connectionEstablishedSeconds": 0.063453803,
+              "uploadSeconds": 6.67e-7,
+              "downloadSeconds": 0.061766168
             },
             {
-              "connectionEstablishedSeconds": 0.065249297,
-              "uploadSeconds": 0.00000169,
-              "downloadSeconds": 0.064097755
+              "connectionEstablishedSeconds": 0.067533886,
+              "uploadSeconds": 0.000001827,
+              "downloadSeconds": 0.064261728
             },
             {
-              "connectionEstablishedSeconds": 0.064081193,
-              "uploadSeconds": 7.64e-7,
-              "downloadSeconds": 0.062326683
+              "connectionEstablishedSeconds": 0.065824063,
+              "uploadSeconds": 0.000001908,
+              "downloadSeconds": 0.064185538
             },
             {
-              "connectionEstablishedSeconds": 0.063041856,
+              "connectionEstablishedSeconds": 0.064414247,
+              "uploadSeconds": 0.000001777,
+              "downloadSeconds": 0.062788112
+            },
+            {
+              "connectionEstablishedSeconds": 0.063145715,
+              "uploadSeconds": 0.000001837,
+              "downloadSeconds": 0.061507258
+            },
+            {
+              "connectionEstablishedSeconds": 0.064571773,
+              "uploadSeconds": 0.00000176,
+              "downloadSeconds": 0.062921305
+            },
+            {
+              "connectionEstablishedSeconds": 0.064329536,
+              "uploadSeconds": 7.7e-7,
+              "downloadSeconds": 0.062733902
+            },
+            {
+              "connectionEstablishedSeconds": 0.063574457,
+              "uploadSeconds": 6.55e-7,
+              "downloadSeconds": 0.061928445
+            },
+            {
+              "connectionEstablishedSeconds": 0.063684941,
               "uploadSeconds": 0.000001814,
-              "downloadSeconds": 0.061309187
+              "downloadSeconds": 0.062144699
             },
             {
-              "connectionEstablishedSeconds": 0.063910362,
-              "uploadSeconds": 0.00000181,
-              "downloadSeconds": 0.062275784
-            },
-            {
-              "connectionEstablishedSeconds": 0.063506594,
-              "uploadSeconds": 0.000001843,
-              "downloadSeconds": 0.061753042
-            },
-            {
-              "connectionEstablishedSeconds": 0.066419848,
-              "uploadSeconds": 0.000001996,
-              "downloadSeconds": 0.064808717
-            },
-            {
-              "connectionEstablishedSeconds": 0.062470426,
-              "uploadSeconds": 0.000001741,
-              "downloadSeconds": 0.06096953
-            },
-            {
-              "connectionEstablishedSeconds": 0.064943312,
-              "uploadSeconds": 0.000001849,
-              "downloadSeconds": 0.063242568
-            },
-            {
-              "connectionEstablishedSeconds": 0.064688986,
-              "uploadSeconds": 0.000001694,
-              "downloadSeconds": 0.06291107
-            },
-            {
-              "connectionEstablishedSeconds": 0.064706476,
-              "uploadSeconds": 0.00000183,
-              "downloadSeconds": 0.06321239
-            },
-            {
-              "connectionEstablishedSeconds": 0.060864393,
-              "uploadSeconds": 7.13e-7,
-              "downloadSeconds": 0.059260479
-            },
-            {
-              "connectionEstablishedSeconds": 0.064634663,
-              "uploadSeconds": 0.00000181,
-              "downloadSeconds": 0.062899306
-            },
-            {
-              "connectionEstablishedSeconds": 0.062740938,
-              "uploadSeconds": 0.000001724,
-              "downloadSeconds": 0.061089935
-            },
-            {
-              "connectionEstablishedSeconds": 0.06110142,
-              "uploadSeconds": 0.000001824,
-              "downloadSeconds": 0.059406993
-            },
-            {
-              "connectionEstablishedSeconds": 0.065856369,
-              "uploadSeconds": 0.000001818,
-              "downloadSeconds": 0.064210017
-            },
-            {
-              "connectionEstablishedSeconds": 0.063945114,
-              "uploadSeconds": 7.78e-7,
-              "downloadSeconds": 0.06232278
-            },
-            {
-              "connectionEstablishedSeconds": 0.06562598,
-              "uploadSeconds": 0.000001739,
-              "downloadSeconds": 0.063622294
-            },
-            {
-              "connectionEstablishedSeconds": 0.066873176,
-              "uploadSeconds": 0.000001773,
-              "downloadSeconds": 0.065124502
-            },
-            {
-              "connectionEstablishedSeconds": 0.063249351,
-              "uploadSeconds": 0.000002101,
-              "downloadSeconds": 0.061409982
-            },
-            {
-              "connectionEstablishedSeconds": 0.063833002,
-              "uploadSeconds": 7.34e-7,
-              "downloadSeconds": 0.062095569
-            },
-            {
-              "connectionEstablishedSeconds": 0.064269477,
-              "uploadSeconds": 7.34e-7,
-              "downloadSeconds": 0.062764291
-            },
-            {
-              "connectionEstablishedSeconds": 0.063465935,
-              "uploadSeconds": 7.32e-7,
-              "downloadSeconds": 0.061807299
-            },
-            {
-              "connectionEstablishedSeconds": 0.0637097,
-              "uploadSeconds": 0.00000172,
-              "downloadSeconds": 0.062126378
-            },
-            {
-              "connectionEstablishedSeconds": 0.065199418,
-              "uploadSeconds": 0.000001855,
-              "downloadSeconds": 0.063405634
-            },
-            {
-              "connectionEstablishedSeconds": 0.063962776,
-              "uploadSeconds": 0.000001932,
-              "downloadSeconds": 0.062353148
-            },
-            {
-              "connectionEstablishedSeconds": 0.065688074,
-              "uploadSeconds": 7.1e-7,
-              "downloadSeconds": 0.064095358
-            },
-            {
-              "connectionEstablishedSeconds": 0.065177434,
+              "connectionEstablishedSeconds": 0.065248651,
               "uploadSeconds": 0.000001761,
-              "downloadSeconds": 0.06355402
+              "downloadSeconds": 0.063635889
             },
             {
-              "connectionEstablishedSeconds": 0.065289624,
-              "uploadSeconds": 0.000001871,
-              "downloadSeconds": 0.063665141
+              "connectionEstablishedSeconds": 0.062888987,
+              "uploadSeconds": 0.000001766,
+              "downloadSeconds": 0.061333808
             },
             {
-              "connectionEstablishedSeconds": 0.06637104,
-              "uploadSeconds": 0.000001787,
-              "downloadSeconds": 0.064671943
+              "connectionEstablishedSeconds": 0.062495181,
+              "uploadSeconds": 0.000001727,
+              "downloadSeconds": 0.060910486
             },
             {
-              "connectionEstablishedSeconds": 0.062665683,
-              "uploadSeconds": 0.000001973,
-              "downloadSeconds": 0.06036064
+              "connectionEstablishedSeconds": 0.061005789,
+              "uploadSeconds": 7.09e-7,
+              "downloadSeconds": 0.059455919
             },
             {
-              "connectionEstablishedSeconds": 0.065424972,
-              "uploadSeconds": 0.000001703,
-              "downloadSeconds": 0.063783958
+              "connectionEstablishedSeconds": 0.064478585,
+              "uploadSeconds": 0.000001737,
+              "downloadSeconds": 0.06281553
             },
             {
-              "connectionEstablishedSeconds": 0.064705635,
-              "uploadSeconds": 7.31e-7,
-              "downloadSeconds": 0.063094454
+              "connectionEstablishedSeconds": 0.062454254,
+              "uploadSeconds": 0.000001867,
+              "downloadSeconds": 0.060819645
+            },
+            {
+              "connectionEstablishedSeconds": 0.065255324,
+              "uploadSeconds": 0.000001756,
+              "downloadSeconds": 0.063602326
+            },
+            {
+              "connectionEstablishedSeconds": 0.062055576,
+              "uploadSeconds": 7.44e-7,
+              "downloadSeconds": 0.060455686
+            },
+            {
+              "connectionEstablishedSeconds": 0.066634361,
+              "uploadSeconds": 0.000001745,
+              "downloadSeconds": 0.064154614
+            },
+            {
+              "connectionEstablishedSeconds": 0.065356468,
+              "uploadSeconds": 0.000001718,
+              "downloadSeconds": 0.063758737
+            },
+            {
+              "connectionEstablishedSeconds": 0.063229657,
+              "uploadSeconds": 0.000001786,
+              "downloadSeconds": 0.061511939
+            },
+            {
+              "connectionEstablishedSeconds": 0.061751818,
+              "uploadSeconds": 6.77e-7,
+              "downloadSeconds": 0.060130236
+            },
+            {
+              "connectionEstablishedSeconds": 0.064834215,
+              "uploadSeconds": 7.52e-7,
+              "downloadSeconds": 0.063223928
+            },
+            {
+              "connectionEstablishedSeconds": 0.065323919,
+              "uploadSeconds": 0.000001766,
+              "downloadSeconds": 0.063761162
+            },
+            {
+              "connectionEstablishedSeconds": 0.064654637,
+              "uploadSeconds": 6.61e-7,
+              "downloadSeconds": 0.06307213
+            },
+            {
+              "connectionEstablishedSeconds": 0.061151181,
+              "uploadSeconds": 0.000002048,
+              "downloadSeconds": 0.059393933
+            },
+            {
+              "connectionEstablishedSeconds": 0.066678722,
+              "uploadSeconds": 0.000001843,
+              "downloadSeconds": 0.065026017
+            },
+            {
+              "connectionEstablishedSeconds": 0.061621551,
+              "uploadSeconds": 0.000001801,
+              "downloadSeconds": 0.059896765
+            },
+            {
+              "connectionEstablishedSeconds": 0.065268154,
+              "uploadSeconds": 0.000001698,
+              "downloadSeconds": 0.063545918
+            },
+            {
+              "connectionEstablishedSeconds": 0.064312612,
+              "uploadSeconds": 7.46e-7,
+              "downloadSeconds": 0.062722097
+            },
+            {
+              "connectionEstablishedSeconds": 0.064034255,
+              "uploadSeconds": 0.000001838,
+              "downloadSeconds": 0.062325111
+            },
+            {
+              "connectionEstablishedSeconds": 0.06502196,
+              "uploadSeconds": 0.000001751,
+              "downloadSeconds": 0.062502688
+            },
+            {
+              "connectionEstablishedSeconds": 0.066040776,
+              "uploadSeconds": 0.000001795,
+              "downloadSeconds": 0.064447869
+            },
+            {
+              "connectionEstablishedSeconds": 0.061958007,
+              "uploadSeconds": 0.000001712,
+              "downloadSeconds": 0.060529294
+            },
+            {
+              "connectionEstablishedSeconds": 0.062529329,
+              "uploadSeconds": 7.46e-7,
+              "downloadSeconds": 0.060860608
+            },
+            {
+              "connectionEstablishedSeconds": 0.064877895,
+              "uploadSeconds": 0.000001842,
+              "downloadSeconds": 0.06340455
+            },
+            {
+              "connectionEstablishedSeconds": 0.062968037,
+              "uploadSeconds": 0.000001806,
+              "downloadSeconds": 0.06133636
+            },
+            {
+              "connectionEstablishedSeconds": 0.062629803,
+              "uploadSeconds": 0.000001859,
+              "downloadSeconds": 0.06085844
+            },
+            {
+              "connectionEstablishedSeconds": 0.062286495,
+              "uploadSeconds": 7.62e-7,
+              "downloadSeconds": 0.060687572
+            },
+            {
+              "connectionEstablishedSeconds": 0.061797799,
+              "uploadSeconds": 0.000001768,
+              "downloadSeconds": 0.060149257
+            },
+            {
+              "connectionEstablishedSeconds": 0.065891438,
+              "uploadSeconds": 7.61e-7,
+              "downloadSeconds": 0.064306904
+            },
+            {
+              "connectionEstablishedSeconds": 0.06226347,
+              "uploadSeconds": 0.000001774,
+              "downloadSeconds": 0.06142646
+            },
+            {
+              "connectionEstablishedSeconds": 0.063052821,
+              "uploadSeconds": 0.00000174,
+              "downloadSeconds": 0.061442282
+            },
+            {
+              "connectionEstablishedSeconds": 0.065785278,
+              "uploadSeconds": 0.000001783,
+              "downloadSeconds": 0.064155999
+            },
+            {
+              "connectionEstablishedSeconds": 0.063619823,
+              "uploadSeconds": 0.000001794,
+              "downloadSeconds": 0.062080533
+            },
+            {
+              "connectionEstablishedSeconds": 0.064504737,
+              "uploadSeconds": 0.000001699,
+              "downloadSeconds": 0.062789832
+            },
+            {
+              "connectionEstablishedSeconds": 0.066131541,
+              "uploadSeconds": 0.000001854,
+              "downloadSeconds": 0.064514268
+            },
+            {
+              "connectionEstablishedSeconds": 0.061934264,
+              "uploadSeconds": 0.000001727,
+              "downloadSeconds": 0.060205341
+            },
+            {
+              "connectionEstablishedSeconds": 0.061799629,
+              "uploadSeconds": 0.000001802,
+              "downloadSeconds": 0.060281556
+            },
+            {
+              "connectionEstablishedSeconds": 0.062666625,
+              "uploadSeconds": 0.000001704,
+              "downloadSeconds": 0.060979079
+            },
+            {
+              "connectionEstablishedSeconds": 0.064806916,
+              "uploadSeconds": 0.000001819,
+              "downloadSeconds": 0.063166144
+            },
+            {
+              "connectionEstablishedSeconds": 0.062246318,
+              "uploadSeconds": 6.92e-7,
+              "downloadSeconds": 0.060729196
+            },
+            {
+              "connectionEstablishedSeconds": 0.061268258,
+              "uploadSeconds": 7.6e-7,
+              "downloadSeconds": 0.059645958
+            },
+            {
+              "connectionEstablishedSeconds": 0.062319598,
+              "uploadSeconds": 0.000001863,
+              "downloadSeconds": 0.061273583
+            },
+            {
+              "connectionEstablishedSeconds": 0.066712762,
+              "uploadSeconds": 7.39e-7,
+              "downloadSeconds": 0.065062983
+            },
+            {
+              "connectionEstablishedSeconds": 0.064125282,
+              "uploadSeconds": 0.000001711,
+              "downloadSeconds": 0.062471341
+            },
+            {
+              "connectionEstablishedSeconds": 0.062314829,
+              "uploadSeconds": 7.52e-7,
+              "downloadSeconds": 0.060759741
+            },
+            {
+              "connectionEstablishedSeconds": 0.061910734,
+              "uploadSeconds": 0.00000177,
+              "downloadSeconds": 0.060320397
+            },
+            {
+              "connectionEstablishedSeconds": 0.064269073,
+              "uploadSeconds": 0.000001741,
+              "downloadSeconds": 0.062720996
+            },
+            {
+              "connectionEstablishedSeconds": 0.063583025,
+              "uploadSeconds": 0.000001747,
+              "downloadSeconds": 0.061804342
+            },
+            {
+              "connectionEstablishedSeconds": 0.065872113,
+              "uploadSeconds": 0.000001807,
+              "downloadSeconds": 0.064194406
+            },
+            {
+              "connectionEstablishedSeconds": 0.066311907,
+              "uploadSeconds": 0.000001782,
+              "downloadSeconds": 0.064670437
+            },
+            {
+              "connectionEstablishedSeconds": 0.066168252,
+              "uploadSeconds": 0.000001899,
+              "downloadSeconds": 0.064468189
+            },
+            {
+              "connectionEstablishedSeconds": 0.062754644,
+              "uploadSeconds": 0.000001798,
+              "downloadSeconds": 0.061120241
+            },
+            {
+              "connectionEstablishedSeconds": 0.062455648,
+              "uploadSeconds": 7.38e-7,
+              "downloadSeconds": 0.060839206
+            },
+            {
+              "connectionEstablishedSeconds": 0.063806339,
+              "uploadSeconds": 0.00000179,
+              "downloadSeconds": 0.06216697
+            },
+            {
+              "connectionEstablishedSeconds": 0.064597413,
+              "uploadSeconds": 0.00000173,
+              "downloadSeconds": 0.062937481
+            },
+            {
+              "connectionEstablishedSeconds": 0.062850815,
+              "uploadSeconds": 6.97e-7,
+              "downloadSeconds": 0.061280022
+            },
+            {
+              "connectionEstablishedSeconds": 0.064407337,
+              "uploadSeconds": 0.000001778,
+              "downloadSeconds": 0.062887685
+            },
+            {
+              "connectionEstablishedSeconds": 0.062786629,
+              "uploadSeconds": 0.000001772,
+              "downloadSeconds": 0.062066669
+            },
+            {
+              "connectionEstablishedSeconds": 0.061890579,
+              "uploadSeconds": 0.000001729,
+              "downloadSeconds": 0.060166971
+            },
+            {
+              "connectionEstablishedSeconds": 0.062408563,
+              "uploadSeconds": 0.000001801,
+              "downloadSeconds": 0.060810089
+            },
+            {
+              "connectionEstablishedSeconds": 0.062490624,
+              "uploadSeconds": 9.15e-7,
+              "downloadSeconds": 0.060857065
+            },
+            {
+              "connectionEstablishedSeconds": 0.06523268,
+              "uploadSeconds": 0.000001826,
+              "downloadSeconds": 0.063717055
+            },
+            {
+              "connectionEstablishedSeconds": 0.063790145,
+              "uploadSeconds": 0.000001761,
+              "downloadSeconds": 0.062229234
+            },
+            {
+              "connectionEstablishedSeconds": 0.060365532,
+              "uploadSeconds": 0.000001775,
+              "downloadSeconds": 0.058712024
+            },
+            {
+              "connectionEstablishedSeconds": 0.064417197,
+              "uploadSeconds": 0.000001763,
+              "downloadSeconds": 0.062880639
+            },
+            {
+              "connectionEstablishedSeconds": 0.063397122,
+              "uploadSeconds": 0.000001746,
+              "downloadSeconds": 0.061765186
+            },
+            {
+              "connectionEstablishedSeconds": 0.066704004,
+              "uploadSeconds": 0.000001707,
+              "downloadSeconds": 0.065128395
+            },
+            {
+              "connectionEstablishedSeconds": 0.064486371,
+              "uploadSeconds": 0.000001713,
+              "downloadSeconds": 0.062865375
+            },
+            {
+              "connectionEstablishedSeconds": 0.064802805,
+              "uploadSeconds": 7.2e-7,
+              "downloadSeconds": 0.063277579
+            },
+            {
+              "connectionEstablishedSeconds": 0.063924621,
+              "uploadSeconds": 0.000001697,
+              "downloadSeconds": 0.062248425
+            },
+            {
+              "connectionEstablishedSeconds": 0.065993297,
+              "uploadSeconds": 0.000001752,
+              "downloadSeconds": 0.064359758
+            },
+            {
+              "connectionEstablishedSeconds": 0.064030815,
+              "uploadSeconds": 7.17e-7,
+              "downloadSeconds": 0.062482167
+            },
+            {
+              "connectionEstablishedSeconds": 0.062975846,
+              "uploadSeconds": 6.98e-7,
+              "downloadSeconds": 0.061397444
             }
           ],
           "implementation": "quic-go",
@@ -982,504 +862,304 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.126942223,
-              "uploadSeconds": 0.000002365,
-              "downloadSeconds": 0.063743985
+              "latency": 0.184132654
             },
             {
-              "connectionEstablishedSeconds": 0.129295372,
-              "uploadSeconds": 0.00000192,
-              "downloadSeconds": 0.064682509
+              "latency": 0.194068936
             },
             {
-              "connectionEstablishedSeconds": 0.129768923,
-              "uploadSeconds": 0.000001704,
-              "downloadSeconds": 0.065037798
+              "latency": 0.191915091
             },
             {
-              "connectionEstablishedSeconds": 0.123600152,
-              "uploadSeconds": 0.000001813,
-              "downloadSeconds": 0.061774496
+              "latency": 0.184928078
             },
             {
-              "connectionEstablishedSeconds": 0.128035321,
-              "uploadSeconds": 0.000001702,
-              "downloadSeconds": 0.064082694
+              "latency": 0.183934167
             },
             {
-              "connectionEstablishedSeconds": 0.121026518,
-              "uploadSeconds": 0.000001726,
-              "downloadSeconds": 0.060509221
+              "latency": 0.184182073
             },
             {
-              "connectionEstablishedSeconds": 0.126800344,
-              "uploadSeconds": 0.000002242,
-              "downloadSeconds": 0.063314286
+              "latency": 0.192029766
             },
             {
-              "connectionEstablishedSeconds": 0.129647161,
-              "uploadSeconds": 0.000002486,
-              "downloadSeconds": 0.064824471
+              "latency": 0.190439227
             },
             {
-              "connectionEstablishedSeconds": 0.123199402,
-              "uploadSeconds": 0.000001661,
-              "downloadSeconds": 0.061598863
+              "latency": 0.194579933
             },
             {
-              "connectionEstablishedSeconds": 0.127989193,
-              "uploadSeconds": 0.000001733,
-              "downloadSeconds": 0.063972541
+              "latency": 0.18786885
             },
             {
-              "connectionEstablishedSeconds": 0.126010653,
-              "uploadSeconds": 0.000001798,
-              "downloadSeconds": 0.062962346
+              "latency": 0.182042588
             },
             {
-              "connectionEstablishedSeconds": 0.129831981,
-              "uploadSeconds": 0.000001649,
-              "downloadSeconds": 0.064948712
+              "latency": 0.195974107
             },
             {
-              "connectionEstablishedSeconds": 0.125489475,
-              "uploadSeconds": 0.000001669,
-              "downloadSeconds": 0.062847671
+              "latency": 0.193752757
             },
             {
-              "connectionEstablishedSeconds": 0.126238218,
-              "uploadSeconds": 0.000001634,
-              "downloadSeconds": 0.063051357
+              "latency": 0.19580449
             },
             {
-              "connectionEstablishedSeconds": 0.129056283,
-              "uploadSeconds": 0.000001871,
-              "downloadSeconds": 0.064548455
+              "latency": 0.189173311
             },
             {
-              "connectionEstablishedSeconds": 0.122463576,
-              "uploadSeconds": 0.000001873,
-              "downloadSeconds": 0.061220602
+              "latency": 0.186218502
             },
             {
-              "connectionEstablishedSeconds": 0.129516166,
-              "uploadSeconds": 0.000002036,
-              "downloadSeconds": 0.064762367
+              "latency": 0.185516962
             },
             {
-              "connectionEstablishedSeconds": 0.116596929,
-              "uploadSeconds": 0.000001673,
-              "downloadSeconds": 0.058290019
+              "latency": 0.193657657
             },
             {
-              "connectionEstablishedSeconds": 0.141630184,
-              "uploadSeconds": 0.000001947,
-              "downloadSeconds": 0.063497261
+              "latency": 0.190656587
             },
             {
-              "connectionEstablishedSeconds": 0.12986187,
-              "uploadSeconds": 0.000001712,
-              "downloadSeconds": 0.06490279
+              "latency": 0.185120937
             },
             {
-              "connectionEstablishedSeconds": 0.128644074,
-              "uploadSeconds": 0.000001685,
-              "downloadSeconds": 0.064237667
+              "latency": 0.189140803
             },
             {
-              "connectionEstablishedSeconds": 0.122887001,
-              "uploadSeconds": 0.000001889,
-              "downloadSeconds": 0.061421422
+              "latency": 0.185150775
             },
             {
-              "connectionEstablishedSeconds": 0.127039579,
-              "uploadSeconds": 0.000001885,
-              "downloadSeconds": 0.063494302
+              "latency": 0.190844677
             },
             {
-              "connectionEstablishedSeconds": 0.128683913,
-              "uploadSeconds": 0.000002124,
-              "downloadSeconds": 0.064358518
+              "latency": 0.187113354
             },
             {
-              "connectionEstablishedSeconds": 0.128384975,
-              "uploadSeconds": 0.000001659,
-              "downloadSeconds": 0.064129054
+              "latency": 0.187236342
             },
             {
-              "connectionEstablishedSeconds": 0.128997139,
-              "uploadSeconds": 0.000001702,
-              "downloadSeconds": 0.06447986
+              "latency": 0.186080189
             },
             {
-              "connectionEstablishedSeconds": 0.12793287,
-              "uploadSeconds": 0.000001869,
-              "downloadSeconds": 0.06396775
+              "latency": 0.195096425
             },
             {
-              "connectionEstablishedSeconds": 0.124082763,
-              "uploadSeconds": 0.000001698,
-              "downloadSeconds": 0.062029126
+              "latency": 0.188929417
             },
             {
-              "connectionEstablishedSeconds": 0.126708355,
-              "uploadSeconds": 0.000001748,
-              "downloadSeconds": 0.063323382
+              "latency": 0.18796103
             },
             {
-              "connectionEstablishedSeconds": 0.128975799,
-              "uploadSeconds": 0.000001654,
-              "downloadSeconds": 0.064501399
+              "latency": 0.185178755
             },
             {
-              "connectionEstablishedSeconds": 0.1292131,
-              "uploadSeconds": 0.000001705,
-              "downloadSeconds": 0.064638372
+              "latency": 0.187649523
             },
             {
-              "connectionEstablishedSeconds": 0.125226977,
-              "uploadSeconds": 0.000001689,
-              "downloadSeconds": 0.062704776
+              "latency": 0.182106208
             },
             {
-              "connectionEstablishedSeconds": 0.130452951,
-              "uploadSeconds": 0.000001922,
-              "downloadSeconds": 0.065206671
+              "latency": 0.194297538
             },
             {
-              "connectionEstablishedSeconds": 0.126270836,
-              "uploadSeconds": 0.000001778,
-              "downloadSeconds": 0.063104478
+              "latency": 0.184068868
             },
             {
-              "connectionEstablishedSeconds": 0.126167525,
-              "uploadSeconds": 0.000001616,
-              "downloadSeconds": 0.063098974
+              "latency": 0.175417602
             },
             {
-              "connectionEstablishedSeconds": 0.127841453,
-              "uploadSeconds": 0.000001811,
-              "downloadSeconds": 0.063930787
+              "latency": 0.191739911
             },
             {
-              "connectionEstablishedSeconds": 0.128939264,
-              "uploadSeconds": 0.000002076,
-              "downloadSeconds": 0.064470581
+              "latency": 0.18783925
             },
             {
-              "connectionEstablishedSeconds": 0.124303772,
-              "uploadSeconds": 0.000001842,
-              "downloadSeconds": 0.062183724
+              "latency": 0.190802342
             },
             {
-              "connectionEstablishedSeconds": 0.126348586,
-              "uploadSeconds": 0.000001791,
-              "downloadSeconds": 0.063154844
+              "latency": 0.185588224
             },
             {
-              "connectionEstablishedSeconds": 0.127755758,
-              "uploadSeconds": 0.000001785,
-              "downloadSeconds": 0.063894459
+              "latency": 0.18831657
             },
             {
-              "connectionEstablishedSeconds": 0.129457672,
-              "uploadSeconds": 0.000002391,
-              "downloadSeconds": 0.064700609
+              "latency": 0.192850426
             },
             {
-              "connectionEstablishedSeconds": 0.122909898,
-              "uploadSeconds": 0.000001746,
-              "downloadSeconds": 0.061491456
+              "latency": 0.180095663
             },
             {
-              "connectionEstablishedSeconds": 0.123784186,
-              "uploadSeconds": 0.000001784,
-              "downloadSeconds": 0.061999664
+              "latency": 0.183457111
             },
             {
-              "connectionEstablishedSeconds": 0.127851629,
-              "uploadSeconds": 0.000001679,
-              "downloadSeconds": 0.063985385
+              "latency": 0.189265544
             },
             {
-              "connectionEstablishedSeconds": 0.12932324,
-              "uploadSeconds": 0.000001827,
-              "downloadSeconds": 0.064679131
+              "latency": 0.19230742
             },
             {
-              "connectionEstablishedSeconds": 0.12660816,
-              "uploadSeconds": 0.000001793,
-              "downloadSeconds": 0.06332388
+              "latency": 0.184436256
             },
             {
-              "connectionEstablishedSeconds": 0.120871705,
-              "uploadSeconds": 0.00000179,
-              "downloadSeconds": 0.060446085
+              "latency": 0.187160278
             },
             {
-              "connectionEstablishedSeconds": 0.118100529,
-              "uploadSeconds": 0.00000173,
-              "downloadSeconds": 0.059087264
+              "latency": 0.185060163
             },
             {
-              "connectionEstablishedSeconds": 0.126572056,
-              "uploadSeconds": 0.000001956,
-              "downloadSeconds": 0.063274223
+              "latency": 0.184699135
             },
             {
-              "connectionEstablishedSeconds": 0.123841295,
-              "uploadSeconds": 0.000001938,
-              "downloadSeconds": 0.061978309
+              "latency": 0.183075881
             },
             {
-              "connectionEstablishedSeconds": 0.127973095,
-              "uploadSeconds": 0.000001851,
-              "downloadSeconds": 0.064008529
+              "latency": 0.183561349
             },
             {
-              "connectionEstablishedSeconds": 0.130283019,
-              "uploadSeconds": 0.000001647,
-              "downloadSeconds": 0.065152012
+              "latency": 0.178109643
             },
             {
-              "connectionEstablishedSeconds": 0.128841959,
-              "uploadSeconds": 0.000001844,
-              "downloadSeconds": 0.064416521
+              "latency": 0.181829569
             },
             {
-              "connectionEstablishedSeconds": 0.128233111,
-              "uploadSeconds": 0.000001944,
-              "downloadSeconds": 0.064136145
+              "latency": 0.191897922
             },
             {
-              "connectionEstablishedSeconds": 0.12914781,
-              "uploadSeconds": 0.000001634,
-              "downloadSeconds": 0.064601974
+              "latency": 0.194005334
             },
             {
-              "connectionEstablishedSeconds": 0.126026333,
-              "uploadSeconds": 0.000001726,
-              "downloadSeconds": 0.063072496
+              "latency": 0.188489837
             },
             {
-              "connectionEstablishedSeconds": 0.125242444,
-              "uploadSeconds": 0.000001771,
-              "downloadSeconds": 0.06265885
+              "latency": 0.193578448
             },
             {
-              "connectionEstablishedSeconds": 0.119356822,
-              "uploadSeconds": 0.00000268,
-              "downloadSeconds": 0.059637042
+              "latency": 0.187929267
             },
             {
-              "connectionEstablishedSeconds": 0.121396427,
-              "uploadSeconds": 0.000002106,
-              "downloadSeconds": 0.060649707
+              "latency": 0.184922944
             },
             {
-              "connectionEstablishedSeconds": 0.122918326,
-              "uploadSeconds": 0.000001778,
-              "downloadSeconds": 0.061468633
+              "latency": 0.187795281
             },
             {
-              "connectionEstablishedSeconds": 0.130501829,
-              "uploadSeconds": 0.000001736,
-              "downloadSeconds": 0.064908113
+              "latency": 0.193773021
             },
             {
-              "connectionEstablishedSeconds": 0.125249582,
-              "uploadSeconds": 0.000001861,
-              "downloadSeconds": 0.062594996
+              "latency": 0.184383381
             },
             {
-              "connectionEstablishedSeconds": 0.123120777,
-              "uploadSeconds": 0.000002164,
-              "downloadSeconds": 0.061578881
+              "latency": 0.189312312
             },
             {
-              "connectionEstablishedSeconds": 0.124396915,
-              "uploadSeconds": 0.000001703,
-              "downloadSeconds": 0.062208624
+              "latency": 0.187711496
             },
             {
-              "connectionEstablishedSeconds": 0.126273983,
-              "uploadSeconds": 0.000001813,
-              "downloadSeconds": 0.063130063
+              "latency": 0.193925291
             },
             {
-              "connectionEstablishedSeconds": 0.124430086,
-              "uploadSeconds": 0.000001687,
-              "downloadSeconds": 0.062228188
+              "latency": 0.193784964
             },
             {
-              "connectionEstablishedSeconds": 0.132043221,
-              "uploadSeconds": 0.000001811,
-              "downloadSeconds": 0.065423374
+              "latency": 0.188667647
             },
             {
-              "connectionEstablishedSeconds": 0.12127598,
-              "uploadSeconds": 0.000001624,
-              "downloadSeconds": 0.060656771
+              "latency": 0.189342273
             },
             {
-              "connectionEstablishedSeconds": 0.127779055,
-              "uploadSeconds": 0.000001697,
-              "downloadSeconds": 0.063860988
+              "latency": 0.191128992
             },
             {
-              "connectionEstablishedSeconds": 0.122487726,
-              "uploadSeconds": 0.000001862,
-              "downloadSeconds": 0.06127068
+              "latency": 0.193775777
             },
             {
-              "connectionEstablishedSeconds": 0.126731134,
-              "uploadSeconds": 0.000001728,
-              "downloadSeconds": 0.063326428
+              "latency": 0.191684423
             },
             {
-              "connectionEstablishedSeconds": 0.126230747,
-              "uploadSeconds": 0.00000168,
-              "downloadSeconds": 0.063123085
+              "latency": 0.190111321
             },
             {
-              "connectionEstablishedSeconds": 0.128350478,
-              "uploadSeconds": 0.000001922,
-              "downloadSeconds": 0.064083463
+              "latency": 0.19164226
             },
             {
-              "connectionEstablishedSeconds": 0.129744746,
-              "uploadSeconds": 0.000001907,
-              "downloadSeconds": 0.064915135
+              "latency": 0.18577541
             },
             {
-              "connectionEstablishedSeconds": 0.126254335,
-              "uploadSeconds": 0.000001588,
-              "downloadSeconds": 0.063117523
+              "latency": 0.184102904
             },
             {
-              "connectionEstablishedSeconds": 0.127972742,
-              "uploadSeconds": 0.000001828,
-              "downloadSeconds": 0.063975961
+              "latency": 0.185752668
             },
             {
-              "connectionEstablishedSeconds": 0.121895822,
-              "uploadSeconds": 0.000001712,
-              "downloadSeconds": 0.060978954
+              "latency": 0.177264736
             },
             {
-              "connectionEstablishedSeconds": 0.123748227,
-              "uploadSeconds": 0.000001643,
-              "downloadSeconds": 0.061931251
+              "latency": 0.176941932
             },
             {
-              "connectionEstablishedSeconds": 0.127796747,
-              "uploadSeconds": 0.000001828,
-              "downloadSeconds": 0.063901984
+              "latency": 0.185505702
             },
             {
-              "connectionEstablishedSeconds": 0.124894315,
-              "uploadSeconds": 0.000001677,
-              "downloadSeconds": 0.062428592
+              "latency": 0.183782463
             },
             {
-              "connectionEstablishedSeconds": 0.12745025,
-              "uploadSeconds": 0.000002009,
-              "downloadSeconds": 0.06369987
+              "latency": 0.190740287
             },
             {
-              "connectionEstablishedSeconds": 0.124998457,
-              "uploadSeconds": 0.000001752,
-              "downloadSeconds": 0.062803771
+              "latency": 0.191248024
             },
             {
-              "connectionEstablishedSeconds": 0.129756553,
-              "uploadSeconds": 0.000001712,
-              "downloadSeconds": 0.064856409
+              "latency": 0.175630487
             },
             {
-              "connectionEstablishedSeconds": 0.125216956,
-              "uploadSeconds": 0.000002201,
-              "downloadSeconds": 0.062558495
+              "latency": 0.184778715
             },
             {
-              "connectionEstablishedSeconds": 0.122515436,
-              "uploadSeconds": 0.000002016,
-              "downloadSeconds": 0.061251861
+              "latency": 0.187699975
             },
             {
-              "connectionEstablishedSeconds": 0.127974467,
-              "uploadSeconds": 0.000001656,
-              "downloadSeconds": 0.063976319
+              "latency": 0.191732926
             },
             {
-              "connectionEstablishedSeconds": 0.127917455,
-              "uploadSeconds": 0.000001672,
-              "downloadSeconds": 0.063897681
+              "latency": 0.184517763
             },
             {
-              "connectionEstablishedSeconds": 0.128319597,
-              "uploadSeconds": 0.000001954,
-              "downloadSeconds": 0.064106765
+              "latency": 0.195033722
             },
             {
-              "connectionEstablishedSeconds": 0.128624204,
-              "uploadSeconds": 0.000001899,
-              "downloadSeconds": 0.064251524
+              "latency": 0.18866025
             },
             {
-              "connectionEstablishedSeconds": 0.126486446,
-              "uploadSeconds": 0.000001841,
-              "downloadSeconds": 0.063203465
+              "latency": 0.194798044
             },
             {
-              "connectionEstablishedSeconds": 0.129833791,
-              "uploadSeconds": 0.000001733,
-              "downloadSeconds": 0.064937319
+              "latency": 0.193389921
             },
             {
-              "connectionEstablishedSeconds": 0.124898357,
-              "uploadSeconds": 0.000001724,
-              "downloadSeconds": 0.062520609
+              "latency": 0.181712061
             },
             {
-              "connectionEstablishedSeconds": 0.12929984,
-              "uploadSeconds": 0.000001888,
-              "downloadSeconds": 0.064618047
+              "latency": 0.194496672
             },
             {
-              "connectionEstablishedSeconds": 0.127874998,
-              "uploadSeconds": 0.000002,
-              "downloadSeconds": 0.063890819
+              "latency": 0.190505569
             },
             {
-              "connectionEstablishedSeconds": 0.128142932,
-              "uploadSeconds": 0.000001718,
-              "downloadSeconds": 0.06405662
+              "latency": 0.185409032
             },
             {
-              "connectionEstablishedSeconds": 0.124047196,
-              "uploadSeconds": 0.000001717,
-              "downloadSeconds": 0.062216621
+              "latency": 0.186205174
             },
             {
-              "connectionEstablishedSeconds": 0.1249445,
-              "uploadSeconds": 0.000001788,
-              "downloadSeconds": 0.062462759
+              "latency": 0.183118094
             },
             {
-              "connectionEstablishedSeconds": 0.126187799,
-              "uploadSeconds": 0.000001825,
-              "downloadSeconds": 0.063085401
+              "latency": 0.185340769
             },
             {
-              "connectionEstablishedSeconds": 0.125372997,
-              "uploadSeconds": 0.000001757,
-              "downloadSeconds": 0.062630744
+              "latency": 0.188765951
             },
             {
-              "connectionEstablishedSeconds": 0.124622638,
-              "uploadSeconds": 0.000001808,
-              "downloadSeconds": 0.061894104
+              "latency": 0.193192734
             }
           ],
           "implementation": "rust-libp2p",
@@ -1489,504 +1169,304 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.062492165,
-              "uploadSeconds": 0.061112326,
-              "downloadSeconds": 0.000116715
+              "latency": 0.125777968
             },
             {
-              "connectionEstablishedSeconds": 0.062649228,
-              "uploadSeconds": 0.061280622,
-              "downloadSeconds": 0.000080394
+              "latency": 0.128307512
             },
             {
-              "connectionEstablishedSeconds": 0.064760828,
-              "uploadSeconds": 0.063351283,
-              "downloadSeconds": 0.000075496
+              "latency": 0.127544746
             },
             {
-              "connectionEstablishedSeconds": 0.066180837,
-              "uploadSeconds": 0.064932222,
-              "downloadSeconds": 0.00008116
+              "latency": 0.122402397
             },
             {
-              "connectionEstablishedSeconds": 0.065053382,
-              "uploadSeconds": 0.063823422,
-              "downloadSeconds": 0.000091261
+              "latency": 0.128747625
             },
             {
-              "connectionEstablishedSeconds": 0.065101606,
-              "uploadSeconds": 0.063815129,
-              "downloadSeconds": 0.000092607
+              "latency": 0.123212638
             },
             {
-              "connectionEstablishedSeconds": 0.062689717,
-              "uploadSeconds": 0.061288942,
-              "downloadSeconds": 0.000093534
+              "latency": 0.128605619
             },
             {
-              "connectionEstablishedSeconds": 0.065046629,
-              "uploadSeconds": 0.063763816,
-              "downloadSeconds": 0.000081756
+              "latency": 0.126204388
             },
             {
-              "connectionEstablishedSeconds": 0.062314766,
-              "uploadSeconds": 0.061037749,
-              "downloadSeconds": 0.000046607
+              "latency": 0.121963042
             },
             {
-              "connectionEstablishedSeconds": 0.064858603,
-              "uploadSeconds": 0.063540237,
-              "downloadSeconds": 0.000079145
+              "latency": 0.127325479
             },
             {
-              "connectionEstablishedSeconds": 0.064348321,
-              "uploadSeconds": 0.063027289,
-              "downloadSeconds": 0.000077306
+              "latency": 0.132017483
             },
             {
-              "connectionEstablishedSeconds": 0.064959839,
-              "uploadSeconds": 0.063622551,
-              "downloadSeconds": 0.00004905
+              "latency": 0.128399938
             },
             {
-              "connectionEstablishedSeconds": 0.063707615,
-              "uploadSeconds": 0.062420537,
-              "downloadSeconds": 0.000102342
+              "latency": 0.129433893
             },
             {
-              "connectionEstablishedSeconds": 0.065048512,
-              "uploadSeconds": 0.063737865,
-              "downloadSeconds": 0.000118632
+              "latency": 0.121579533
             },
             {
-              "connectionEstablishedSeconds": 0.064274475,
-              "uploadSeconds": 0.062903113,
-              "downloadSeconds": 0.000085883
+              "latency": 0.129274894
             },
             {
-              "connectionEstablishedSeconds": 0.064577741,
-              "uploadSeconds": 0.063251792,
-              "downloadSeconds": 0.000076561
+              "latency": 0.123804813
             },
             {
-              "connectionEstablishedSeconds": 0.065925377,
-              "uploadSeconds": 0.064583722,
-              "downloadSeconds": 0.000090743
+              "latency": 0.125359927
             },
             {
-              "connectionEstablishedSeconds": 0.062300157,
-              "uploadSeconds": 0.06105258,
-              "downloadSeconds": 0.000135368
+              "latency": 0.127449846
             },
             {
-              "connectionEstablishedSeconds": 0.064730107,
-              "uploadSeconds": 0.063349915,
-              "downloadSeconds": 0.000085658
+              "latency": 0.125559231
             },
             {
-              "connectionEstablishedSeconds": 0.06515572,
-              "uploadSeconds": 0.063910665,
-              "downloadSeconds": 0.000090313
+              "latency": 0.129395209
             },
             {
-              "connectionEstablishedSeconds": 0.065108686,
-              "uploadSeconds": 0.063750982,
-              "downloadSeconds": 0.000067266
+              "latency": 0.128843447
             },
             {
-              "connectionEstablishedSeconds": 0.062007928,
-              "uploadSeconds": 0.060723595,
-              "downloadSeconds": 0.000072241
+              "latency": 0.126127485
             },
             {
-              "connectionEstablishedSeconds": 0.065888524,
-              "uploadSeconds": 0.064580981,
-              "downloadSeconds": 0.000090292
+              "latency": 0.126612377
             },
             {
-              "connectionEstablishedSeconds": 0.065236289,
-              "uploadSeconds": 0.063932549,
-              "downloadSeconds": 0.000089596
+              "latency": 0.119243227
             },
             {
-              "connectionEstablishedSeconds": 0.065947026,
-              "uploadSeconds": 0.064630887,
-              "downloadSeconds": 0.000095345
+              "latency": 0.12322938
             },
             {
-              "connectionEstablishedSeconds": 0.064336634,
-              "uploadSeconds": 0.062985158,
-              "downloadSeconds": 0.000074183
+              "latency": 0.123665717
             },
             {
-              "connectionEstablishedSeconds": 0.062948996,
-              "uploadSeconds": 0.061767861,
-              "downloadSeconds": 0.000075181
+              "latency": 0.12427905
             },
             {
-              "connectionEstablishedSeconds": 0.06109396,
-              "uploadSeconds": 0.059701938,
-              "downloadSeconds": 0.000071589
+              "latency": 0.131403776
             },
             {
-              "connectionEstablishedSeconds": 0.064372236,
-              "uploadSeconds": 0.062974949,
-              "downloadSeconds": 0.000079756
+              "latency": 0.119572069
             },
             {
-              "connectionEstablishedSeconds": 0.064453895,
-              "uploadSeconds": 0.063101378,
-              "downloadSeconds": 0.00009592
+              "latency": 0.125500863
             },
             {
-              "connectionEstablishedSeconds": 0.06549708,
-              "uploadSeconds": 0.06415425,
-              "downloadSeconds": 0.000098662
+              "latency": 0.127419779
             },
             {
-              "connectionEstablishedSeconds": 0.061722141,
-              "uploadSeconds": 0.060439927,
-              "downloadSeconds": 0.000067907
+              "latency": 0.126610934
             },
             {
-              "connectionEstablishedSeconds": 0.062618168,
-              "uploadSeconds": 0.061334678,
-              "downloadSeconds": 0.000077256
+              "latency": 0.124426014
             },
             {
-              "connectionEstablishedSeconds": 0.065047814,
-              "uploadSeconds": 0.06367261,
-              "downloadSeconds": 0.000091801
+              "latency": 0.12868814
             },
             {
-              "connectionEstablishedSeconds": 0.063579779,
-              "uploadSeconds": 0.062226479,
-              "downloadSeconds": 0.000082145
+              "latency": 0.118254702
             },
             {
-              "connectionEstablishedSeconds": 0.063011302,
-              "uploadSeconds": 0.061565533,
-              "downloadSeconds": 0.000086583
+              "latency": 0.124258382
             },
             {
-              "connectionEstablishedSeconds": 0.065309634,
-              "uploadSeconds": 0.064046614,
-              "downloadSeconds": 0.000085699
+              "latency": 0.131919118
             },
             {
-              "connectionEstablishedSeconds": 0.063779301,
-              "uploadSeconds": 0.063372405,
-              "downloadSeconds": 0.000136163
+              "latency": 0.127277312
             },
             {
-              "connectionEstablishedSeconds": 0.064275774,
-              "uploadSeconds": 0.062967983,
-              "downloadSeconds": 0.000111519
+              "latency": 0.126236011
             },
             {
-              "connectionEstablishedSeconds": 0.062869924,
-              "uploadSeconds": 0.061522136,
-              "downloadSeconds": 0.000099826
+              "latency": 0.124394349
             },
             {
-              "connectionEstablishedSeconds": 0.065951048,
-              "uploadSeconds": 0.064701169,
-              "downloadSeconds": 0.000078351
+              "latency": 0.12443177
             },
             {
-              "connectionEstablishedSeconds": 0.066478972,
-              "uploadSeconds": 0.065097486,
-              "downloadSeconds": 0.000082354
+              "latency": 0.122816709
             },
             {
-              "connectionEstablishedSeconds": 0.065269249,
-              "uploadSeconds": 0.063912204,
-              "downloadSeconds": 0.000104537
+              "latency": 0.130763296
             },
             {
-              "connectionEstablishedSeconds": 0.065817256,
-              "uploadSeconds": 0.06446906,
-              "downloadSeconds": 0.00007819
+              "latency": 0.122420805
             },
             {
-              "connectionEstablishedSeconds": 0.064223987,
-              "uploadSeconds": 0.062801823,
-              "downloadSeconds": 0.000078383
+              "latency": 0.129442081
             },
             {
-              "connectionEstablishedSeconds": 0.06476724,
-              "uploadSeconds": 0.063393313,
-              "downloadSeconds": 0.000099092
+              "latency": 0.124228893
             },
             {
-              "connectionEstablishedSeconds": 0.063259049,
-              "uploadSeconds": 0.061967122,
-              "downloadSeconds": 0.000078373
+              "latency": 0.126475667
             },
             {
-              "connectionEstablishedSeconds": 0.062528862,
-              "uploadSeconds": 0.06046343,
-              "downloadSeconds": 0.000076467
+              "latency": 0.129426322
             },
             {
-              "connectionEstablishedSeconds": 0.066188334,
-              "uploadSeconds": 0.064863762,
-              "downloadSeconds": 0.000079565
+              "latency": 0.128563104
             },
             {
-              "connectionEstablishedSeconds": 0.062887682,
-              "uploadSeconds": 0.061551332,
-              "downloadSeconds": 0.000076819
+              "latency": 0.129833668
             },
             {
-              "connectionEstablishedSeconds": 0.066111253,
-              "uploadSeconds": 0.064702484,
-              "downloadSeconds": 0.000066659
+              "latency": 0.12555755
             },
             {
-              "connectionEstablishedSeconds": 0.063300491,
-              "uploadSeconds": 0.061926982,
-              "downloadSeconds": 0.000083907
+              "latency": 0.128004788
             },
             {
-              "connectionEstablishedSeconds": 0.06449862,
-              "uploadSeconds": 0.063121687,
-              "downloadSeconds": 0.000093747
+              "latency": 0.129274112
             },
             {
-              "connectionEstablishedSeconds": 0.064823713,
-              "uploadSeconds": 0.063492443,
-              "downloadSeconds": 0.000084742
+              "latency": 0.126944688
             },
             {
-              "connectionEstablishedSeconds": 0.065926331,
-              "uploadSeconds": 0.06454414,
-              "downloadSeconds": 0.000098276
+              "latency": 0.121298884
             },
             {
-              "connectionEstablishedSeconds": 0.065139319,
-              "uploadSeconds": 0.063690364,
-              "downloadSeconds": 0.000077539
+              "latency": 0.119382693
             },
             {
-              "connectionEstablishedSeconds": 0.065358817,
-              "uploadSeconds": 0.06400259,
-              "downloadSeconds": 0.00003313
+              "latency": 0.125480662
             },
             {
-              "connectionEstablishedSeconds": 0.065301446,
-              "uploadSeconds": 0.064061379,
-              "downloadSeconds": 0.000077036
+              "latency": 0.123206752
             },
             {
-              "connectionEstablishedSeconds": 0.063128633,
-              "uploadSeconds": 0.061784849,
-              "downloadSeconds": 0.000066813
+              "latency": 0.121188501
             },
             {
-              "connectionEstablishedSeconds": 0.063143836,
-              "uploadSeconds": 0.061849758,
-              "downloadSeconds": 0.00007549
+              "latency": 0.124577036
             },
             {
-              "connectionEstablishedSeconds": 0.062985418,
-              "uploadSeconds": 0.061620493,
-              "downloadSeconds": 0.000077547
+              "latency": 0.120140975
             },
             {
-              "connectionEstablishedSeconds": 0.066465888,
-              "uploadSeconds": 0.064557997,
-              "downloadSeconds": 0.000080725
+              "latency": 0.124274923
             },
             {
-              "connectionEstablishedSeconds": 0.063822981,
-              "uploadSeconds": 0.0624959,
-              "downloadSeconds": 0.000076361
+              "latency": 0.124345149
             },
             {
-              "connectionEstablishedSeconds": 0.066168641,
-              "uploadSeconds": 0.064885029,
-              "downloadSeconds": 0.000082184
+              "latency": 0.130448889
             },
             {
-              "connectionEstablishedSeconds": 0.065318529,
-              "uploadSeconds": 0.063980222,
-              "downloadSeconds": 0.000075709
+              "latency": 0.125562158
             },
             {
-              "connectionEstablishedSeconds": 0.063808287,
-              "uploadSeconds": 0.062508188,
-              "downloadSeconds": 0.00007488
+              "latency": 0.125679497
             },
             {
-              "connectionEstablishedSeconds": 0.063995944,
-              "uploadSeconds": 0.0627541,
-              "downloadSeconds": 0.000072214
+              "latency": 0.130337557
             },
             {
-              "connectionEstablishedSeconds": 0.06397866,
-              "uploadSeconds": 0.062611512,
-              "downloadSeconds": 0.00006927
+              "latency": 0.125082166
             },
             {
-              "connectionEstablishedSeconds": 0.065037845,
-              "uploadSeconds": 0.063947489,
-              "downloadSeconds": 0.000080016
+              "latency": 0.119229966
             },
             {
-              "connectionEstablishedSeconds": 0.066120082,
-              "uploadSeconds": 0.064685778,
-              "downloadSeconds": 0.000082905
+              "latency": 0.130524917
             },
             {
-              "connectionEstablishedSeconds": 0.062625315,
-              "uploadSeconds": 0.061221872,
-              "downloadSeconds": 0.000031938
+              "latency": 0.129044001
             },
             {
-              "connectionEstablishedSeconds": 0.065900539,
-              "uploadSeconds": 0.06464932,
-              "downloadSeconds": 0.000077138
+              "latency": 0.120590611
             },
             {
-              "connectionEstablishedSeconds": 0.064467677,
-              "uploadSeconds": 0.0630704,
-              "downloadSeconds": 0.000087459
+              "latency": 0.12352362
             },
             {
-              "connectionEstablishedSeconds": 0.065558181,
-              "uploadSeconds": 0.064390576,
-              "downloadSeconds": 0.000088838
+              "latency": 0.126382508
             },
             {
-              "connectionEstablishedSeconds": 0.064554054,
-              "uploadSeconds": 0.063124382,
-              "downloadSeconds": 0.000086044
+              "latency": 0.125797204
             },
             {
-              "connectionEstablishedSeconds": 0.065518499,
-              "uploadSeconds": 0.0642783,
-              "downloadSeconds": 0.000069911
+              "latency": 0.126544318
             },
             {
-              "connectionEstablishedSeconds": 0.066629516,
-              "uploadSeconds": 0.065206442,
-              "downloadSeconds": 0.000081926
+              "latency": 0.121320157
             },
             {
-              "connectionEstablishedSeconds": 0.065656045,
-              "uploadSeconds": 0.064359504,
-              "downloadSeconds": 0.000044615
+              "latency": 0.123327912
             },
             {
-              "connectionEstablishedSeconds": 0.063976017,
-              "uploadSeconds": 0.062635566,
-              "downloadSeconds": 0.000071372
+              "latency": 0.130680105
             },
             {
-              "connectionEstablishedSeconds": 0.062951525,
-              "uploadSeconds": 0.061702677,
-              "downloadSeconds": 0.000078439
+              "latency": 0.125024032
             },
             {
-              "connectionEstablishedSeconds": 0.063737264,
-              "uploadSeconds": 0.06236826,
-              "downloadSeconds": 0.00006622
+              "latency": 0.130920126
             },
             {
-              "connectionEstablishedSeconds": 0.065378439,
-              "uploadSeconds": 0.064143514,
-              "downloadSeconds": 0.000085874
+              "latency": 0.128272278
             },
             {
-              "connectionEstablishedSeconds": 0.063799799,
-              "uploadSeconds": 0.062465944,
-              "downloadSeconds": 0.000076315
+              "latency": 0.124534074
             },
             {
-              "connectionEstablishedSeconds": 0.064016785,
-              "uploadSeconds": 0.062693022,
-              "downloadSeconds": 0.000073532
+              "latency": 0.128728945
             },
             {
-              "connectionEstablishedSeconds": 0.066494306,
-              "uploadSeconds": 0.065370658,
-              "downloadSeconds": 0.000110275
+              "latency": 0.127538361
             },
             {
-              "connectionEstablishedSeconds": 0.063535833,
-              "uploadSeconds": 0.062204885,
-              "downloadSeconds": 0.000096163
+              "latency": 0.130405102
             },
             {
-              "connectionEstablishedSeconds": 0.060309504,
-              "uploadSeconds": 0.058998211,
-              "downloadSeconds": 0.000076909
+              "latency": 0.127636921
             },
             {
-              "connectionEstablishedSeconds": 0.062002445,
-              "uploadSeconds": 0.060868854,
-              "downloadSeconds": 0.000067506
+              "latency": 0.12912564
             },
             {
-              "connectionEstablishedSeconds": 0.06525739,
-              "uploadSeconds": 0.063977881,
-              "downloadSeconds": 0.000079046
+              "latency": 0.123547132
             },
             {
-              "connectionEstablishedSeconds": 0.063392018,
-              "uploadSeconds": 0.062113137,
-              "downloadSeconds": 0.000079119
+              "latency": 0.124658027
             },
             {
-              "connectionEstablishedSeconds": 0.065732927,
-              "uploadSeconds": 0.064370846,
-              "downloadSeconds": 0.000066241
+              "latency": 0.120190847
             },
             {
-              "connectionEstablishedSeconds": 0.06651007,
-              "uploadSeconds": 0.065177715,
-              "downloadSeconds": 0.000134526
+              "latency": 0.122444408
             },
             {
-              "connectionEstablishedSeconds": 0.064256641,
-              "uploadSeconds": 0.063039581,
-              "downloadSeconds": 0.000073272
+              "latency": 0.123913223
             },
             {
-              "connectionEstablishedSeconds": 0.065119473,
-              "uploadSeconds": 0.06376839,
-              "downloadSeconds": 0.000074958
+              "latency": 0.125410338
             },
             {
-              "connectionEstablishedSeconds": 0.062175277,
-              "uploadSeconds": 0.061104338,
-              "downloadSeconds": 0.000087541
+              "latency": 0.127199426
             },
             {
-              "connectionEstablishedSeconds": 0.063139385,
-              "uploadSeconds": 0.06214719,
-              "downloadSeconds": 0.000078032
+              "latency": 0.120169365
             },
             {
-              "connectionEstablishedSeconds": 0.064046091,
-              "uploadSeconds": 0.06271439,
-              "downloadSeconds": 0.000068561
+              "latency": 0.128054344
             },
             {
-              "connectionEstablishedSeconds": 0.063052851,
-              "uploadSeconds": 0.062245386,
-              "downloadSeconds": 0.000045205
+              "latency": 0.127913262
             },
             {
-              "connectionEstablishedSeconds": 0.064833757,
-              "uploadSeconds": 0.063268495,
-              "downloadSeconds": 0.000300286
+              "latency": 0.128675879
             },
             {
-              "connectionEstablishedSeconds": 0.065363519,
-              "uploadSeconds": 0.064063992,
-              "downloadSeconds": 0.00007668
+              "latency": 0.128183154
             }
           ],
           "implementation": "rust-libp2p",
@@ -1996,504 +1476,304 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.064520194,
-              "uploadSeconds": 0.062763047,
-              "downloadSeconds": 0.000311714
+              "latency": 0.123009715
             },
             {
-              "connectionEstablishedSeconds": 0.061672534,
-              "uploadSeconds": 0.060131542,
-              "downloadSeconds": 0.000290564
+              "latency": 0.125303542
             },
             {
-              "connectionEstablishedSeconds": 0.06559133,
-              "uploadSeconds": 0.064091439,
-              "downloadSeconds": 0.000220565
+              "latency": 0.125447547
             },
             {
-              "connectionEstablishedSeconds": 0.06509549,
-              "uploadSeconds": 0.063602653,
-              "downloadSeconds": 0.000232934
+              "latency": 0.124743468
             },
             {
-              "connectionEstablishedSeconds": 0.066234416,
-              "uploadSeconds": 0.064778126,
-              "downloadSeconds": 0.000224712
+              "latency": 0.122889889
             },
             {
-              "connectionEstablishedSeconds": 0.063305258,
-              "uploadSeconds": 0.061815194,
-              "downloadSeconds": 0.000211531
+              "latency": 0.123582121
             },
             {
-              "connectionEstablishedSeconds": 0.065295876,
-              "uploadSeconds": 0.063799653,
-              "downloadSeconds": 0.000215023
+              "latency": 0.128946825
             },
             {
-              "connectionEstablishedSeconds": 0.066643606,
-              "uploadSeconds": 0.065195529,
-              "downloadSeconds": 0.000278385
+              "latency": 0.126276622
             },
             {
-              "connectionEstablishedSeconds": 0.063005459,
-              "uploadSeconds": 0.061678785,
-              "downloadSeconds": 0.000260314
+              "latency": 0.129613931
             },
             {
-              "connectionEstablishedSeconds": 0.065838078,
-              "uploadSeconds": 0.064328347,
-              "downloadSeconds": 0.000289925
+              "latency": 0.121296503
             },
             {
-              "connectionEstablishedSeconds": 0.06564289,
-              "uploadSeconds": 0.064197027,
-              "downloadSeconds": 0.000239059
+              "latency": 0.125443063
             },
             {
-              "connectionEstablishedSeconds": 0.064409611,
-              "uploadSeconds": 0.062990114,
-              "downloadSeconds": 0.000220292
+              "latency": 0.126228718
             },
             {
-              "connectionEstablishedSeconds": 0.062809421,
-              "uploadSeconds": 0.061497011,
-              "downloadSeconds": 0.000217806
+              "latency": 0.125643139
             },
             {
-              "connectionEstablishedSeconds": 0.063838736,
-              "uploadSeconds": 0.062350353,
-              "downloadSeconds": 0.000285214
+              "latency": 0.124991346
             },
             {
-              "connectionEstablishedSeconds": 0.064723174,
-              "uploadSeconds": 0.063331722,
-              "downloadSeconds": 0.00020302
+              "latency": 0.13255148
             },
             {
-              "connectionEstablishedSeconds": 0.064209506,
-              "uploadSeconds": 0.062743849,
-              "downloadSeconds": 0.000228847
+              "latency": 0.12602645
             },
             {
-              "connectionEstablishedSeconds": 0.065077603,
-              "uploadSeconds": 0.063613483,
-              "downloadSeconds": 0.00028078
+              "latency": 0.125632463
             },
             {
-              "connectionEstablishedSeconds": 0.062394046,
-              "uploadSeconds": 0.061067573,
-              "downloadSeconds": 0.000201108
+              "latency": 0.130966744
             },
             {
-              "connectionEstablishedSeconds": 0.065299326,
-              "uploadSeconds": 0.063748553,
-              "downloadSeconds": 0.000242959
+              "latency": 0.12773041
             },
             {
-              "connectionEstablishedSeconds": 0.064665813,
-              "uploadSeconds": 0.063258611,
-              "downloadSeconds": 0.000290005
+              "latency": 0.125446888
             },
             {
-              "connectionEstablishedSeconds": 0.063905388,
-              "uploadSeconds": 0.062530847,
-              "downloadSeconds": 0.000234923
+              "latency": 0.132567675
             },
             {
-              "connectionEstablishedSeconds": 0.06432057,
-              "uploadSeconds": 0.062942497,
-              "downloadSeconds": 0.000227728
+              "latency": 0.130911048
             },
             {
-              "connectionEstablishedSeconds": 0.065251547,
-              "uploadSeconds": 0.063915261,
-              "downloadSeconds": 0.000286787
+              "latency": 0.125630409
             },
             {
-              "connectionEstablishedSeconds": 0.065145683,
-              "uploadSeconds": 0.063710432,
-              "downloadSeconds": 0.00019077
+              "latency": 0.128439978
             },
             {
-              "connectionEstablishedSeconds": 0.066127095,
-              "uploadSeconds": 0.064834648,
-              "downloadSeconds": 0.000209692
+              "latency": 0.126255169
             },
             {
-              "connectionEstablishedSeconds": 0.062005086,
-              "uploadSeconds": 0.060587007,
-              "downloadSeconds": 0.000143414
+              "latency": 0.129537998
             },
             {
-              "connectionEstablishedSeconds": 0.064123733,
-              "uploadSeconds": 0.062807069,
-              "downloadSeconds": 0.000197959
+              "latency": 0.123738751
             },
             {
-              "connectionEstablishedSeconds": 0.062011479,
-              "uploadSeconds": 0.060655504,
-              "downloadSeconds": 0.000273931
+              "latency": 0.128765568
             },
             {
-              "connectionEstablishedSeconds": 0.063505832,
-              "uploadSeconds": 0.062131307,
-              "downloadSeconds": 0.000204597
+              "latency": 0.129124072
             },
             {
-              "connectionEstablishedSeconds": 0.063511408,
-              "uploadSeconds": 0.062059862,
-              "downloadSeconds": 0.000246621
+              "latency": 0.128546892
             },
             {
-              "connectionEstablishedSeconds": 0.06440964,
-              "uploadSeconds": 0.062882752,
-              "downloadSeconds": 0.000228304
+              "latency": 0.126928585
             },
             {
-              "connectionEstablishedSeconds": 0.060028443,
-              "uploadSeconds": 0.058494391,
-              "downloadSeconds": 0.00028323
+              "latency": 0.124300298
             },
             {
-              "connectionEstablishedSeconds": 0.066110257,
-              "uploadSeconds": 0.064746388,
-              "downloadSeconds": 0.00023999
+              "latency": 0.123540521
             },
             {
-              "connectionEstablishedSeconds": 0.065221789,
-              "uploadSeconds": 0.06388649,
-              "downloadSeconds": 0.000282664
+              "latency": 0.128840944
             },
             {
-              "connectionEstablishedSeconds": 0.064010908,
-              "uploadSeconds": 0.062539179,
-              "downloadSeconds": 0.000293821
+              "latency": 0.126553297
             },
             {
-              "connectionEstablishedSeconds": 0.066279266,
-              "uploadSeconds": 0.06482569,
-              "downloadSeconds": 0.000189668
+              "latency": 0.12957911
             },
             {
-              "connectionEstablishedSeconds": 0.064467997,
-              "uploadSeconds": 0.062964242,
-              "downloadSeconds": 0.000205917
+              "latency": 0.127501387
             },
             {
-              "connectionEstablishedSeconds": 0.063683088,
-              "uploadSeconds": 0.062621114,
-              "downloadSeconds": 0.000225339
+              "latency": 0.128468983
             },
             {
-              "connectionEstablishedSeconds": 0.065295598,
-              "uploadSeconds": 0.063874133,
-              "downloadSeconds": 0.000301366
+              "latency": 0.123684096
             },
             {
-              "connectionEstablishedSeconds": 0.066577362,
-              "uploadSeconds": 0.065280399,
-              "downloadSeconds": 0.000195606
+              "latency": 0.119435728
             },
             {
-              "connectionEstablishedSeconds": 0.063268171,
-              "uploadSeconds": 0.061804848,
-              "downloadSeconds": 0.000296705
+              "latency": 0.130333639
             },
             {
-              "connectionEstablishedSeconds": 0.065474833,
-              "uploadSeconds": 0.064150838,
-              "downloadSeconds": 0.000243106
+              "latency": 0.124900602
             },
             {
-              "connectionEstablishedSeconds": 0.064503497,
-              "uploadSeconds": 0.063037301,
-              "downloadSeconds": 0.000240357
+              "latency": 0.130070071
             },
             {
-              "connectionEstablishedSeconds": 0.063228496,
-              "uploadSeconds": 0.061711898,
-              "downloadSeconds": 0.0002308
+              "latency": 0.127693458
             },
             {
-              "connectionEstablishedSeconds": 0.065222472,
-              "uploadSeconds": 0.063772095,
-              "downloadSeconds": 0.000225858
+              "latency": 0.129003245
             },
             {
-              "connectionEstablishedSeconds": 0.064831753,
-              "uploadSeconds": 0.063397533,
-              "downloadSeconds": 0.000249322
+              "latency": 0.132047538
             },
             {
-              "connectionEstablishedSeconds": 0.064904029,
-              "uploadSeconds": 0.063438406,
-              "downloadSeconds": 0.000198988
+              "latency": 0.12461281
             },
             {
-              "connectionEstablishedSeconds": 0.064007547,
-              "uploadSeconds": 0.062655107,
-              "downloadSeconds": 0.000226498
+              "latency": 0.127948798
             },
             {
-              "connectionEstablishedSeconds": 0.06389538,
-              "uploadSeconds": 0.062495956,
-              "downloadSeconds": 0.000296354
+              "latency": 0.125516213
             },
             {
-              "connectionEstablishedSeconds": 0.065208755,
-              "uploadSeconds": 0.063847459,
-              "downloadSeconds": 0.000176159
+              "latency": 0.125860936
             },
             {
-              "connectionEstablishedSeconds": 0.06254477,
-              "uploadSeconds": 0.061182311,
-              "downloadSeconds": 0.000191264
+              "latency": 0.124831679
             },
             {
-              "connectionEstablishedSeconds": 0.065895003,
-              "uploadSeconds": 0.064422187,
-              "downloadSeconds": 0.000201304
+              "latency": 0.122833095
             },
             {
-              "connectionEstablishedSeconds": 0.066959431,
-              "uploadSeconds": 0.06549081,
-              "downloadSeconds": 0.000201391
+              "latency": 0.130561063
             },
             {
-              "connectionEstablishedSeconds": 0.065483631,
-              "uploadSeconds": 0.064122764,
-              "downloadSeconds": 0.000199658
+              "latency": 0.131093567
             },
             {
-              "connectionEstablishedSeconds": 0.065869684,
-              "uploadSeconds": 0.064596755,
-              "downloadSeconds": 0.000252607
+              "latency": 0.127323963
             },
             {
-              "connectionEstablishedSeconds": 0.065208161,
-              "uploadSeconds": 0.063724092,
-              "downloadSeconds": 0.000326259
+              "latency": 0.124479805
             },
             {
-              "connectionEstablishedSeconds": 0.063874435,
-              "uploadSeconds": 0.062467287,
-              "downloadSeconds": 0.000189696
+              "latency": 0.126513746
             },
             {
-              "connectionEstablishedSeconds": 0.062529457,
-              "uploadSeconds": 0.061205657,
-              "downloadSeconds": 0.000263333
+              "latency": 0.130026632
             },
             {
-              "connectionEstablishedSeconds": 0.065449242,
-              "uploadSeconds": 0.064066552,
-              "downloadSeconds": 0.000276344
+              "latency": 0.130066528
             },
             {
-              "connectionEstablishedSeconds": 0.064139182,
-              "uploadSeconds": 0.06264439,
-              "downloadSeconds": 0.000202631
+              "latency": 0.122845331
             },
             {
-              "connectionEstablishedSeconds": 0.061921946,
-              "uploadSeconds": 0.060384157,
-              "downloadSeconds": 0.000226218
+              "latency": 0.124507854
             },
             {
-              "connectionEstablishedSeconds": 0.066197629,
-              "uploadSeconds": 0.06483258,
-              "downloadSeconds": 0.000237098
+              "latency": 0.130884729
             },
             {
-              "connectionEstablishedSeconds": 0.064473701,
-              "uploadSeconds": 0.063108909,
-              "downloadSeconds": 0.000208065
+              "latency": 0.120988883
             },
             {
-              "connectionEstablishedSeconds": 0.06539491,
-              "uploadSeconds": 0.063917182,
-              "downloadSeconds": 0.00027215
+              "latency": 0.125774698
             },
             {
-              "connectionEstablishedSeconds": 0.065071228,
-              "uploadSeconds": 0.063778824,
-              "downloadSeconds": 0.000238865
+              "latency": 0.126484946
             },
             {
-              "connectionEstablishedSeconds": 0.064651975,
-              "uploadSeconds": 0.063283752,
-              "downloadSeconds": 0.000156891
+              "latency": 0.126468707
             },
             {
-              "connectionEstablishedSeconds": 0.064982133,
-              "uploadSeconds": 0.063516095,
-              "downloadSeconds": 0.000200867
+              "latency": 0.123656736
             },
             {
-              "connectionEstablishedSeconds": 0.062978826,
-              "uploadSeconds": 0.061688863,
-              "downloadSeconds": 0.000188278
+              "latency": 0.132574109
             },
             {
-              "connectionEstablishedSeconds": 0.062295427,
-              "uploadSeconds": 0.060913366,
-              "downloadSeconds": 0.000255438
+              "latency": 0.121921803
             },
             {
-              "connectionEstablishedSeconds": 0.064525031,
-              "uploadSeconds": 0.063123822,
-              "downloadSeconds": 0.000226088
+              "latency": 0.128035923
             },
             {
-              "connectionEstablishedSeconds": 0.062325794,
-              "uploadSeconds": 0.061063754,
-              "downloadSeconds": 0.000218165
+              "latency": 0.130713875
             },
             {
-              "connectionEstablishedSeconds": 0.064822543,
-              "uploadSeconds": 0.063304121,
-              "downloadSeconds": 0.000251781
+              "latency": 0.127916236
             },
             {
-              "connectionEstablishedSeconds": 0.061440857,
-              "uploadSeconds": 0.059937803,
-              "downloadSeconds": 0.000269138
+              "latency": 0.126354233
             },
             {
-              "connectionEstablishedSeconds": 0.065088219,
-              "uploadSeconds": 0.063709099,
-              "downloadSeconds": 0.00022092
+              "latency": 0.12551248
             },
             {
-              "connectionEstablishedSeconds": 0.062920135,
-              "uploadSeconds": 0.061504746,
-              "downloadSeconds": 0.000207534
+              "latency": 0.125169279
             },
             {
-              "connectionEstablishedSeconds": 0.065019389,
-              "uploadSeconds": 0.063622874,
-              "downloadSeconds": 0.000219459
+              "latency": 0.126407875
             },
             {
-              "connectionEstablishedSeconds": 0.065977009,
-              "uploadSeconds": 0.064597124,
-              "downloadSeconds": 0.000250198
+              "latency": 0.127732602
             },
             {
-              "connectionEstablishedSeconds": 0.062422976,
-              "uploadSeconds": 0.060975136,
-              "downloadSeconds": 0.000214674
+              "latency": 0.122444346
             },
             {
-              "connectionEstablishedSeconds": 0.064642922,
-              "uploadSeconds": 0.063189755,
-              "downloadSeconds": 0.00029799
+              "latency": 0.125910469
             },
             {
-              "connectionEstablishedSeconds": 0.065682327,
-              "uploadSeconds": 0.064287936,
-              "downloadSeconds": 0.000292814
+              "latency": 0.126633221
             },
             {
-              "connectionEstablishedSeconds": 0.063473996,
-              "uploadSeconds": 0.062029369,
-              "downloadSeconds": 0.000231583
+              "latency": 0.123138109
             },
             {
-              "connectionEstablishedSeconds": 0.063469822,
-              "uploadSeconds": 0.061954741,
-              "downloadSeconds": 0.000246131
+              "latency": 0.127190048
             },
             {
-              "connectionEstablishedSeconds": 0.064851128,
-              "uploadSeconds": 0.063434178,
-              "downloadSeconds": 0.000213867
+              "latency": 0.125373263
             },
             {
-              "connectionEstablishedSeconds": 0.062144428,
-              "uploadSeconds": 0.060606703,
-              "downloadSeconds": 0.000217533
+              "latency": 0.130775642
             },
             {
-              "connectionEstablishedSeconds": 0.065986455,
-              "uploadSeconds": 0.064577873,
-              "downloadSeconds": 0.000206804
+              "latency": 0.126479922
             },
             {
-              "connectionEstablishedSeconds": 0.064726192,
-              "uploadSeconds": 0.063332243,
-              "downloadSeconds": 0.000239735
+              "latency": 0.123469529
             },
             {
-              "connectionEstablishedSeconds": 0.064632716,
-              "uploadSeconds": 0.063309348,
-              "downloadSeconds": 0.000265871
+              "latency": 0.127197619
             },
             {
-              "connectionEstablishedSeconds": 0.066051432,
-              "uploadSeconds": 0.064603075,
-              "downloadSeconds": 0.000279868
+              "latency": 0.12796889
             },
             {
-              "connectionEstablishedSeconds": 0.064319152,
-              "uploadSeconds": 0.062978197,
-              "downloadSeconds": 0.000267011
+              "latency": 0.12870022
             },
             {
-              "connectionEstablishedSeconds": 0.065578875,
-              "uploadSeconds": 0.064210311,
-              "downloadSeconds": 0.000312327
+              "latency": 0.122779333
             },
             {
-              "connectionEstablishedSeconds": 0.06249902,
-              "uploadSeconds": 0.061115234,
-              "downloadSeconds": 0.000208288
+              "latency": 0.129133343
             },
             {
-              "connectionEstablishedSeconds": 0.064433692,
-              "uploadSeconds": 0.063065887,
-              "downloadSeconds": 0.000199075
+              "latency": 0.128028004
             },
             {
-              "connectionEstablishedSeconds": 0.063908527,
-              "uploadSeconds": 0.062421652,
-              "downloadSeconds": 0.000192921
+              "latency": 0.12549691
             },
             {
-              "connectionEstablishedSeconds": 0.065314004,
-              "uploadSeconds": 0.063971269,
-              "downloadSeconds": 0.000224887
+              "latency": 0.125466561
             },
             {
-              "connectionEstablishedSeconds": 0.066661819,
-              "uploadSeconds": 0.065122878,
-              "downloadSeconds": 0.000303099
+              "latency": 0.131906053
             },
             {
-              "connectionEstablishedSeconds": 0.062946918,
-              "uploadSeconds": 0.061544363,
-              "downloadSeconds": 0.000211652
+              "latency": 0.121921702
             },
             {
-              "connectionEstablishedSeconds": 0.061860653,
-              "uploadSeconds": 0.060460049,
-              "downloadSeconds": 0.000195749
+              "latency": 0.12959066
             },
             {
-              "connectionEstablishedSeconds": 0.065215099,
-              "uploadSeconds": 0.063931388,
-              "downloadSeconds": 0.000234829
+              "latency": 0.127225396
             },
             {
-              "connectionEstablishedSeconds": 0.06453588,
-              "uploadSeconds": 0.06308244,
-              "downloadSeconds": 0.000227521
+              "latency": 0.11967506
             },
             {
-              "connectionEstablishedSeconds": 0.06571602,
-              "uploadSeconds": 0.064277054,
-              "downloadSeconds": 0.000233697
+              "latency": 0.123612348
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -2503,504 +1783,304 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.185053145,
-              "downloadSeconds": 0.000042529
+              "latency": 0.185961485
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.186749887,
-              "downloadSeconds": 0.000034788
+              "latency": 0.188375741
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.177589981,
-              "downloadSeconds": 0.000034141
+              "latency": 0.190612922
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.186222307,
-              "downloadSeconds": 0.000023625
+              "latency": 0.190957367
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190720809,
-              "downloadSeconds": 0.000035193
+              "latency": 0.193958657
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.193406136,
-              "downloadSeconds": 0.000035356
+              "latency": 0.183547678
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.192963271,
-              "downloadSeconds": 0.00003445
+              "latency": 0.184320209
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.195476643,
-              "downloadSeconds": 0.000036906
+              "latency": 0.188832759
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.187020122,
-              "downloadSeconds": 0.000030902
+              "latency": 0.182914815
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190978917,
-              "downloadSeconds": 0.000035416
+              "latency": 0.185030383
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.18895168,
-              "downloadSeconds": 0.000030577
+              "latency": 0.193356891
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19280074,
-              "downloadSeconds": 0.000034784
+              "latency": 0.190457075
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.194281643,
-              "downloadSeconds": 0.00003553
+              "latency": 0.185981253
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188287778,
-              "downloadSeconds": 0.000037338
+              "latency": 0.191331879
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.195430346,
-              "downloadSeconds": 0.000037072
+              "latency": 0.182717303
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.194384239,
-              "downloadSeconds": 0.000034565
+              "latency": 0.186655694
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191915218,
-              "downloadSeconds": 0.000031388
+              "latency": 0.18842115
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190814481,
-              "downloadSeconds": 0.000033409
+              "latency": 0.189984872
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188226132,
-              "downloadSeconds": 0.000031379
+              "latency": 0.183096242
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188944544,
-              "downloadSeconds": 0.000037297
+              "latency": 0.185881694
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.192830669,
-              "downloadSeconds": 0.000031164
+              "latency": 0.185340571
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191889106,
-              "downloadSeconds": 0.00003192
+              "latency": 0.18461522
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.184959513,
-              "downloadSeconds": 0.000032864
+              "latency": 0.186025353
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19342802,
-              "downloadSeconds": 0.000032484
+              "latency": 0.189214854
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.193531339,
-              "downloadSeconds": 0.000024694
+              "latency": 0.190976998
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191605955,
-              "downloadSeconds": 0.000039426
+              "latency": 0.191156926
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188998617,
-              "downloadSeconds": 0.000031029
+              "latency": 0.188917358
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188507885,
-              "downloadSeconds": 0.00002276
+              "latency": 0.179752705
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.196444295,
-              "downloadSeconds": 0.000025062
+              "latency": 0.184555396
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.193288603,
-              "downloadSeconds": 0.000022276
+              "latency": 0.183720716
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190196478,
-              "downloadSeconds": 0.000035304
+              "latency": 0.195191566
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19101996,
-              "downloadSeconds": 0.000031468
+              "latency": 0.185168084
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.18771346,
-              "downloadSeconds": 0.000034425
+              "latency": 0.193332951
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.192304997,
-              "downloadSeconds": 0.000033108
+              "latency": 0.183290752
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.182804295,
-              "downloadSeconds": 0.000034492
+              "latency": 0.184111927
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191296398,
-              "downloadSeconds": 0.000035555
+              "latency": 0.188479487
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.183664688,
-              "downloadSeconds": 0.000034473
+              "latency": 0.188744324
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.192932606,
-              "downloadSeconds": 0.000034101
+              "latency": 0.191527443
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191965651,
-              "downloadSeconds": 0.00004048
+              "latency": 0.182386011
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.193361465,
-              "downloadSeconds": 0.000037094
+              "latency": 0.185881535
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.182595081,
-              "downloadSeconds": 0.000026521
+              "latency": 0.18291621
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.193753749,
-              "downloadSeconds": 0.000031588
+              "latency": 0.187003834
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191619186,
-              "downloadSeconds": 0.000034298
+              "latency": 0.178580196
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.186816459,
-              "downloadSeconds": 0.00003413
+              "latency": 0.182966457
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19257261,
-              "downloadSeconds": 0.000033194
+              "latency": 0.19156239
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.189630143,
-              "downloadSeconds": 0.000025527
+              "latency": 0.1802248
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.182871119,
-              "downloadSeconds": 0.000035417
+              "latency": 0.190849347
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.187070763,
-              "downloadSeconds": 0.000039682
+              "latency": 0.192672815
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.182966939,
-              "downloadSeconds": 0.000034868
+              "latency": 0.187506079
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19029279,
-              "downloadSeconds": 0.000032821
+              "latency": 0.176972689
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.189312151,
-              "downloadSeconds": 0.000023169
+              "latency": 0.189345238
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191229498,
-              "downloadSeconds": 0.000030995
+              "latency": 0.185527481
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.18908621,
-              "downloadSeconds": 0.000024805
+              "latency": 0.191707959
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190969054,
-              "downloadSeconds": 0.000035044
+              "latency": 0.187159697
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.182805951,
-              "downloadSeconds": 0.000035045
+              "latency": 0.192613505
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.184211676,
-              "downloadSeconds": 0.00003118
+              "latency": 0.185720473
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190939334,
-              "downloadSeconds": 0.00003687
+              "latency": 0.18177996
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190777691,
-              "downloadSeconds": 0.000035732
+              "latency": 0.181090506
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.187917115,
-              "downloadSeconds": 0.000034899
+              "latency": 0.183976665
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190072014,
-              "downloadSeconds": 0.000039331
+              "latency": 0.192820029
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191356984,
-              "downloadSeconds": 0.000036338
+              "latency": 0.193548702
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191103454,
-              "downloadSeconds": 0.000035841
+              "latency": 0.178046098
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.176751719,
-              "downloadSeconds": 0.000034908
+              "latency": 0.187386167
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19357032,
-              "downloadSeconds": 0.000027657
+              "latency": 0.184856735
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.185481567,
-              "downloadSeconds": 0.000034332
+              "latency": 0.181595157
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190641535,
-              "downloadSeconds": 0.000033533
+              "latency": 0.184597279
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191202351,
-              "downloadSeconds": 0.000034829
+              "latency": 0.191130816
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.186108976,
-              "downloadSeconds": 0.000023441
+              "latency": 0.187089569
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191705913,
-              "downloadSeconds": 0.000023135
+              "latency": 0.187772461
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.186858248,
-              "downloadSeconds": 0.000033264
+              "latency": 0.19046177
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.186761576,
-              "downloadSeconds": 0.000037166
+              "latency": 0.186334128
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191750803,
-              "downloadSeconds": 0.000025621
+              "latency": 0.184603884
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.186545117,
-              "downloadSeconds": 0.000035984
+              "latency": 0.1935887
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.182424793,
-              "downloadSeconds": 0.00003531
+              "latency": 0.188782643
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19095818,
-              "downloadSeconds": 0.00003541
+              "latency": 0.189003157
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.193940523,
-              "downloadSeconds": 0.000034823
+              "latency": 0.191010376
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19126552,
-              "downloadSeconds": 0.000030258
+              "latency": 0.191431241
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.192959396,
-              "downloadSeconds": 0.00003533
+              "latency": 0.186968898
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191230252,
-              "downloadSeconds": 0.00003462
+              "latency": 0.191125795
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191606432,
-              "downloadSeconds": 0.000035102
+              "latency": 0.183442057
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190014888,
-              "downloadSeconds": 0.000029117
+              "latency": 0.195882124
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190648226,
-              "downloadSeconds": 0.000025677
+              "latency": 0.184102748
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.189448378,
-              "downloadSeconds": 0.000033677
+              "latency": 0.186756025
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.195077934,
-              "downloadSeconds": 0.000034017
+              "latency": 0.187291222
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.181657919,
-              "downloadSeconds": 0.000034153
+              "latency": 0.175203264
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.189491676,
-              "downloadSeconds": 0.000027625
+              "latency": 0.176218714
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.191770687,
-              "downloadSeconds": 0.000031336
+              "latency": 0.195973862
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.189495974,
-              "downloadSeconds": 0.000034939
+              "latency": 0.18419611
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190744158,
-              "downloadSeconds": 0.000036604
+              "latency": 0.190925537
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188132312,
-              "downloadSeconds": 0.000034402
+              "latency": 0.188930836
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.177152609,
-              "downloadSeconds": 0.000035554
+              "latency": 0.196213305
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.180191044,
-              "downloadSeconds": 0.000027139
+              "latency": 0.187859907
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188539768,
-              "downloadSeconds": 0.000035181
+              "latency": 0.18496212
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.188009218,
-              "downloadSeconds": 0.000028091
+              "latency": 0.187973095
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.190402823,
-              "downloadSeconds": 0.000034882
+              "latency": 0.187376657
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.176183458,
-              "downloadSeconds": 0.000027937
+              "latency": 0.180131081
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.185653132,
-              "downloadSeconds": 0.000035795
+              "latency": 0.188552894
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.19374182,
-              "downloadSeconds": 0.000035146
+              "latency": 0.189526143
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.180572218,
-              "downloadSeconds": 0.00003475
+              "latency": 0.180011438
             },
             {
-              "connectionEstablishedSeconds": 0,
-              "uploadSeconds": 0.192778229,
-              "downloadSeconds": 0.00002868
+              "latency": 0.189606794
             }
           ],
           "implementation": "https",
@@ -3010,504 +2090,304 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.255564771,
-              "uploadSeconds": 0.000058962,
-              "downloadSeconds": 0.124655922
+              "latency": 0.371673364
             },
             {
-              "connectionEstablishedSeconds": 0.240628743,
-              "uploadSeconds": 0.000031327,
-              "downloadSeconds": 0.059283787
+              "latency": 0.310527868
             },
             {
-              "connectionEstablishedSeconds": 0.246060026,
-              "uploadSeconds": 0.000032811,
-              "downloadSeconds": 0.120545382
+              "latency": 0.309783624
             },
             {
-              "connectionEstablishedSeconds": 0.257898273,
-              "uploadSeconds": 0.000061307,
-              "downloadSeconds": 0.063628717
+              "latency": 0.390526476
             },
             {
-              "connectionEstablishedSeconds": 0.256797484,
-              "uploadSeconds": 0.000015293,
-              "downloadSeconds": 0.126097157
+              "latency": 0.309294922
             },
             {
-              "connectionEstablishedSeconds": 0.257655875,
-              "uploadSeconds": 0.000031895,
-              "downloadSeconds": 0.063533893
+              "latency": 0.320893325
             },
             {
-              "connectionEstablishedSeconds": 0.256532527,
-              "uploadSeconds": 0.000034072,
-              "downloadSeconds": 0.063442454
+              "latency": 0.315424144
             },
             {
-              "connectionEstablishedSeconds": 0.256347155,
-              "uploadSeconds": 0.000047138,
-              "downloadSeconds": 0.125774714
+              "latency": 0.324311415
             },
             {
-              "connectionEstablishedSeconds": 0.259335178,
-              "uploadSeconds": 0.000049483,
-              "downloadSeconds": 0.063913947
+              "latency": 0.374898917
             },
             {
-              "connectionEstablishedSeconds": 0.233717447,
-              "uploadSeconds": 0.00002658,
-              "downloadSeconds": 0.058006432
+              "latency": 0.370672619
             },
             {
-              "connectionEstablishedSeconds": 0.258911012,
-              "uploadSeconds": 0.000050582,
-              "downloadSeconds": 0.126864314
+              "latency": 0.31457677
             },
             {
-              "connectionEstablishedSeconds": 0.256092791,
-              "uploadSeconds": 0.00005145,
-              "downloadSeconds": 0.063076668
+              "latency": 0.389143043
             },
             {
-              "connectionEstablishedSeconds": 0.253528586,
-              "uploadSeconds": 0.000035863,
-              "downloadSeconds": 0.12516235
+              "latency": 0.311358109
             },
             {
-              "connectionEstablishedSeconds": 0.250931815,
-              "uploadSeconds": 0.000048435,
-              "downloadSeconds": 0.061765651
+              "latency": 0.37827599
             },
             {
-              "connectionEstablishedSeconds": 0.258632992,
-              "uploadSeconds": 0.000051462,
-              "downloadSeconds": 0.126959835
+              "latency": 0.311336431
             },
             {
-              "connectionEstablishedSeconds": 0.257017873,
-              "uploadSeconds": 0.000049839,
-              "downloadSeconds": 0.126077058
+              "latency": 0.316977723
             },
             {
-              "connectionEstablishedSeconds": 0.259292194,
-              "uploadSeconds": 0.000050133,
-              "downloadSeconds": 0.127185628
+              "latency": 0.320063546
             },
             {
-              "connectionEstablishedSeconds": 0.240883048,
-              "uploadSeconds": 0.000029202,
-              "downloadSeconds": 0.117895391
+              "latency": 0.306109548
             },
             {
-              "connectionEstablishedSeconds": 0.238878753,
-              "uploadSeconds": 0.000055267,
-              "downloadSeconds": 0.116871413
+              "latency": 0.378276207
             },
             {
-              "connectionEstablishedSeconds": 0.252530614,
-              "uploadSeconds": 0.000053341,
-              "downloadSeconds": 0.124574708
+              "latency": 0.29973811
             },
             {
-              "connectionEstablishedSeconds": 0.248543388,
-              "uploadSeconds": 0.000035107,
-              "downloadSeconds": 0.061000007
+              "latency": 0.31010851
             },
             {
-              "connectionEstablishedSeconds": 0.252642228,
-              "uploadSeconds": 0.000022627,
-              "downloadSeconds": 0.062691633
+              "latency": 0.379182714
             },
             {
-              "connectionEstablishedSeconds": 0.244578188,
-              "uploadSeconds": 0.000031248,
-              "downloadSeconds": 0.120452768
+              "latency": 0.307516103
             },
             {
-              "connectionEstablishedSeconds": 0.255823597,
-              "uploadSeconds": 0.000045341,
-              "downloadSeconds": 0.125369052
+              "latency": 0.316331042
             },
             {
-              "connectionEstablishedSeconds": 0.255313133,
-              "uploadSeconds": 0.000054953,
-              "downloadSeconds": 0.123889423
+              "latency": 0.31866157
             },
             {
-              "connectionEstablishedSeconds": 0.25583746,
-              "uploadSeconds": 0.000049329,
-              "downloadSeconds": 0.06339297
+              "latency": 0.310953094
             },
             {
-              "connectionEstablishedSeconds": 0.256002126,
-              "uploadSeconds": 0.000057044,
-              "downloadSeconds": 0.126471927
+              "latency": 0.308377534
             },
             {
-              "connectionEstablishedSeconds": 0.252109507,
-              "uploadSeconds": 0.00005592,
-              "downloadSeconds": 0.062519518
+              "latency": 0.30688395
             },
             {
-              "connectionEstablishedSeconds": 0.251913238,
-              "uploadSeconds": 0.000028096,
-              "downloadSeconds": 0.123525763
+              "latency": 0.309395132
             },
             {
-              "connectionEstablishedSeconds": 0.254943314,
-              "uploadSeconds": 0.000027106,
-              "downloadSeconds": 0.12496839
+              "latency": 0.314995966
             },
             {
-              "connectionEstablishedSeconds": 0.247363092,
-              "uploadSeconds": 0.000046956,
-              "downloadSeconds": 0.122142147
+              "latency": 0.357796605
             },
             {
-              "connectionEstablishedSeconds": 0.252327697,
-              "uploadSeconds": 0.000032412,
-              "downloadSeconds": 0.062109734
+              "latency": 0.316310205
             },
             {
-              "connectionEstablishedSeconds": 0.25467206,
-              "uploadSeconds": 0.000051041,
-              "downloadSeconds": 0.062652737
+              "latency": 0.307071256
             },
             {
-              "connectionEstablishedSeconds": 0.252011661,
-              "uploadSeconds": 0.000028809,
-              "downloadSeconds": 0.062551701
+              "latency": 0.3119234
             },
             {
-              "connectionEstablishedSeconds": 0.256222493,
-              "uploadSeconds": 0.000049471,
-              "downloadSeconds": 0.063473614
+              "latency": 0.310987794
             },
             {
-              "connectionEstablishedSeconds": 0.249629093,
-              "uploadSeconds": 0.000015106,
-              "downloadSeconds": 0.061868423
+              "latency": 0.317234556
             },
             {
-              "connectionEstablishedSeconds": 0.256758085,
-              "uploadSeconds": 0.000046705,
-              "downloadSeconds": 0.126453964
+              "latency": 0.298399712
             },
             {
-              "connectionEstablishedSeconds": 0.246384913,
-              "uploadSeconds": 0.000046164,
-              "downloadSeconds": 0.061167599
+              "latency": 0.326935269
             },
             {
-              "connectionEstablishedSeconds": 0.253809944,
-              "uploadSeconds": 0.000046954,
-              "downloadSeconds": 0.06251466
+              "latency": 0.320704366
             },
             {
-              "connectionEstablishedSeconds": 0.252680571,
-              "uploadSeconds": 0.00004862,
-              "downloadSeconds": 0.124903987
+              "latency": 0.320087989
             },
             {
-              "connectionEstablishedSeconds": 0.260555268,
-              "uploadSeconds": 0.000024659,
-              "downloadSeconds": 0.06422256
+              "latency": 0.323290207
             },
             {
-              "connectionEstablishedSeconds": 0.253972966,
-              "uploadSeconds": 0.000030325,
-              "downloadSeconds": 0.062968215
+              "latency": 0.365360326
             },
             {
-              "connectionEstablishedSeconds": 0.251677426,
-              "uploadSeconds": 0.000058083,
-              "downloadSeconds": 0.123469886
+              "latency": 0.307250184
             },
             {
-              "connectionEstablishedSeconds": 0.255464321,
-              "uploadSeconds": 0.000030361,
-              "downloadSeconds": 0.063452473
+              "latency": 0.371798191
             },
             {
-              "connectionEstablishedSeconds": 0.257554731,
-              "uploadSeconds": 0.000047156,
-              "downloadSeconds": 0.126325713
+              "latency": 0.308768596
             },
             {
-              "connectionEstablishedSeconds": 0.254332788,
-              "uploadSeconds": 0.000053547,
-              "downloadSeconds": 0.062627469
+              "latency": 0.388180711
             },
             {
-              "connectionEstablishedSeconds": 0.24463752,
-              "uploadSeconds": 0.000029926,
-              "downloadSeconds": 0.060626808
+              "latency": 0.325229648
             },
             {
-              "connectionEstablishedSeconds": 0.251500685,
-              "uploadSeconds": 0.000034964,
-              "downloadSeconds": 0.062436547
+              "latency": 0.359241619
             },
             {
-              "connectionEstablishedSeconds": 0.248732914,
-              "uploadSeconds": 0.000031966,
-              "downloadSeconds": 0.061784867
+              "latency": 0.373853866
             },
             {
-              "connectionEstablishedSeconds": 0.254063006,
-              "uploadSeconds": 0.000060283,
-              "downloadSeconds": 0.124453353
+              "latency": 0.316128988
             },
             {
-              "connectionEstablishedSeconds": 0.254678345,
-              "uploadSeconds": 0.000029515,
-              "downloadSeconds": 0.063197481
+              "latency": 0.363671409
             },
             {
-              "connectionEstablishedSeconds": 0.256487616,
-              "uploadSeconds": 0.000028327,
-              "downloadSeconds": 0.063529376
+              "latency": 0.364167016
             },
             {
-              "connectionEstablishedSeconds": 0.254123118,
-              "uploadSeconds": 0.000030113,
-              "downloadSeconds": 0.124538531
+              "latency": 0.321862292
             },
             {
-              "connectionEstablishedSeconds": 0.25159968,
-              "uploadSeconds": 0.000030301,
-              "downloadSeconds": 0.061926504
+              "latency": 0.378195501
             },
             {
-              "connectionEstablishedSeconds": 0.25943308,
-              "uploadSeconds": 0.00002747,
-              "downloadSeconds": 0.064337808
+              "latency": 0.305405033
             },
             {
-              "connectionEstablishedSeconds": 0.256212381,
-              "uploadSeconds": 0.000051275,
-              "downloadSeconds": 0.063474669
+              "latency": 0.383036021
             },
             {
-              "connectionEstablishedSeconds": 0.253068728,
-              "uploadSeconds": 0.000031105,
-              "downloadSeconds": 0.062774459
+              "latency": 0.322979748
             },
             {
-              "connectionEstablishedSeconds": 0.25281207,
-              "uploadSeconds": 0.000032473,
-              "downloadSeconds": 0.062257546
+              "latency": 0.385531653
             },
             {
-              "connectionEstablishedSeconds": 0.245992583,
-              "uploadSeconds": 0.000047141,
-              "downloadSeconds": 0.060600227
+              "latency": 0.376895007
             },
             {
-              "connectionEstablishedSeconds": 0.248401528,
-              "uploadSeconds": 0.000051407,
-              "downloadSeconds": 0.061628242
+              "latency": 0.370288002
             },
             {
-              "connectionEstablishedSeconds": 0.254361874,
-              "uploadSeconds": 0.000032809,
-              "downloadSeconds": 0.063058271
+              "latency": 0.370799304
             },
             {
-              "connectionEstablishedSeconds": 0.25985272,
-              "uploadSeconds": 0.000048011,
-              "downloadSeconds": 0.064490936
+              "latency": 0.367503576
             },
             {
-              "connectionEstablishedSeconds": 0.251897611,
-              "uploadSeconds": 0.000045946,
-              "downloadSeconds": 0.062066764
+              "latency": 0.30317632
             },
             {
-              "connectionEstablishedSeconds": 0.248299434,
-              "uploadSeconds": 0.000042741,
-              "downloadSeconds": 0.061555421
+              "latency": 0.306185982
             },
             {
-              "connectionEstablishedSeconds": 0.240883312,
-              "uploadSeconds": 0.000043219,
-              "downloadSeconds": 0.117887156
+              "latency": 0.309685666
             },
             {
-              "connectionEstablishedSeconds": 0.253741863,
-              "uploadSeconds": 0.00004853,
-              "downloadSeconds": 0.125259598
+              "latency": 0.319031544
             },
             {
-              "connectionEstablishedSeconds": 0.259493548,
-              "uploadSeconds": 0.000050997,
-              "downloadSeconds": 0.064455196
+              "latency": 0.322063518
             },
             {
-              "connectionEstablishedSeconds": 0.257220143,
-              "uploadSeconds": 0.000030118,
-              "downloadSeconds": 0.063426681
+              "latency": 0.320676913
             },
             {
-              "connectionEstablishedSeconds": 0.246216063,
-              "uploadSeconds": 0.000028691,
-              "downloadSeconds": 0.060675077
+              "latency": 0.311714831
             },
             {
-              "connectionEstablishedSeconds": 0.246821242,
-              "uploadSeconds": 0.000028037,
-              "downloadSeconds": 0.061043753
+              "latency": 0.388734707
             },
             {
-              "connectionEstablishedSeconds": 0.249273925,
-              "uploadSeconds": 0.000046106,
-              "downloadSeconds": 0.061133894
+              "latency": 0.371604758
             },
             {
-              "connectionEstablishedSeconds": 0.246100615,
-              "uploadSeconds": 0.000027492,
-              "downloadSeconds": 0.060683507
+              "latency": 0.382371194
             },
             {
-              "connectionEstablishedSeconds": 0.254584769,
-              "uploadSeconds": 0.000029223,
-              "downloadSeconds": 0.063075631
+              "latency": 0.304823606
             },
             {
-              "connectionEstablishedSeconds": 0.251221668,
-              "uploadSeconds": 0.000019521,
-              "downloadSeconds": 0.061797471
+              "latency": 0.30671412
             },
             {
-              "connectionEstablishedSeconds": 0.261594006,
-              "uploadSeconds": 0.000047526,
-              "downloadSeconds": 0.064500959
+              "latency": 0.316717461
             },
             {
-              "connectionEstablishedSeconds": 0.255117473,
-              "uploadSeconds": 0.000034003,
-              "downloadSeconds": 0.062865607
+              "latency": 0.317143564
             },
             {
-              "connectionEstablishedSeconds": 0.259363593,
-              "uploadSeconds": 0.000025603,
-              "downloadSeconds": 0.064428592
+              "latency": 0.325290747
             },
             {
-              "connectionEstablishedSeconds": 0.256991666,
-              "uploadSeconds": 0.000038121,
-              "downloadSeconds": 0.126587719
+              "latency": 0.319788498
             },
             {
-              "connectionEstablishedSeconds": 0.256222985,
-              "uploadSeconds": 0.000034028,
-              "downloadSeconds": 0.063668828
+              "latency": 0.321180212
             },
             {
-              "connectionEstablishedSeconds": 0.246441053,
-              "uploadSeconds": 0.000054022,
-              "downloadSeconds": 0.060693367
+              "latency": 0.312451854
             },
             {
-              "connectionEstablishedSeconds": 0.250188094,
-              "uploadSeconds": 0.000047133,
-              "downloadSeconds": 0.122659442
+              "latency": 0.308637822
             },
             {
-              "connectionEstablishedSeconds": 0.250006049,
-              "uploadSeconds": 0.000029392,
-              "downloadSeconds": 0.061585645
+              "latency": 0.306170505
             },
             {
-              "connectionEstablishedSeconds": 0.257920889,
-              "uploadSeconds": 0.000032591,
-              "downloadSeconds": 0.063517178
+              "latency": 0.321725459
             },
             {
-              "connectionEstablishedSeconds": 0.250465138,
-              "uploadSeconds": 0.000029506,
-              "downloadSeconds": 0.061617335
+              "latency": 0.367621984
             },
             {
-              "connectionEstablishedSeconds": 0.245868712,
-              "uploadSeconds": 0.000027911,
-              "downloadSeconds": 0.060637803
+              "latency": 0.378936172
             },
             {
-              "connectionEstablishedSeconds": 0.25524009,
-              "uploadSeconds": 0.000035514,
-              "downloadSeconds": 0.125044365
+              "latency": 0.319996168
             },
             {
-              "connectionEstablishedSeconds": 0.261456952,
-              "uploadSeconds": 0.00005156,
-              "downloadSeconds": 0.064948587
+              "latency": 0.319607042
             },
             {
-              "connectionEstablishedSeconds": 0.238494124,
-              "uploadSeconds": 0.000055281,
-              "downloadSeconds": 0.117753391
+              "latency": 0.350467783
             },
             {
-              "connectionEstablishedSeconds": 0.254645427,
-              "uploadSeconds": 0.000029023,
-              "downloadSeconds": 0.063098551
+              "latency": 0.32098288
             },
             {
-              "connectionEstablishedSeconds": 0.260883166,
-              "uploadSeconds": 0.000030938,
-              "downloadSeconds": 0.06422298
+              "latency": 0.362787417
             },
             {
-              "connectionEstablishedSeconds": 0.245937147,
-              "uploadSeconds": 0.000052181,
-              "downloadSeconds": 0.120588066
+              "latency": 0.321426164
             },
             {
-              "connectionEstablishedSeconds": 0.246092408,
-              "uploadSeconds": 0.000043654,
-              "downloadSeconds": 0.060575934
+              "latency": 0.314355836
             },
             {
-              "connectionEstablishedSeconds": 0.252276353,
-              "uploadSeconds": 0.000052674,
-              "downloadSeconds": 0.062225078
+              "latency": 0.304564324
             },
             {
-              "connectionEstablishedSeconds": 0.254035258,
-              "uploadSeconds": 0.000029773,
-              "downloadSeconds": 0.063026433
+              "latency": 0.366528476
             },
             {
-              "connectionEstablishedSeconds": 0.244492974,
-              "uploadSeconds": 0.000048903,
-              "downloadSeconds": 0.060129062
+              "latency": 0.308103004
             },
             {
-              "connectionEstablishedSeconds": 0.248731287,
-              "uploadSeconds": 0.000054764,
-              "downloadSeconds": 0.061207054
+              "latency": 0.322845997
             },
             {
-              "connectionEstablishedSeconds": 0.25220207,
-              "uploadSeconds": 0.00002132,
-              "downloadSeconds": 0.062101733
+              "latency": 0.31113667
             },
             {
-              "connectionEstablishedSeconds": 0.259540618,
-              "uploadSeconds": 0.000029737,
-              "downloadSeconds": 0.06402198
+              "latency": 0.309033917
             },
             {
-              "connectionEstablishedSeconds": 0.259530792,
-              "uploadSeconds": 0.000036374,
-              "downloadSeconds": 0.064350389
+              "latency": 0.308894674
             },
             {
-              "connectionEstablishedSeconds": 0.256305199,
-              "uploadSeconds": 0.000032371,
-              "downloadSeconds": 0.063607602
+              "latency": 0.302450241
             }
           ],
           "implementation": "go-libp2p",
@@ -3517,504 +2397,304 @@
         {
           "result": [
             {
-              "connectionEstablishedSeconds": 0.127014114,
-              "uploadSeconds": 0.0000599,
-              "downloadSeconds": 0.061673031
+              "latency": 0.191423399
             },
             {
-              "connectionEstablishedSeconds": 0.131064058,
-              "uploadSeconds": 0.000050908,
-              "downloadSeconds": 0.062537019
+              "latency": 0.187232721
             },
             {
-              "connectionEstablishedSeconds": 0.135060958,
-              "uploadSeconds": 0.000017065,
-              "downloadSeconds": 0.064952383
+              "latency": 0.197214885
             },
             {
-              "connectionEstablishedSeconds": 0.130469846,
-              "uploadSeconds": 0.000049737,
-              "downloadSeconds": 0.063554424
+              "latency": 0.19396671
             },
             {
-              "connectionEstablishedSeconds": 0.131299513,
-              "uploadSeconds": 0.000026493,
-              "downloadSeconds": 0.063977902
+              "latency": 0.189624189
             },
             {
-              "connectionEstablishedSeconds": 0.130389784,
-              "uploadSeconds": 0.000040725,
-              "downloadSeconds": 0.063581044
+              "latency": 0.181780785
             },
             {
-              "connectionEstablishedSeconds": 0.129796216,
-              "uploadSeconds": 0.000051097,
-              "downloadSeconds": 0.06321556
+              "latency": 0.190711272
             },
             {
-              "connectionEstablishedSeconds": 0.124704159,
-              "uploadSeconds": 0.000049439,
-              "downloadSeconds": 0.059809119
+              "latency": 0.190395223
             },
             {
-              "connectionEstablishedSeconds": 0.132066235,
-              "uploadSeconds": 0.000055003,
-              "downloadSeconds": 0.063481356
+              "latency": 0.189552051
             },
             {
-              "connectionEstablishedSeconds": 0.131711288,
-              "uploadSeconds": 0.000027967,
-              "downloadSeconds": 0.06333515
+              "latency": 0.188390608
             },
             {
-              "connectionEstablishedSeconds": 0.127610138,
-              "uploadSeconds": 0.000027948,
-              "downloadSeconds": 0.061228341
+              "latency": 0.188042326
             },
             {
-              "connectionEstablishedSeconds": 0.126055326,
-              "uploadSeconds": 0.000021998,
-              "downloadSeconds": 0.06142716
+              "latency": 0.188101559
             },
             {
-              "connectionEstablishedSeconds": 0.123515801,
-              "uploadSeconds": 0.000009845,
-              "downloadSeconds": 0.060132657
+              "latency": 0.197555288
             },
             {
-              "connectionEstablishedSeconds": 0.124995443,
-              "uploadSeconds": 0.000030619,
-              "downloadSeconds": 0.060910578
+              "latency": 0.193904508
             },
             {
-              "connectionEstablishedSeconds": 0.131803299,
-              "uploadSeconds": 0.00004698,
-              "downloadSeconds": 0.064321877
+              "latency": 0.19383215
             },
             {
-              "connectionEstablishedSeconds": 0.132100006,
-              "uploadSeconds": 0.000031614,
-              "downloadSeconds": 0.064446827
+              "latency": 0.18679819
             },
             {
-              "connectionEstablishedSeconds": 0.131765427,
-              "uploadSeconds": 0.000031545,
-              "downloadSeconds": 0.064305327
+              "latency": 0.199310079
             },
             {
-              "connectionEstablishedSeconds": 0.131987682,
-              "uploadSeconds": 0.000047611,
-              "downloadSeconds": 0.063545341
+              "latency": 0.185368522
             },
             {
-              "connectionEstablishedSeconds": 0.13084145,
-              "uploadSeconds": 0.000031347,
-              "downloadSeconds": 0.064606754
+              "latency": 0.189504245
             },
             {
-              "connectionEstablishedSeconds": 0.126397034,
-              "uploadSeconds": 0.000055546,
-              "downloadSeconds": 0.060616997
+              "latency": 0.186942299
             },
             {
-              "connectionEstablishedSeconds": 0.133111555,
-              "uploadSeconds": 0.000027453,
-              "downloadSeconds": 0.064002229
+              "latency": 0.193537279
             },
             {
-              "connectionEstablishedSeconds": 0.130509598,
-              "uploadSeconds": 0.000024595,
-              "downloadSeconds": 0.063286999
+              "latency": 0.193651144
             },
             {
-              "connectionEstablishedSeconds": 0.124489373,
-              "uploadSeconds": 0.000020358,
-              "downloadSeconds": 0.060647534
+              "latency": 0.195254859
             },
             {
-              "connectionEstablishedSeconds": 0.130411284,
-              "uploadSeconds": 0.000032773,
-              "downloadSeconds": 0.063491236
+              "latency": 0.19423762
             },
             {
-              "connectionEstablishedSeconds": 0.128244464,
-              "uploadSeconds": 0.000031167,
-              "downloadSeconds": 0.061581905
+              "latency": 0.180641462
             },
             {
-              "connectionEstablishedSeconds": 0.134535364,
-              "uploadSeconds": 0.0000261,
-              "downloadSeconds": 0.064805122
+              "latency": 0.188116333
             },
             {
-              "connectionEstablishedSeconds": 0.13128741,
-              "uploadSeconds": 0.000050089,
-              "downloadSeconds": 0.063958387
+              "latency": 0.178897273
             },
             {
-              "connectionEstablishedSeconds": 0.131984212,
-              "uploadSeconds": 0.000048742,
-              "downloadSeconds": 0.063452836
+              "latency": 0.192992983
             },
             {
-              "connectionEstablishedSeconds": 0.130849195,
-              "uploadSeconds": 0.000027516,
-              "downloadSeconds": 0.062873869
+              "latency": 0.187942247
             },
             {
-              "connectionEstablishedSeconds": 0.132367723,
-              "uploadSeconds": 0.000028605,
-              "downloadSeconds": 0.063657122
+              "latency": 0.194576767
             },
             {
-              "connectionEstablishedSeconds": 0.131658661,
-              "uploadSeconds": 0.000033672,
-              "downloadSeconds": 0.064163204
+              "latency": 0.198206578
             },
             {
-              "connectionEstablishedSeconds": 0.12824671,
-              "uploadSeconds": 0.000054562,
-              "downloadSeconds": 0.061647757
+              "latency": 0.183801656
             },
             {
-              "connectionEstablishedSeconds": 0.126312532,
-              "uploadSeconds": 0.000048885,
-              "downloadSeconds": 0.0607011
+              "latency": 0.184989843
             },
             {
-              "connectionEstablishedSeconds": 0.131843825,
-              "uploadSeconds": 0.000051974,
-              "downloadSeconds": 0.063365075
+              "latency": 0.190091812
             },
             {
-              "connectionEstablishedSeconds": 0.134680989,
-              "uploadSeconds": 0.00005269,
-              "downloadSeconds": 0.064523439
+              "latency": 0.193317719
             },
             {
-              "connectionEstablishedSeconds": 0.131149962,
-              "uploadSeconds": 0.00002484,
-              "downloadSeconds": 0.063040136
+              "latency": 0.184813014
             },
             {
-              "connectionEstablishedSeconds": 0.131163906,
-              "uploadSeconds": 0.00002525,
-              "downloadSeconds": 0.062826936
+              "latency": 0.191116859
             },
             {
-              "connectionEstablishedSeconds": 0.131417191,
-              "uploadSeconds": 0.000033475,
-              "downloadSeconds": 0.063211569
+              "latency": 0.196169983
             },
             {
-              "connectionEstablishedSeconds": 0.129321818,
-              "uploadSeconds": 0.000021761,
-              "downloadSeconds": 0.062047175
+              "latency": 0.192780408
             },
             {
-              "connectionEstablishedSeconds": 0.133113708,
-              "uploadSeconds": 0.000042621,
-              "downloadSeconds": 0.064113658
+              "latency": 0.190984244
             },
             {
-              "connectionEstablishedSeconds": 0.13301228,
-              "uploadSeconds": 0.000047067,
-              "downloadSeconds": 0.063916395
+              "latency": 0.188311158
             },
             {
-              "connectionEstablishedSeconds": 0.12935223,
-              "uploadSeconds": 0.000055131,
-              "downloadSeconds": 0.06210632
+              "latency": 0.19737033
             },
             {
-              "connectionEstablishedSeconds": 0.127551422,
-              "uploadSeconds": 0.000028851,
-              "downloadSeconds": 0.062295024
+              "latency": 0.18764759
             },
             {
-              "connectionEstablishedSeconds": 0.126331834,
-              "uploadSeconds": 0.000045101,
-              "downloadSeconds": 0.061509655
+              "latency": 0.191209337
             },
             {
-              "connectionEstablishedSeconds": 0.131532682,
-              "uploadSeconds": 0.000052301,
-              "downloadSeconds": 0.062588573
+              "latency": 0.185406847
             },
             {
-              "connectionEstablishedSeconds": 0.127919054,
-              "uploadSeconds": 0.000026387,
-              "downloadSeconds": 0.062280304
+              "latency": 0.189690787
             },
             {
-              "connectionEstablishedSeconds": 0.129176435,
-              "uploadSeconds": 0.000052084,
-              "downloadSeconds": 0.062872466
+              "latency": 0.195821776
             },
             {
-              "connectionEstablishedSeconds": 0.128833594,
-              "uploadSeconds": 0.000031408,
-              "downloadSeconds": 0.06280984
+              "latency": 0.189028192
             },
             {
-              "connectionEstablishedSeconds": 0.131885794,
-              "uploadSeconds": 0.000048593,
-              "downloadSeconds": 0.063311591
+              "latency": 0.184094108
             },
             {
-              "connectionEstablishedSeconds": 0.127375808,
-              "uploadSeconds": 0.000049019,
-              "downloadSeconds": 0.061146478
+              "latency": 0.195840529
             },
             {
-              "connectionEstablishedSeconds": 0.12153029,
-              "uploadSeconds": 0.0000186,
-              "downloadSeconds": 0.059066564
+              "latency": 0.185976588
             },
             {
-              "connectionEstablishedSeconds": 0.126343007,
-              "uploadSeconds": 0.000023853,
-              "downloadSeconds": 0.061518531
+              "latency": 0.190297659
             },
             {
-              "connectionEstablishedSeconds": 0.130463081,
-              "uploadSeconds": 0.000024353,
-              "downloadSeconds": 0.062718483
+              "latency": 0.19415231
             },
             {
-              "connectionEstablishedSeconds": 0.130155148,
-              "uploadSeconds": 0.00003375,
-              "downloadSeconds": 0.062584006
+              "latency": 0.192300551
             },
             {
-              "connectionEstablishedSeconds": 0.127377421,
-              "uploadSeconds": 0.000050033,
-              "downloadSeconds": 0.061144804
+              "latency": 0.18688974
             },
             {
-              "connectionEstablishedSeconds": 0.132263716,
-              "uploadSeconds": 0.000053572,
-              "downloadSeconds": 0.064441815
+              "latency": 0.194102376
             },
             {
-              "connectionEstablishedSeconds": 0.130906676,
-              "uploadSeconds": 0.000050526,
-              "downloadSeconds": 0.062900437
+              "latency": 0.195331475
             },
             {
-              "connectionEstablishedSeconds": 0.132053669,
-              "uploadSeconds": 0.000020333,
-              "downloadSeconds": 0.063625907
+              "latency": 0.188563114
             },
             {
-              "connectionEstablishedSeconds": 0.126343969,
-              "uploadSeconds": 0.000048602,
-              "downloadSeconds": 0.061562747
+              "latency": 0.185872473
             },
             {
-              "connectionEstablishedSeconds": 0.13059195,
-              "uploadSeconds": 0.000038032,
-              "downloadSeconds": 0.06359932
+              "latency": 0.193032211
             },
             {
-              "connectionEstablishedSeconds": 0.125306765,
-              "uploadSeconds": 0.000025331,
-              "downloadSeconds": 0.06024974
+              "latency": 0.197383593
             },
             {
-              "connectionEstablishedSeconds": 0.131732246,
-              "uploadSeconds": 0.000054432,
-              "downloadSeconds": 0.063232591
+              "latency": 0.192119836
             },
             {
-              "connectionEstablishedSeconds": 0.135945769,
-              "uploadSeconds": 0.000030859,
-              "downloadSeconds": 0.064563121
+              "latency": 0.190889943
             },
             {
-              "connectionEstablishedSeconds": 0.130211557,
-              "uploadSeconds": 0.000045455,
-              "downloadSeconds": 0.063471773
+              "latency": 0.191506037
             },
             {
-              "connectionEstablishedSeconds": 0.131806838,
-              "uploadSeconds": 0.00004764,
-              "downloadSeconds": 0.063356395
+              "latency": 0.188116542
             },
             {
-              "connectionEstablishedSeconds": 0.126735568,
-              "uploadSeconds": 0.000050096,
-              "downloadSeconds": 0.060697868
+              "latency": 0.193149617
             },
             {
-              "connectionEstablishedSeconds": 0.131880335,
-              "uploadSeconds": 0.000049507,
-              "downloadSeconds": 0.064224812
+              "latency": 0.189654227
             },
             {
-              "connectionEstablishedSeconds": 0.128441843,
-              "uploadSeconds": 0.000047943,
-              "downloadSeconds": 0.06163169
+              "latency": 0.197194289
             },
             {
-              "connectionEstablishedSeconds": 0.132509961,
-              "uploadSeconds": 0.000028055,
-              "downloadSeconds": 0.06452755
+              "latency": 0.191735177
             },
             {
-              "connectionEstablishedSeconds": 0.125300073,
-              "uploadSeconds": 0.000028357,
-              "downloadSeconds": 0.060982066
+              "latency": 0.183793229
             },
             {
-              "connectionEstablishedSeconds": 0.128716768,
-              "uploadSeconds": 0.00004992,
-              "downloadSeconds": 0.061736618
+              "latency": 0.187128502
             },
             {
-              "connectionEstablishedSeconds": 0.129722375,
-              "uploadSeconds": 0.000027386,
-              "downloadSeconds": 0.063147505
+              "latency": 0.196642592
             },
             {
-              "connectionEstablishedSeconds": 0.132837561,
-              "uploadSeconds": 0.000049241,
-              "downloadSeconds": 0.063550104
+              "latency": 0.193083162
             },
             {
-              "connectionEstablishedSeconds": 0.133588995,
-              "uploadSeconds": 0.00003146,
-              "downloadSeconds": 0.065113178
+              "latency": 0.197121
             },
             {
-              "connectionEstablishedSeconds": 0.125069476,
-              "uploadSeconds": 0.000043879,
-              "downloadSeconds": 0.060026593
+              "latency": 0.182526146
             },
             {
-              "connectionEstablishedSeconds": 0.128337827,
-              "uploadSeconds": 0.000030024,
-              "downloadSeconds": 0.062603579
+              "latency": 0.190164274
             },
             {
-              "connectionEstablishedSeconds": 0.129434388,
-              "uploadSeconds": 0.00002842,
-              "downloadSeconds": 0.062977058
+              "latency": 0.19301012
             },
             {
-              "connectionEstablishedSeconds": 0.131637561,
-              "uploadSeconds": 0.000052806,
-              "downloadSeconds": 0.064200689
+              "latency": 0.179123759
             },
             {
-              "connectionEstablishedSeconds": 0.128330334,
-              "uploadSeconds": 0.000027132,
-              "downloadSeconds": 0.061569876
+              "latency": 0.193418771
             },
             {
-              "connectionEstablishedSeconds": 0.130216018,
-              "uploadSeconds": 0.000029266,
-              "downloadSeconds": 0.063386904
+              "latency": 0.190907392
             },
             {
-              "connectionEstablishedSeconds": 0.127663856,
-              "uploadSeconds": 0.000025337,
-              "downloadSeconds": 0.062249422
+              "latency": 0.184022255
             },
             {
-              "connectionEstablishedSeconds": 0.130767875,
-              "uploadSeconds": 0.000048326,
-              "downloadSeconds": 0.062960272
+              "latency": 0.189528065
             },
             {
-              "connectionEstablishedSeconds": 0.13139533,
-              "uploadSeconds": 0.000045884,
-              "downloadSeconds": 0.063091639
+              "latency": 0.191589164
             },
             {
-              "connectionEstablishedSeconds": 0.132284539,
-              "uploadSeconds": 0.000046307,
-              "downloadSeconds": 0.064433543
+              "latency": 0.183404734
             },
             {
-              "connectionEstablishedSeconds": 0.128954497,
-              "uploadSeconds": 0.000046395,
-              "downloadSeconds": 0.061946524
+              "latency": 0.188702213
             },
             {
-              "connectionEstablishedSeconds": 0.13195501,
-              "uploadSeconds": 0.000028593,
-              "downloadSeconds": 0.064321822
+              "latency": 0.190665175
             },
             {
-              "connectionEstablishedSeconds": 0.129169046,
-              "uploadSeconds": 0.000051974,
-              "downloadSeconds": 0.062097421
+              "latency": 0.189880429
             },
             {
-              "connectionEstablishedSeconds": 0.131516378,
-              "uploadSeconds": 0.000018617,
-              "downloadSeconds": 0.064170442
+              "latency": 0.186954515
             },
             {
-              "connectionEstablishedSeconds": 0.126709992,
-              "uploadSeconds": 0.000047803,
-              "downloadSeconds": 0.061721005
+              "latency": 0.193558266
             },
             {
-              "connectionEstablishedSeconds": 0.134914003,
-              "uploadSeconds": 0.000027086,
-              "downloadSeconds": 0.064980719
+              "latency": 0.184772402
             },
             {
-              "connectionEstablishedSeconds": 0.130706472,
-              "uploadSeconds": 0.000028876,
-              "downloadSeconds": 0.062787784
+              "latency": 0.192563743
             },
             {
-              "connectionEstablishedSeconds": 0.132152472,
-              "uploadSeconds": 0.000058598,
-              "downloadSeconds": 0.063518087
+              "latency": 0.192481196
             },
             {
-              "connectionEstablishedSeconds": 0.132736855,
-              "uploadSeconds": 0.000040063,
-              "downloadSeconds": 0.06371304
+              "latency": 0.189357055
             },
             {
-              "connectionEstablishedSeconds": 0.125053099,
-              "uploadSeconds": 0.000049355,
-              "downloadSeconds": 0.060821904
+              "latency": 0.187583363
             },
             {
-              "connectionEstablishedSeconds": 0.130546318,
-              "uploadSeconds": 0.000049924,
-              "downloadSeconds": 0.062680299
+              "latency": 0.191091853
             },
             {
-              "connectionEstablishedSeconds": 0.119719828,
-              "uploadSeconds": 0.0000306,
-              "downloadSeconds": 0.058134544
+              "latency": 0.198970715
             },
             {
-              "connectionEstablishedSeconds": 0.126296963,
-              "uploadSeconds": 0.000025112,
-              "downloadSeconds": 0.060554586
+              "latency": 0.198342929
             },
             {
-              "connectionEstablishedSeconds": 0.128162133,
-              "uploadSeconds": 0.000048249,
-              "downloadSeconds": 0.061574806
+              "latency": 0.189725958
             },
             {
-              "connectionEstablishedSeconds": 0.13229105,
-              "uploadSeconds": 0.00005374,
-              "downloadSeconds": 0.063552066
+              "latency": 0.194753097
             },
             {
-              "connectionEstablishedSeconds": 0.129765991,
-              "uploadSeconds": 0.000046291,
-              "downloadSeconds": 0.063203821
+              "latency": 0.18938075
             }
           ],
           "implementation": "go-libp2p",
@@ -4031,173 +2711,173 @@
   "pings": {
     "unit": "s",
     "results": [
-      0.0615,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0615,
-      0.061399999999999996,
-      0.0616,
-      0.0615,
-      0.061399999999999996,
-      0.061799999999999994,
-      0.0615,
-      0.061399999999999996,
-      0.0615,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0616,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0616,
-      0.061399999999999996,
-      0.0615,
-      0.062,
-      0.061399999999999996,
-      0.0625,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0616,
-      0.061799999999999994,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.062200000000000005,
-      0.061399999999999996,
-      0.0615,
-      0.0627,
-      0.062200000000000005,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0615,
-      0.061399999999999996,
-      0.0615,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0619,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0615,
-      0.061399999999999996,
-      0.0615,
-      0.061799999999999994,
-      0.0615,
-      0.061399999999999996,
-      0.062299999999999994,
-      0.061399999999999996,
-      0.061700000000000005,
-      0.061399999999999996,
-      0.062,
-      0.0616,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0615,
-      0.061399999999999996,
-      0.0616,
-      0.0615,
-      0.061399999999999996,
-      0.0616,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0615,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.061399999999999996
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.060899999999999996,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.060899999999999996,
+      0.0606,
+      0.0606,
+      0.0608,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.06559999999999999,
+      0.0644,
+      0.060899999999999996,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0605,
+      0.0605,
+      0.0605,
+      0.0605,
+      0.0605,
+      0.0605,
+      0.0605,
+      0.0605,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606
     ]
   },
   "iperf": {
     "unit": "bit/s",
     "results": [
-      3330000000,
-      3340000000,
-      3330000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3330000000,
-      3330000000,
-      3330000000,
-      3330000000,
-      3330000000,
-      3330000000,
-      3340000000,
-      3330000000,
-      3340000000,
-      3340000000,
-      3330000000,
-      3330000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3340000000,
-      3300000000,
-      3290000000,
-      3280000000,
-      3280000000,
-      3280000000,
-      3320000000,
-      3290000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3350000000,
-      3330000000,
-      2830000000
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3230000000,
+      3230000000,
+      3230000000,
+      3220000000,
+      3190000000,
+      3180000000,
+      3190000000,
+      3190000000,
+      3200000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3240000000,
+      3250000000,
+      3240000000,
+      3230000000,
+      3200000000,
+      3200000000,
+      3200000000,
+      3200000000,
+      3200000000,
+      3250000000,
+      3250000000,
+      3240000000,
+      3250000000,
+      3250000000,
+      3260000000,
+      3250000000,
+      3260000000,
+      3250000000,
+      3250000000,
+      3250000000,
+      3260000000,
+      3250000000,
+      3250000000,
+      3230000000,
+      2760000000
     ]
   }
 }

--- a/perf/runner/benchmark-results.json
+++ b/perf/runner/benchmark-results.json
@@ -7,19 +7,19 @@
         {
           "result": [
             {
-              "latency": 1.076291736
+              "latency": 1.089163438
             },
             {
-              "latency": 1.054123943
+              "latency": 1.073140141
             },
             {
-              "latency": 1.050200065
+              "latency": 1.092413254
             },
             {
-              "latency": 1.041819505
+              "latency": 1.0698477
             },
             {
-              "latency": 1.057797816
+              "latency": 1.07078984
             }
           ],
           "implementation": "quic-go",
@@ -29,19 +29,19 @@
         {
           "result": [
             {
-              "latency": 44.16534811
+              "latency": 45.273421797
             },
             {
-              "latency": 45.695923529
+              "latency": 47.888878312
             },
             {
-              "latency": 46.254273865
+              "latency": 44.065128767
             },
             {
-              "latency": 45.14780706
+              "latency": 48.282910529
             },
             {
-              "latency": 43.581983029
+              "latency": 45.498755791
             }
           ],
           "implementation": "rust-libp2p",
@@ -51,19 +51,19 @@
         {
           "result": [
             {
-              "latency": 15.019096329
+              "latency": 10.259611927
             },
             {
-              "latency": 7.116648387
+              "latency": 6.97696991
             },
             {
-              "latency": 15.388309106
+              "latency": 6.313410241
             },
             {
-              "latency": 14.228255102
+              "latency": 11.681981744
             },
             {
-              "latency": 16.918129636
+              "latency": 16.21113012
             }
           ],
           "implementation": "rust-libp2p",
@@ -73,19 +73,19 @@
         {
           "result": [
             {
-              "latency": 1.494282053
+              "latency": 1.4748042510000001
             },
             {
-              "latency": 1.4723175560000001
+              "latency": 1.421224037
             },
             {
-              "latency": 1.414392724
+              "latency": 1.4923433400000001
             },
             {
-              "latency": 1.528559929
+              "latency": 1.484234063
             },
             {
-              "latency": 1.454336788
+              "latency": 1.512597599
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -95,19 +95,19 @@
         {
           "result": [
             {
-              "latency": 2.703742719
+              "latency": 2.972323978
             },
             {
-              "latency": 2.730379033
+              "latency": 2.696220451
             },
             {
-              "latency": 2.837615297
+              "latency": 2.802687287
             },
             {
-              "latency": 2.804376235
+              "latency": 2.920361255
             },
             {
-              "latency": 2.672181984
+              "latency": 2.703010861
             }
           ],
           "implementation": "https",
@@ -117,19 +117,19 @@
         {
           "result": [
             {
-              "latency": 3.496662055
+              "latency": 3.167962882
             },
             {
-              "latency": 3.307046005
+              "latency": 3.4471643690000002
             },
             {
-              "latency": 3.46973589
+              "latency": 3.4640786009999998
             },
             {
-              "latency": 3.180000734
+              "latency": 3.145722324
             },
             {
-              "latency": 3.24012571
+              "latency": 3.536917435
             }
           ],
           "implementation": "go-libp2p",
@@ -139,19 +139,19 @@
         {
           "result": [
             {
-              "latency": 1.501449945
+              "latency": 1.5263650229999999
             },
             {
-              "latency": 1.4143393
+              "latency": 1.509688272
             },
             {
-              "latency": 1.42933566
+              "latency": 1.474257421
             },
             {
-              "latency": 1.484004778
+              "latency": 1.436329921
             },
             {
-              "latency": 1.5304768370000001
+              "latency": 1.5185167179999999
             }
           ],
           "implementation": "go-libp2p",
@@ -171,19 +171,19 @@
         {
           "result": [
             {
-              "latency": 1.189993868
+              "latency": 1.126518966
             },
             {
-              "latency": 1.146422362
+              "latency": 1.118475179
             },
             {
-              "latency": 1.116911238
+              "latency": 1.129681525
             },
             {
-              "latency": 1.138824115
+              "latency": 1.146352167
             },
             {
-              "latency": 1.148605318
+              "latency": 1.104298922
             }
           ],
           "implementation": "quic-go",
@@ -193,19 +193,19 @@
         {
           "result": [
             {
-              "latency": 46.375497756
+              "latency": 43.865104152
             },
             {
-              "latency": 45.08127772
+              "latency": 47.064488992
             },
             {
-              "latency": 47.330392228
+              "latency": 44.090104578
             },
             {
-              "latency": 45.595953236
+              "latency": 48.396326920999996
             },
             {
-              "latency": 45.609456533
+              "latency": 48.422155604
             }
           ],
           "implementation": "rust-libp2p",
@@ -215,19 +215,19 @@
         {
           "result": [
             {
-              "latency": 12.051492852
+              "latency": 15.218780544
             },
             {
-              "latency": 13.478499355
+              "latency": 13.081463441
             },
             {
-              "latency": 16.047649583
+              "latency": 11.000094613
             },
             {
-              "latency": 12.588987083
+              "latency": 6.51186057
             },
             {
-              "latency": 17.816787494
+              "latency": 11.331908448
             }
           ],
           "implementation": "rust-libp2p",
@@ -237,19 +237,19 @@
         {
           "result": [
             {
-              "latency": 1.431002173
+              "latency": 1.48602608
             },
             {
-              "latency": 1.452056393
+              "latency": 1.481363488
             },
             {
-              "latency": 1.509078116
+              "latency": 1.449341325
             },
             {
-              "latency": 1.478887671
+              "latency": 1.504867138
             },
             {
-              "latency": 1.462417322
+              "latency": 1.47313451
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -259,19 +259,19 @@
         {
           "result": [
             {
-              "latency": 3.038907166
+              "latency": 2.774002117
             },
             {
-              "latency": 2.824677411
+              "latency": 2.764803904
             },
             {
-              "latency": 2.7438175769999997
+              "latency": 2.671047053
             },
             {
-              "latency": 2.731011736
+              "latency": 2.63024296
             },
             {
-              "latency": 2.774879066
+              "latency": 2.801801962
             }
           ],
           "implementation": "https",
@@ -281,19 +281,19 @@
         {
           "result": [
             {
-              "latency": 3.147791355
+              "latency": 3.190488386
             },
             {
-              "latency": 3.421461513
+              "latency": 3.411670796
             },
             {
-              "latency": 3.266139658
+              "latency": 3.358084792
             },
             {
-              "latency": 3.258962067
+              "latency": 3.541594134
             },
             {
-              "latency": 3.199516925
+              "latency": 3.224666796
             }
           ],
           "implementation": "go-libp2p",
@@ -303,19 +303,19 @@
         {
           "result": [
             {
-              "latency": 1.491891099
+              "latency": 1.506189631
             },
             {
-              "latency": 1.489047447
+              "latency": 1.436941623
             },
             {
-              "latency": 1.454172726
+              "latency": 1.5130232019999998
             },
             {
-              "latency": 1.459982982
+              "latency": 1.436359458
             },
             {
-              "latency": 1.460719245
+              "latency": 7.50142514
             }
           ],
           "implementation": "go-libp2p",
@@ -335,304 +335,304 @@
         {
           "result": [
             {
-              "latency": 0.128778316
+              "latency": 0.124505378
             },
             {
-              "latency": 0.127469537
+              "latency": 0.123507272
             },
             {
-              "latency": 0.131561963
+              "latency": 0.128361262
             },
             {
-              "latency": 0.129618787
+              "latency": 0.122621238
             },
             {
-              "latency": 0.121589047
+              "latency": 0.131911723
             },
             {
-              "latency": 0.120087889
+              "latency": 0.12826431
             },
             {
-              "latency": 0.129238066
+              "latency": 0.128880681
             },
             {
-              "latency": 0.128154375
+              "latency": 0.124449259
             },
             {
-              "latency": 0.122632899
+              "latency": 0.125871107
             },
             {
-              "latency": 0.128841497
+              "latency": 0.122762879
             },
             {
-              "latency": 0.129398769
+              "latency": 0.126629308
             },
             {
-              "latency": 0.127577694
+              "latency": 0.126522502
             },
             {
-              "latency": 0.130814101
+              "latency": 0.125500917
             },
             {
-              "latency": 0.127332431
+              "latency": 0.123300641
             },
             {
-              "latency": 0.122099479
+              "latency": 0.125217973
             },
             {
-              "latency": 0.127720132
+              "latency": 0.127126926
             },
             {
-              "latency": 0.128957147
+              "latency": 0.123303591
             },
             {
-              "latency": 0.125100613
+              "latency": 0.125056704
             },
             {
-              "latency": 0.126716213
+              "latency": 0.122072976
             },
             {
-              "latency": 0.127232762
+              "latency": 0.129341243
             },
             {
-              "latency": 0.127697753
+              "latency": 0.127575843
             },
             {
-              "latency": 0.124250773
+              "latency": 0.127904913
             },
             {
-              "latency": 0.125667603
+              "latency": 0.123418496
             },
             {
-              "latency": 0.123547899
+              "latency": 0.121984978
             },
             {
-              "latency": 0.126130999
+              "latency": 0.126993306
             },
             {
-              "latency": 0.118363609
+              "latency": 0.129280612
             },
             {
-              "latency": 0.127593263
+              "latency": 0.12474134
             },
             {
-              "latency": 0.12252807
+              "latency": 0.127936098
             },
             {
-              "latency": 0.120965223
+              "latency": 0.12673381
             },
             {
-              "latency": 0.131540436
+              "latency": 0.127438003
             },
             {
-              "latency": 0.126413356
+              "latency": 0.124471246
             },
             {
-              "latency": 0.127671877
+              "latency": 0.132203778
             },
             {
-              "latency": 0.121485181
+              "latency": 0.130657916
             },
             {
-              "latency": 0.123425921
+              "latency": 0.128125495
             },
             {
-              "latency": 0.123083684
+              "latency": 0.124296967
             },
             {
-              "latency": 0.119423222
+              "latency": 0.129235874
             },
             {
-              "latency": 0.12741316
+              "latency": 0.13049939
             },
             {
-              "latency": 0.120603398
+              "latency": 0.124897633
             },
             {
-              "latency": 0.130413205
+              "latency": 0.131088615
             },
             {
-              "latency": 0.129347356
+              "latency": 0.127795623
             },
             {
-              "latency": 0.128436254
+              "latency": 0.128448128
             },
             {
-              "latency": 0.125031583
+              "latency": 0.124821704
             },
             {
-              "latency": 0.123462743
+              "latency": 0.126442362
             },
             {
-              "latency": 0.124576027
+              "latency": 0.123138772
             },
             {
-              "latency": 0.125252087
+              "latency": 0.129509366
             },
             {
-              "latency": 0.126904966
+              "latency": 0.124727948
             },
             {
-              "latency": 0.121406829
+              "latency": 0.125270916
             },
             {
-              "latency": 0.126998465
+              "latency": 0.1255401
             },
             {
-              "latency": 0.129123316
+              "latency": 0.125516539
             },
             {
-              "latency": 0.129215614
+              "latency": 0.123706295
             },
             {
-              "latency": 0.125167593
+              "latency": 0.122597258
             },
             {
-              "latency": 0.128404373
+              "latency": 0.130149993
             },
             {
-              "latency": 0.129171708
+              "latency": 0.126368598
             },
             {
-              "latency": 0.121965573
+              "latency": 0.127624864
             },
             {
-              "latency": 0.124967033
+              "latency": 0.129374551
             },
             {
-              "latency": 0.127878265
+              "latency": 0.125880419
             },
             {
-              "latency": 0.121986949
+              "latency": 0.125832137
             },
             {
-              "latency": 0.122498511
+              "latency": 0.12155412
             },
             {
-              "latency": 0.127003199
+              "latency": 0.124714985
             },
             {
-              "latency": 0.124850559
+              "latency": 0.129117674
             },
             {
-              "latency": 0.126491896
+              "latency": 0.127559273
             },
             {
-              "latency": 0.122218999
+              "latency": 0.129352257
             },
             {
-              "latency": 0.123493427
+              "latency": 0.131843659
             },
             {
-              "latency": 0.128767318
+              "latency": 0.126192368
             },
             {
-              "latency": 0.130736413
+              "latency": 0.130678167
             },
             {
-              "latency": 0.130598075
+              "latency": 0.130014741
             },
             {
-              "latency": 0.123158153
+              "latency": 0.124657447
             },
             {
-              "latency": 0.130519919
+              "latency": 0.129176184
             },
             {
-              "latency": 0.129149146
+              "latency": 0.128468954
             },
             {
-              "latency": 0.127126663
+              "latency": 0.130181924
             },
             {
-              "latency": 0.131662174
+              "latency": 0.127414184
             },
             {
-              "latency": 0.123208875
+              "latency": 0.127303225
             },
             {
-              "latency": 0.128711221
+              "latency": 0.12359558
             },
             {
-              "latency": 0.123587744
+              "latency": 0.123642652
             },
             {
-              "latency": 0.124567763
+              "latency": 0.125675948
             },
             {
-              "latency": 0.125842806
+              "latency": 0.129708003
             },
             {
-              "latency": 0.131417373
+              "latency": 0.126260732
             },
             {
-              "latency": 0.128938279
+              "latency": 0.129271369
             },
             {
-              "latency": 0.123769083
+              "latency": 0.128927981
             },
             {
-              "latency": 0.121339546
+              "latency": 0.123341976
             },
             {
-              "latency": 0.129764257
+              "latency": 0.123585708
             },
             {
-              "latency": 0.124688569
+              "latency": 0.125299635
             },
             {
-              "latency": 0.130251241
+              "latency": 0.127492637
             },
             {
-              "latency": 0.127405207
+              "latency": 0.129617109
             },
             {
-              "latency": 0.120138297
+              "latency": 0.123018172
             },
             {
-              "latency": 0.123446696
+              "latency": 0.123559394
             },
             {
-              "latency": 0.123607508
+              "latency": 0.129513163
             },
             {
-              "latency": 0.132104626
+              "latency": 0.131009225
             },
             {
-              "latency": 0.127348688
+              "latency": 0.128555611
             },
             {
-              "latency": 0.122169618
+              "latency": 0.121640639
             },
             {
-              "latency": 0.120313531
+              "latency": 0.12480892
             },
             {
-              "latency": 0.124832798
+              "latency": 0.128437919
             },
             {
-              "latency": 0.124513629
+              "latency": 0.126605087
             },
             {
-              "latency": 0.124865312
+              "latency": 0.131375676
             },
             {
-              "latency": 0.125800435
+              "latency": 0.123629706
             },
             {
-              "latency": 0.129231798
+              "latency": 0.130127735
             },
             {
-              "latency": 0.122101501
+              "latency": 0.12624402
             },
             {
-              "latency": 0.12246849
+              "latency": 0.121646371
             },
             {
-              "latency": 0.118254725
+              "latency": 0.123268179
             },
             {
-              "latency": 0.129137945
+              "latency": 0.130700338
             }
           ],
           "implementation": "quic-go",
@@ -642,304 +642,304 @@
         {
           "result": [
             {
-              "latency": 0.194451835
+              "latency": 0.182142109
             },
             {
-              "latency": 0.186451174
+              "latency": 0.183418869
             },
             {
-              "latency": 0.193438491
+              "latency": 0.190336514
             },
             {
-              "latency": 0.190564768
+              "latency": 0.189183544
             },
             {
-              "latency": 0.187831091
+              "latency": 0.190448597
             },
             {
-              "latency": 0.182534244
+              "latency": 0.185565373
             },
             {
-              "latency": 0.18337949
+              "latency": 0.19241759
             },
             {
-              "latency": 0.190037528
+              "latency": 0.18336685
             },
             {
-              "latency": 0.194479668
+              "latency": 0.196292274
             },
             {
-              "latency": 0.178294527
+              "latency": 0.190831235
             },
             {
-              "latency": 0.188886096
+              "latency": 0.190520245
             },
             {
-              "latency": 0.189220322
+              "latency": 0.183510279
             },
             {
-              "latency": 0.180851106
+              "latency": 0.192077921
             },
             {
-              "latency": 0.184920659
+              "latency": 0.177140708
             },
             {
-              "latency": 0.184796303
+              "latency": 0.186153297
             },
             {
-              "latency": 0.194234811
+              "latency": 0.193720369
             },
             {
-              "latency": 0.194405267
+              "latency": 0.184597678
             },
             {
-              "latency": 0.192226653
+              "latency": 0.189787222
             },
             {
-              "latency": 0.185539979
+              "latency": 0.190848864
             },
             {
-              "latency": 0.196452274
+              "latency": 0.185833888
             },
             {
-              "latency": 0.189949096
+              "latency": 0.179622145
             },
             {
-              "latency": 0.195212551
+              "latency": 0.185950133
             },
             {
-              "latency": 0.189861751
+              "latency": 0.193546567
             },
             {
-              "latency": 0.179555303
+              "latency": 0.183940226
             },
             {
-              "latency": 0.180013864
+              "latency": 0.187916448
             },
             {
-              "latency": 0.190173924
+              "latency": 0.18887184
             },
             {
-              "latency": 0.194005551
+              "latency": 0.177176334
             },
             {
-              "latency": 0.190004745
+              "latency": 0.186606359
             },
             {
-              "latency": 0.193823196
+              "latency": 0.189386055
             },
             {
-              "latency": 0.19171575
+              "latency": 0.178494779
             },
             {
-              "latency": 0.180711271
+              "latency": 0.188323537
             },
             {
-              "latency": 0.191806515
+              "latency": 0.186141735
             },
             {
-              "latency": 0.193719375
+              "latency": 0.1869658
             },
             {
-              "latency": 0.18798901
+              "latency": 0.194249366
             },
             {
-              "latency": 0.184585025
+              "latency": 0.187236752
             },
             {
-              "latency": 0.18013775
+              "latency": 0.176934938
             },
             {
-              "latency": 0.182118414
+              "latency": 0.194663586
             },
             {
-              "latency": 0.187322986
+              "latency": 0.183711071
             },
             {
-              "latency": 0.192263869
+              "latency": 0.189984427
             },
             {
-              "latency": 0.189206943
+              "latency": 0.183232165
             },
             {
-              "latency": 0.182054991
+              "latency": 0.183576968
             },
             {
-              "latency": 0.191965517
+              "latency": 0.193323702
             },
             {
-              "latency": 0.192388417
+              "latency": 0.186986711
             },
             {
-              "latency": 0.187836666
+              "latency": 0.185890529
             },
             {
-              "latency": 0.192673837
+              "latency": 0.179914275
             },
             {
-              "latency": 0.190358423
+              "latency": 0.184896773
             },
             {
-              "latency": 0.178843271
+              "latency": 0.189654162
             },
             {
-              "latency": 0.190329395
+              "latency": 0.190164815
             },
             {
-              "latency": 0.188767856
+              "latency": 0.197052122
             },
             {
-              "latency": 0.193039113
+              "latency": 0.182139597
             },
             {
-              "latency": 0.189378861
+              "latency": 0.196538185
             },
             {
-              "latency": 0.180581338
+              "latency": 0.1930329
             },
             {
-              "latency": 0.190311719
+              "latency": 0.184440821
             },
             {
-              "latency": 0.190238506
+              "latency": 0.194332335
             },
             {
-              "latency": 0.1900226
+              "latency": 0.186481446
             },
             {
-              "latency": 0.18997099
+              "latency": 0.19602474
             },
             {
-              "latency": 0.18736788
+              "latency": 0.18457142
             },
             {
-              "latency": 0.175769002
+              "latency": 0.184163845
             },
             {
-              "latency": 0.175167531
+              "latency": 0.183166516
             },
             {
-              "latency": 0.181570747
+              "latency": 0.188089178
             },
             {
-              "latency": 0.191929862
+              "latency": 0.190753109
             },
             {
-              "latency": 0.189411135
+              "latency": 0.194009121
             },
             {
-              "latency": 0.192853281
+              "latency": 0.18160685
             },
             {
-              "latency": 0.192835651
+              "latency": 0.181751918
             },
             {
-              "latency": 0.193717575
+              "latency": 0.185718414
             },
             {
-              "latency": 0.182864022
+              "latency": 0.186434768
             },
             {
-              "latency": 0.19361636
+              "latency": 0.192428796
             },
             {
-              "latency": 0.193591332
+              "latency": 0.191096623
             },
             {
-              "latency": 0.180649164
+              "latency": 0.194285859
             },
             {
-              "latency": 0.189260578
+              "latency": 0.183271124
             },
             {
-              "latency": 0.193246694
+              "latency": 0.183652231
             },
             {
-              "latency": 0.187795838
+              "latency": 0.177581764
             },
             {
-              "latency": 0.179139719
+              "latency": 0.192038252
             },
             {
-              "latency": 0.185541725
+              "latency": 0.185681352
             },
             {
-              "latency": 0.192129952
+              "latency": 0.186534748
             },
             {
-              "latency": 0.185659853
+              "latency": 0.191146252
             },
             {
-              "latency": 0.196146717
+              "latency": 0.18588408
             },
             {
-              "latency": 0.191922301
+              "latency": 0.182325286
             },
             {
-              "latency": 0.19164444
+              "latency": 0.189503391
             },
             {
-              "latency": 0.187682375
+              "latency": 0.180867623
             },
             {
-              "latency": 0.185163314
+              "latency": 0.188129589
             },
             {
-              "latency": 0.183345077
+              "latency": 0.193286007
             },
             {
-              "latency": 0.185399162
+              "latency": 0.191196184
             },
             {
-              "latency": 0.180919665
+              "latency": 0.186104078
             },
             {
-              "latency": 0.189076171
+              "latency": 0.186359139
             },
             {
-              "latency": 0.188332826
+              "latency": 0.193051604
             },
             {
-              "latency": 0.187848309
+              "latency": 0.189455076
             },
             {
-              "latency": 0.181638079
+              "latency": 0.188675599
             },
             {
-              "latency": 0.186504867
+              "latency": 0.184970505
             },
             {
-              "latency": 0.186598922
+              "latency": 0.184096101
             },
             {
-              "latency": 0.187723356
+              "latency": 0.194713781
             },
             {
-              "latency": 0.189050685
+              "latency": 0.181522647
             },
             {
-              "latency": 0.191821807
+              "latency": 0.19489057
             },
             {
-              "latency": 0.185332018
+              "latency": 0.178497205
             },
             {
-              "latency": 0.194105184
+              "latency": 0.188164147
             },
             {
-              "latency": 0.187772729
+              "latency": 0.184548293
             },
             {
-              "latency": 0.18611103
+              "latency": 0.185229968
             },
             {
-              "latency": 0.192435064
+              "latency": 0.192957235
             },
             {
-              "latency": 0.185084407
+              "latency": 0.194910025
             },
             {
-              "latency": 0.19300613
+              "latency": 0.190047297
             }
           ],
           "implementation": "rust-libp2p",
@@ -949,304 +949,304 @@
         {
           "result": [
             {
-              "latency": 0.132473722
+              "latency": 0.125929233
             },
             {
-              "latency": 0.123907839
+              "latency": 0.121072551
             },
             {
-              "latency": 0.123883659
+              "latency": 0.125848182
             },
             {
-              "latency": 0.127584568
+              "latency": 0.129329871
             },
             {
-              "latency": 0.130431119
+              "latency": 0.128163607
             },
             {
-              "latency": 0.12941286
+              "latency": 0.118532779
             },
             {
-              "latency": 0.132304419
+              "latency": 0.129157593
             },
             {
-              "latency": 0.129690487
+              "latency": 0.125845954
             },
             {
-              "latency": 0.127371591
+              "latency": 0.125662769
             },
             {
-              "latency": 0.126363515
+              "latency": 0.126540638
             },
             {
-              "latency": 0.122298816
+              "latency": 0.125871725
             },
             {
-              "latency": 0.127523061
+              "latency": 0.126596316
             },
             {
-              "latency": 0.126499856
+              "latency": 0.125187442
             },
             {
-              "latency": 0.129228008
+              "latency": 0.123659608
             },
             {
-              "latency": 0.131050145
+              "latency": 0.12949364
             },
             {
-              "latency": 0.122523645
+              "latency": 0.130970251
             },
             {
-              "latency": 0.129565031
+              "latency": 0.125447373
             },
             {
-              "latency": 0.128277824
+              "latency": 0.129110039
             },
             {
-              "latency": 0.130131171
+              "latency": 0.131000574
             },
             {
-              "latency": 0.121801737
+              "latency": 0.122849665
             },
             {
-              "latency": 0.129169755
+              "latency": 0.124812925
             },
             {
-              "latency": 0.129957882
+              "latency": 0.123836997
             },
             {
-              "latency": 0.121018887
+              "latency": 0.122528106
             },
             {
-              "latency": 0.119571043
+              "latency": 0.128562099
             },
             {
-              "latency": 0.125826218
+              "latency": 0.130371901
             },
             {
-              "latency": 0.126335034
+              "latency": 0.125656524
             },
             {
-              "latency": 0.130856212
+              "latency": 0.125463656
             },
             {
-              "latency": 0.127233231
+              "latency": 0.12386604
             },
             {
-              "latency": 0.127985903
+              "latency": 0.127812527
             },
             {
-              "latency": 0.124884129
+              "latency": 0.121816074
             },
             {
-              "latency": 0.121464
+              "latency": 0.126008173
             },
             {
-              "latency": 0.127073324
+              "latency": 0.123649717
             },
             {
-              "latency": 0.124166892
+              "latency": 0.126184539
             },
             {
-              "latency": 0.127758126
+              "latency": 0.125785432
             },
             {
-              "latency": 0.128962933
+              "latency": 0.128369338
             },
             {
-              "latency": 0.126441492
+              "latency": 0.125884592
             },
             {
-              "latency": 0.124466931
+              "latency": 0.125655989
             },
             {
-              "latency": 0.130062954
+              "latency": 0.124030215
             },
             {
-              "latency": 0.127704648
+              "latency": 0.125159162
             },
             {
-              "latency": 0.124660515
+              "latency": 0.128989463
             },
             {
-              "latency": 0.126121013
+              "latency": 0.130226153
             },
             {
-              "latency": 0.123013337
+              "latency": 0.132187883
             },
             {
-              "latency": 0.127792705
+              "latency": 0.119924263
             },
             {
-              "latency": 0.129753899
+              "latency": 0.129930038
             },
             {
-              "latency": 0.122129055
+              "latency": 0.123705312
             },
             {
-              "latency": 0.123229192
+              "latency": 0.130744207
             },
             {
-              "latency": 0.126501385
+              "latency": 0.131017902
             },
             {
-              "latency": 0.126055576
+              "latency": 0.124433967
             },
             {
-              "latency": 0.122623908
+              "latency": 0.125671995
             },
             {
-              "latency": 0.127836704
+              "latency": 0.127924266
             },
             {
-              "latency": 0.128006421
+              "latency": 0.129294495
             },
             {
-              "latency": 0.129010036
+              "latency": 0.129356077
             },
             {
-              "latency": 0.121786081
+              "latency": 0.12818679
             },
             {
-              "latency": 0.130556038
+              "latency": 0.12610988
             },
             {
-              "latency": 0.129327295
+              "latency": 0.130829249
             },
             {
-              "latency": 0.127269595
+              "latency": 0.130490764
             },
             {
-              "latency": 0.120584624
+              "latency": 0.12507386
             },
             {
-              "latency": 0.127407605
+              "latency": 0.126480077
             },
             {
-              "latency": 0.132209438
+              "latency": 0.124513442
             },
             {
-              "latency": 0.126888193
+              "latency": 0.132014176
             },
             {
-              "latency": 0.124783315
+              "latency": 0.121831654
             },
             {
-              "latency": 0.126951769
+              "latency": 0.128826301
             },
             {
-              "latency": 0.125702211
+              "latency": 0.12555997
             },
             {
-              "latency": 0.130318831
+              "latency": 0.12352345
             },
             {
-              "latency": 0.12911532
+              "latency": 0.12977827
             },
             {
-              "latency": 0.128259457
+              "latency": 0.124230729
             },
             {
-              "latency": 0.123542554
+              "latency": 0.131989337
             },
             {
-              "latency": 0.127796734
+              "latency": 0.124493011
             },
             {
-              "latency": 0.130587252
+              "latency": 0.122490063
             },
             {
-              "latency": 0.127228686
+              "latency": 0.127058744
             },
             {
-              "latency": 0.125676443
+              "latency": 0.1295083
             },
             {
-              "latency": 0.131576634
+              "latency": 0.126175987
             },
             {
-              "latency": 0.124277581
+              "latency": 0.127590626
             },
             {
-              "latency": 0.129109379
+              "latency": 0.126419929
             },
             {
-              "latency": 0.127632488
+              "latency": 0.131350932
             },
             {
-              "latency": 0.130513684
+              "latency": 0.128651632
             },
             {
-              "latency": 0.123783327
+              "latency": 0.12542208
             },
             {
-              "latency": 0.126000158
+              "latency": 0.12562436
             },
             {
-              "latency": 0.128634206
+              "latency": 0.1318564
             },
             {
-              "latency": 0.129204082
+              "latency": 0.127004922
             },
             {
-              "latency": 0.129297543
+              "latency": 0.128239414
             },
             {
-              "latency": 0.125235293
+              "latency": 0.121725391
             },
             {
-              "latency": 0.130794466
+              "latency": 0.124930389
             },
             {
-              "latency": 0.125732436
+              "latency": 0.130193632
             },
             {
-              "latency": 0.12190303
+              "latency": 0.129390284
             },
             {
-              "latency": 0.129105473
+              "latency": 0.126962538
             },
             {
-              "latency": 0.126836548
+              "latency": 0.122395395
             },
             {
-              "latency": 0.128431996
+              "latency": 0.128916575
             },
             {
-              "latency": 0.129480684
+              "latency": 0.129471157
             },
             {
-              "latency": 0.128740291
+              "latency": 0.129341022
             },
             {
-              "latency": 0.129401259
+              "latency": 0.127512712
             },
             {
-              "latency": 0.125434555
+              "latency": 0.123958151
             },
             {
-              "latency": 0.12911872
+              "latency": 0.125635969
             },
             {
-              "latency": 0.125560768
+              "latency": 0.129553995
             },
             {
-              "latency": 0.120354713
+              "latency": 0.130977204
             },
             {
-              "latency": 0.123648391
+              "latency": 0.129604158
             },
             {
-              "latency": 0.12950968
+              "latency": 0.124996375
             },
             {
-              "latency": 0.125939919
+              "latency": 0.12165574
             },
             {
-              "latency": 0.122573392
+              "latency": 0.130553196
             },
             {
-              "latency": 0.122343263
+              "latency": 0.127085119
             }
           ],
           "implementation": "rust-libp2p",
@@ -1256,304 +1256,304 @@
         {
           "result": [
             {
-              "latency": 0.132982741
+              "latency": 0.124711663
             },
             {
-              "latency": 0.120039262
+              "latency": 0.12794112
             },
             {
-              "latency": 0.12331894
+              "latency": 0.129447353
             },
             {
-              "latency": 0.127802802
+              "latency": 0.124307094
             },
             {
-              "latency": 0.124956771
+              "latency": 0.123884021
             },
             {
-              "latency": 0.125928828
+              "latency": 0.129099674
             },
             {
-              "latency": 0.128977437
+              "latency": 0.121006904
             },
             {
-              "latency": 0.129853212
+              "latency": 0.124049721
             },
             {
-              "latency": 0.128628306
+              "latency": 0.131329485
             },
             {
-              "latency": 0.123053472
+              "latency": 0.125813789
             },
             {
-              "latency": 0.124259507
+              "latency": 0.130221893
             },
             {
-              "latency": 0.124676891
+              "latency": 0.125753525
             },
             {
-              "latency": 0.127004035
+              "latency": 0.126908245
             },
             {
-              "latency": 0.128784202
+              "latency": 0.125547165
             },
             {
-              "latency": 0.128030182
+              "latency": 0.124629962
             },
             {
-              "latency": 0.127765475
+              "latency": 0.123851542
             },
             {
-              "latency": 0.129510112
+              "latency": 0.128414478
             },
             {
-              "latency": 0.121169853
+              "latency": 0.129910918
             },
             {
-              "latency": 0.128672583
+              "latency": 0.126788404
             },
             {
-              "latency": 0.128438711
+              "latency": 0.128203134
             },
             {
-              "latency": 0.130829935
+              "latency": 0.127606658
             },
             {
-              "latency": 0.127941703
+              "latency": 0.119968361
             },
             {
-              "latency": 0.124612603
+              "latency": 0.122353299
             },
             {
-              "latency": 0.12903103
+              "latency": 0.129250484
             },
             {
-              "latency": 0.128902837
+              "latency": 0.12788092
             },
             {
-              "latency": 0.132204804
+              "latency": 0.118847764
             },
             {
-              "latency": 0.127708521
+              "latency": 0.121738002
             },
             {
-              "latency": 0.124726022
+              "latency": 0.126342096
             },
             {
-              "latency": 0.12779992
+              "latency": 0.129250406
             },
             {
-              "latency": 0.125644837
+              "latency": 0.122838449
             },
             {
-              "latency": 0.132090723
+              "latency": 0.121817368
             },
             {
-              "latency": 0.12641923
+              "latency": 0.126083413
             },
             {
-              "latency": 0.123609485
+              "latency": 0.12428253
             },
             {
-              "latency": 0.127542777
+              "latency": 0.12564673
             },
             {
-              "latency": 0.130249325
+              "latency": 0.125141166
             },
             {
-              "latency": 0.11871774
+              "latency": 0.127601021
             },
             {
-              "latency": 0.130873923
+              "latency": 0.123678913
             },
             {
-              "latency": 0.131143898
+              "latency": 0.123875276
             },
             {
-              "latency": 0.126906674
+              "latency": 0.125945386
             },
             {
-              "latency": 0.128430274
+              "latency": 0.128435138
             },
             {
-              "latency": 0.126165267
+              "latency": 0.123944771
             },
             {
-              "latency": 0.128249568
+              "latency": 0.128793859
             },
             {
-              "latency": 0.126736323
+              "latency": 0.122357755
             },
             {
-              "latency": 0.129403641
+              "latency": 0.126319784
             },
             {
-              "latency": 0.128606683
+              "latency": 0.123500791
             },
             {
-              "latency": 0.126262637
+              "latency": 0.123411496
             },
             {
-              "latency": 0.125719285
+              "latency": 0.129228304
             },
             {
-              "latency": 0.121633628
+              "latency": 0.127902452
             },
             {
-              "latency": 0.126707951
+              "latency": 0.128979253
             },
             {
-              "latency": 0.124797375
+              "latency": 0.124786205
             },
             {
-              "latency": 0.127685473
+              "latency": 0.12489481
             },
             {
-              "latency": 0.124450102
+              "latency": 0.129476747
             },
             {
-              "latency": 0.125804493
+              "latency": 0.132739449
             },
             {
-              "latency": 0.129022753
+              "latency": 0.126596608
             },
             {
-              "latency": 0.130932983
+              "latency": 0.123892193
             },
             {
-              "latency": 0.124832814
+              "latency": 0.129399417
             },
             {
-              "latency": 0.128441849
+              "latency": 0.128014274
             },
             {
-              "latency": 0.127484862
+              "latency": 0.128232922
             },
             {
-              "latency": 0.127550448
+              "latency": 0.125772402
             },
             {
-              "latency": 0.123603179
+              "latency": 0.129255212
             },
             {
-              "latency": 0.1293483
+              "latency": 0.129317514
             },
             {
-              "latency": 0.131064809
+              "latency": 0.131034253
             },
             {
-              "latency": 0.127198234
+              "latency": 0.120305554
             },
             {
-              "latency": 0.12810162
+              "latency": 0.128057167
             },
             {
-              "latency": 0.123543716
+              "latency": 0.128322495
             },
             {
-              "latency": 0.130604059
+              "latency": 0.127702437
             },
             {
-              "latency": 0.128108102
+              "latency": 0.123953765
             },
             {
-              "latency": 0.124091915
+              "latency": 0.131064802
             },
             {
-              "latency": 0.127515558
+              "latency": 0.125711535
             },
             {
-              "latency": 0.131941105
+              "latency": 0.12410507
             },
             {
-              "latency": 0.12380863
+              "latency": 0.128206123
             },
             {
-              "latency": 0.125942241
+              "latency": 0.131078274
             },
             {
-              "latency": 0.127220743
+              "latency": 0.123528644
             },
             {
-              "latency": 0.13012345
+              "latency": 0.124669614
             },
             {
-              "latency": 0.12277998
+              "latency": 0.126290317
             },
             {
-              "latency": 0.123558504
+              "latency": 0.126863494
             },
             {
-              "latency": 0.129004583
+              "latency": 0.130159053
             },
             {
-              "latency": 0.120927219
+              "latency": 0.125257062
             },
             {
-              "latency": 0.130499269
+              "latency": 0.129222809
             },
             {
-              "latency": 0.131927074
+              "latency": 0.125540531
             },
             {
-              "latency": 0.123872696
+              "latency": 0.126082864
             },
             {
-              "latency": 0.126444181
+              "latency": 0.127881897
             },
             {
-              "latency": 0.126735474
+              "latency": 0.125331844
             },
             {
-              "latency": 0.118941103
+              "latency": 0.127288638
             },
             {
-              "latency": 0.126020058
+              "latency": 0.125656721
             },
             {
-              "latency": 0.121667638
+              "latency": 0.123760439
             },
             {
-              "latency": 0.128334338
+              "latency": 0.126993199
             },
             {
-              "latency": 0.128180825
+              "latency": 0.128965198
             },
             {
-              "latency": 0.127820918
+              "latency": 0.125824756
             },
             {
-              "latency": 0.130636587
+              "latency": 0.124826783
             },
             {
-              "latency": 0.125535494
+              "latency": 0.126446357
             },
             {
-              "latency": 0.12402695
+              "latency": 0.126765472
             },
             {
-              "latency": 0.129733582
+              "latency": 0.122939009
             },
             {
-              "latency": 0.130914024
+              "latency": 0.127211497
             },
             {
-              "latency": 0.129755091
+              "latency": 0.125842573
             },
             {
-              "latency": 0.124036562
+              "latency": 0.129666126
             },
             {
-              "latency": 0.125101143
+              "latency": 0.123824525
             },
             {
-              "latency": 0.125727743
+              "latency": 0.128113495
             },
             {
-              "latency": 0.123882753
+              "latency": 0.125614086
             },
             {
-              "latency": 0.120636983
+              "latency": 0.118318795
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -1563,304 +1563,304 @@
         {
           "result": [
             {
-              "latency": 0.186125696
+              "latency": 0.189790511
             },
             {
-              "latency": 0.193250325
+              "latency": 0.185295445
             },
             {
-              "latency": 0.185964855
+              "latency": 0.183155099
             },
             {
-              "latency": 0.193867584
+              "latency": 0.179711021
             },
             {
-              "latency": 0.193941329
+              "latency": 0.1815628
             },
             {
-              "latency": 0.176674272
+              "latency": 0.194026824
             },
             {
-              "latency": 0.190724684
+              "latency": 0.189149759
             },
             {
-              "latency": 0.19519593
+              "latency": 0.193674257
             },
             {
-              "latency": 0.180019999
+              "latency": 0.184257063
             },
             {
-              "latency": 0.183562506
+              "latency": 0.186093547
             },
             {
-              "latency": 0.189823227
+              "latency": 0.187334695
             },
             {
-              "latency": 0.18405577
+              "latency": 0.182795737
             },
             {
-              "latency": 0.18493169
+              "latency": 0.1836873
             },
             {
-              "latency": 0.177044087
+              "latency": 0.183141449
             },
             {
-              "latency": 0.187134092
+              "latency": 0.195912805
             },
             {
-              "latency": 0.188591711
+              "latency": 0.181645614
             },
             {
-              "latency": 0.184366198
+              "latency": 0.192973117
             },
             {
-              "latency": 0.185794476
+              "latency": 0.191678052
             },
             {
-              "latency": 0.187004954
+              "latency": 0.185993716
             },
             {
-              "latency": 0.18914213
+              "latency": 0.185307192
             },
             {
-              "latency": 0.189644751
+              "latency": 0.182947308
             },
             {
-              "latency": 0.189928517
+              "latency": 0.186831802
             },
             {
-              "latency": 0.191496238
+              "latency": 0.187671655
             },
             {
-              "latency": 0.183023641
+              "latency": 0.18498848
             },
             {
-              "latency": 0.194129703
+              "latency": 0.182876052
             },
             {
-              "latency": 0.17998652
+              "latency": 0.188781533
             },
             {
-              "latency": 0.180727405
+              "latency": 0.187729865
             },
             {
-              "latency": 0.181391702
+              "latency": 0.184475212
             },
             {
-              "latency": 0.191511831
+              "latency": 0.189245883
             },
             {
-              "latency": 0.185509152
+              "latency": 0.188484098
             },
             {
-              "latency": 0.187078731
+              "latency": 0.191772284
             },
             {
-              "latency": 0.191933372
+              "latency": 0.175307994
             },
             {
-              "latency": 0.189498499
+              "latency": 0.187499625
             },
             {
-              "latency": 0.192412675
+              "latency": 0.186462152
             },
             {
-              "latency": 0.180940503
+              "latency": 0.180680321
             },
             {
-              "latency": 0.189006545
+              "latency": 0.187132631
             },
             {
-              "latency": 0.191555153
+              "latency": 0.181225107
             },
             {
-              "latency": 0.180675049
+              "latency": 0.189710868
             },
             {
-              "latency": 0.191179167
+              "latency": 0.178397465
             },
             {
-              "latency": 0.183964293
+              "latency": 0.184407615
             },
             {
-              "latency": 0.18407678
+              "latency": 0.190179779
             },
             {
-              "latency": 0.180040156
+              "latency": 0.190448009
             },
             {
-              "latency": 0.182903184
+              "latency": 0.191511598
             },
             {
-              "latency": 0.191253657
+              "latency": 0.185985554
             },
             {
-              "latency": 0.184018242
+              "latency": 0.184779263
             },
             {
-              "latency": 0.189415129
+              "latency": 0.190281713
             },
             {
-              "latency": 0.188437639
+              "latency": 0.192063289
             },
             {
-              "latency": 0.188172973
+              "latency": 0.188147145
             },
             {
-              "latency": 0.191325137
+              "latency": 0.180085677
             },
             {
-              "latency": 0.183988608
+              "latency": 0.191160117
             },
             {
-              "latency": 0.17878703
+              "latency": 0.186452748
             },
             {
-              "latency": 0.191425188
+              "latency": 0.190510791
             },
             {
-              "latency": 0.194040285
+              "latency": 0.178278712
             },
             {
-              "latency": 0.178680372
+              "latency": 0.19119249
             },
             {
-              "latency": 0.182980123
+              "latency": 0.186555507
             },
             {
-              "latency": 0.184576482
+              "latency": 0.18344632
             },
             {
-              "latency": 0.189634115
+              "latency": 0.190256379
             },
             {
-              "latency": 0.185244352
+              "latency": 0.187129558
             },
             {
-              "latency": 0.184475783
+              "latency": 0.188593118
             },
             {
-              "latency": 0.185240399
+              "latency": 0.188291769
             },
             {
-              "latency": 0.183127664
+              "latency": 0.189530894
             },
             {
-              "latency": 0.186619498
+              "latency": 0.193427067
             },
             {
-              "latency": 0.189170996
+              "latency": 0.184417052
             },
             {
-              "latency": 0.18097901
+              "latency": 0.188620338
             },
             {
-              "latency": 0.185719833
+              "latency": 0.18527377
             },
             {
-              "latency": 0.183939276
+              "latency": 0.185096546
             },
             {
-              "latency": 0.185534372
+              "latency": 0.185786131
             },
             {
-              "latency": 0.190195576
+              "latency": 0.187227528
             },
             {
-              "latency": 0.190227328
+              "latency": 0.188418518
             },
             {
-              "latency": 0.179358115
+              "latency": 0.181754552
             },
             {
-              "latency": 0.189939701
+              "latency": 0.189666996
             },
             {
-              "latency": 0.191620701
+              "latency": 0.183232835
             },
             {
-              "latency": 0.190432082
+              "latency": 0.193937989
             },
             {
-              "latency": 0.189711716
+              "latency": 0.191676161
             },
             {
-              "latency": 0.191393569
+              "latency": 0.184168146
             },
             {
-              "latency": 0.186676361
+              "latency": 0.192910263
             },
             {
-              "latency": 0.187128108
+              "latency": 0.190126967
             },
             {
-              "latency": 0.19163339
+              "latency": 0.184652012
             },
             {
-              "latency": 0.190444934
+              "latency": 0.194854231
             },
             {
-              "latency": 0.191894003
+              "latency": 0.191820108
             },
             {
-              "latency": 0.193703399
+              "latency": 0.184788853
             },
             {
-              "latency": 0.186724084
+              "latency": 0.182854005
             },
             {
-              "latency": 0.182533103
+              "latency": 0.187661199
             },
             {
-              "latency": 0.191307252
+              "latency": 0.191536986
             },
             {
-              "latency": 0.19439515
+              "latency": 0.186257161
             },
             {
-              "latency": 0.182694701
+              "latency": 0.184256646
             },
             {
-              "latency": 0.192908215
+              "latency": 0.184307283
             },
             {
-              "latency": 0.188891329
+              "latency": 0.191534485
             },
             {
-              "latency": 0.18689351
+              "latency": 0.18713131
             },
             {
-              "latency": 0.194006596
+              "latency": 0.195688403
             },
             {
-              "latency": 0.188805502
+              "latency": 0.187721822
             },
             {
-              "latency": 0.192716938
+              "latency": 0.181363513
             },
             {
-              "latency": 0.186011507
+              "latency": 0.182569903
             },
             {
-              "latency": 0.187493413
+              "latency": 0.180166992
             },
             {
-              "latency": 0.185759809
+              "latency": 0.186078742
             },
             {
-              "latency": 0.188207822
+              "latency": 0.182399878
             },
             {
-              "latency": 0.174226319
+              "latency": 0.185006688
             },
             {
-              "latency": 0.183135039
+              "latency": 0.178717493
             },
             {
-              "latency": 0.188057533
+              "latency": 0.192207732
             },
             {
-              "latency": 0.190845358
+              "latency": 0.186360171
             }
           ],
           "implementation": "https",
@@ -1870,304 +1870,304 @@
         {
           "result": [
             {
-              "latency": 0.381345476
+              "latency": 0.383642396
             },
             {
-              "latency": 0.310011261
+              "latency": 0.326242407
             },
             {
-              "latency": 0.317913746
+              "latency": 0.375458882
             },
             {
-              "latency": 0.323272544
+              "latency": 0.381880358
             },
             {
-              "latency": 0.325687199
+              "latency": 0.37881667
             },
             {
-              "latency": 0.320573025
+              "latency": 0.305622027
             },
             {
-              "latency": 0.313464596
+              "latency": 0.312562396
             },
             {
-              "latency": 0.370251777
+              "latency": 0.381778356
             },
             {
-              "latency": 0.378091945
+              "latency": 0.317120152
             },
             {
-              "latency": 0.319399785
+              "latency": 0.31815487
             },
             {
-              "latency": 0.301834857
+              "latency": 0.304278713
             },
             {
-              "latency": 0.308979855
+              "latency": 0.303479672
             },
             {
-              "latency": 0.365884228
+              "latency": 0.31955074
             },
             {
-              "latency": 0.367893885
+              "latency": 0.380605836
             },
             {
-              "latency": 0.369976706
+              "latency": 0.371075826
             },
             {
-              "latency": 0.372506986
+              "latency": 0.312903296
             },
             {
-              "latency": 0.324844364
+              "latency": 0.328395721
             },
             {
-              "latency": 0.320817126
+              "latency": 0.310456624
             },
             {
-              "latency": 0.314459952
+              "latency": 0.317059618
             },
             {
-              "latency": 0.306336014
+              "latency": 0.322894807
             },
             {
-              "latency": 0.379710604
+              "latency": 0.305456603
             },
             {
-              "latency": 0.385618294
+              "latency": 0.310807656
             },
             {
-              "latency": 0.368690487
+              "latency": 0.318165659
             },
             {
-              "latency": 0.374676726
+              "latency": 0.387913351
             },
             {
-              "latency": 0.307193992
+              "latency": 0.385624152
             },
             {
-              "latency": 0.326221013
+              "latency": 0.302301882
             },
             {
-              "latency": 0.299707419
+              "latency": 0.313749659
             },
             {
-              "latency": 0.310218207
+              "latency": 0.382760295
             },
             {
-              "latency": 0.382603071
+              "latency": 0.373617899
             },
             {
-              "latency": 0.314321228
+              "latency": 0.321561163
             },
             {
-              "latency": 0.319414389
+              "latency": 0.314461474
             },
             {
-              "latency": 0.375599452
+              "latency": 0.384423016
             },
             {
-              "latency": 0.384297199
+              "latency": 0.370762783
             },
             {
-              "latency": 0.321740903
+              "latency": 0.374690437
             },
             {
-              "latency": 0.359745621
+              "latency": 0.307652925
             },
             {
-              "latency": 0.373883766
+              "latency": 0.31443201
             },
             {
-              "latency": 0.327330737
+              "latency": 0.307369129
             },
             {
-              "latency": 0.378808013
+              "latency": 0.315145952
             },
             {
-              "latency": 0.304814796
+              "latency": 0.298814889
             },
             {
-              "latency": 0.3091126
+              "latency": 0.315929323
             },
             {
-              "latency": 0.313902152
+              "latency": 0.307303032
             },
             {
-              "latency": 0.364586316
+              "latency": 0.392239282
             },
             {
-              "latency": 0.314528068
+              "latency": 0.320687279
             },
             {
-              "latency": 0.315348514
+              "latency": 0.315087975
             },
             {
-              "latency": 0.389889588
+              "latency": 0.375055478
             },
             {
-              "latency": 0.323187201
+              "latency": 0.351042395
             },
             {
-              "latency": 0.324784963
+              "latency": 0.305972681
             },
             {
-              "latency": 0.314591965
+              "latency": 0.373808898
             },
             {
-              "latency": 0.351267005
+              "latency": 0.364874683
             },
             {
-              "latency": 0.320534706
+              "latency": 0.386616409
             },
             {
-              "latency": 0.368794151
+              "latency": 0.316946171
             },
             {
-              "latency": 0.373100058
+              "latency": 0.312275649
             },
             {
-              "latency": 0.308748147
+              "latency": 0.31780707
             },
             {
-              "latency": 0.376614136
+              "latency": 0.31386822
             },
             {
-              "latency": 0.312456194
+              "latency": 0.31743788
             },
             {
-              "latency": 0.325722553
+              "latency": 0.382624286
             },
             {
-              "latency": 0.390807912
+              "latency": 0.370693481
             },
             {
-              "latency": 0.355294057
+              "latency": 0.379058533
             },
             {
-              "latency": 0.390622256
+              "latency": 0.299326869
             },
             {
-              "latency": 0.306195931
+              "latency": 0.316920674
             },
             {
-              "latency": 0.304690134
+              "latency": 0.377521693
             },
             {
-              "latency": 0.309909989
+              "latency": 0.387288812
             },
             {
-              "latency": 0.31619949
+              "latency": 0.295622551
             },
             {
-              "latency": 0.382414554
+              "latency": 0.317102948
             },
             {
-              "latency": 0.360632248
+              "latency": 0.314121484
             },
             {
-              "latency": 0.309611042
+              "latency": 0.368235078
             },
             {
-              "latency": 0.304919525
+              "latency": 0.317031216
             },
             {
-              "latency": 0.319058779
+              "latency": 0.384547106
             },
             {
-              "latency": 0.36637229
+              "latency": 0.302815948
             },
             {
-              "latency": 0.37605942
+              "latency": 0.376902539
             },
             {
-              "latency": 0.38276463
+              "latency": 0.379793017
             },
             {
-              "latency": 0.360984833
+              "latency": 0.319458051
             },
             {
-              "latency": 0.308069556
+              "latency": 0.324156633
             },
             {
-              "latency": 0.379511297
+              "latency": 0.310092709
             },
             {
-              "latency": 0.305277423
+              "latency": 0.324754808
             },
             {
-              "latency": 0.378561533
+              "latency": 0.365567509
             },
             {
-              "latency": 0.298489139
+              "latency": 0.316843405
             },
             {
-              "latency": 0.36619677
+              "latency": 0.307828866
             },
             {
-              "latency": 0.294356067
+              "latency": 0.316958198
             },
             {
-              "latency": 0.320096416
+              "latency": 0.305390631
             },
             {
-              "latency": 0.305988316
+              "latency": 0.308114465
             },
             {
-              "latency": 0.312524791
+              "latency": 0.308879938
             },
             {
-              "latency": 0.317066632
+              "latency": 0.365852334
             },
             {
-              "latency": 0.371120667
+              "latency": 0.326668034
             },
             {
-              "latency": 0.313505867
+              "latency": 0.313859124
             },
             {
-              "latency": 0.31490379
+              "latency": 0.367744378
             },
             {
-              "latency": 0.309255169
+              "latency": 0.379773909
             },
             {
-              "latency": 0.315183889
+              "latency": 0.328453607
             },
             {
-              "latency": 0.374551557
+              "latency": 0.310803227
             },
             {
-              "latency": 0.310813122
+              "latency": 0.318056611
             },
             {
-              "latency": 0.326105982
+              "latency": 0.306364893
             },
             {
-              "latency": 0.361435493
+              "latency": 0.31942839
             },
             {
-              "latency": 0.384574249
+              "latency": 0.324237355
             },
             {
-              "latency": 0.388043664
+              "latency": 0.376765459
             },
             {
-              "latency": 0.313482988
+              "latency": 0.311093663
             },
             {
-              "latency": 0.310522136
+              "latency": 0.3111702
             },
             {
-              "latency": 0.319512899
+              "latency": 0.354253478
             },
             {
-              "latency": 0.381366334
+              "latency": 0.320253107
             },
             {
-              "latency": 0.307855739
+              "latency": 0.375954895
             },
             {
-              "latency": 0.32477267
+              "latency": 0.381460108
             }
           ],
           "implementation": "go-libp2p",
@@ -2177,304 +2177,304 @@
         {
           "result": [
             {
-              "latency": 0.190272312
+              "latency": 0.19453549
             },
             {
-              "latency": 0.192737986
+              "latency": 0.181236003
             },
             {
-              "latency": 0.178975299
+              "latency": 0.196288022
             },
             {
-              "latency": 0.189846031
+              "latency": 0.190355794
             },
             {
-              "latency": 0.19752571
+              "latency": 0.190841121
             },
             {
-              "latency": 0.194253008
+              "latency": 0.18716941
             },
             {
-              "latency": 0.194017635
+              "latency": 0.19650049
             },
             {
-              "latency": 0.18571502
+              "latency": 0.188182381
             },
             {
-              "latency": 0.189081691
+              "latency": 0.193627759
             },
             {
-              "latency": 0.189678026
+              "latency": 0.188128636
             },
             {
-              "latency": 0.191616926
+              "latency": 0.194418389
             },
             {
-              "latency": 0.197603829
+              "latency": 0.188949334
             },
             {
-              "latency": 0.191199481
+              "latency": 0.189266168
             },
             {
-              "latency": 0.188314244
+              "latency": 0.180826855
             },
             {
-              "latency": 0.1917676
+              "latency": 0.184595038
             },
             {
-              "latency": 0.195318591
+              "latency": 0.193345535
             },
             {
-              "latency": 0.192820369
+              "latency": 0.183882747
             },
             {
-              "latency": 0.189895717
+              "latency": 0.189709915
             },
             {
-              "latency": 0.185209963
+              "latency": 0.196078717
             },
             {
-              "latency": 0.188153369
+              "latency": 0.191911677
             },
             {
-              "latency": 0.189796726
+              "latency": 0.18939479
             },
             {
-              "latency": 0.187092593
+              "latency": 0.192517586
             },
             {
-              "latency": 0.186806678
+              "latency": 0.199450097
             },
             {
-              "latency": 0.196754997
+              "latency": 0.200158189
             },
             {
-              "latency": 0.186781455
+              "latency": 0.19496058
             },
             {
-              "latency": 0.197279633
+              "latency": 0.185530974
             },
             {
-              "latency": 0.18821387
+              "latency": 0.191961824
             },
             {
-              "latency": 0.189552705
+              "latency": 0.195304983
             },
             {
-              "latency": 0.190420264
+              "latency": 0.19602959
             },
             {
-              "latency": 0.196921864
+              "latency": 0.190337939
             },
             {
-              "latency": 0.19977009
+              "latency": 0.194327732
             },
             {
-              "latency": 0.185068748
+              "latency": 0.19097137
             },
             {
-              "latency": 0.188800741
+              "latency": 0.189164008
             },
             {
-              "latency": 0.180653926
+              "latency": 0.190408712
             },
             {
-              "latency": 0.185203665
+              "latency": 0.187420072
             },
             {
-              "latency": 0.182306439
+              "latency": 0.19369834
             },
             {
-              "latency": 0.19250827
+              "latency": 0.196783974
             },
             {
-              "latency": 0.182466566
+              "latency": 0.189094353
             },
             {
-              "latency": 0.193343197
+              "latency": 0.192343669
             },
             {
-              "latency": 0.188437325
+              "latency": 0.193692168
             },
             {
-              "latency": 0.19009732
+              "latency": 0.195561611
             },
             {
-              "latency": 0.188445093
+              "latency": 0.184410675
             },
             {
-              "latency": 0.183592127
+              "latency": 0.188916338
             },
             {
-              "latency": 0.194702645
+              "latency": 0.195941445
             },
             {
-              "latency": 0.193154196
+              "latency": 0.197444673
             },
             {
-              "latency": 0.185560042
+              "latency": 0.187195485
             },
             {
-              "latency": 0.195239293
+              "latency": 0.192929232
             },
             {
-              "latency": 0.19328836
+              "latency": 0.189574539
             },
             {
-              "latency": 0.191927884
+              "latency": 0.19285592
             },
             {
-              "latency": 0.194307721
+              "latency": 0.194587249
             },
             {
-              "latency": 0.19447864
+              "latency": 0.188780293
             },
             {
-              "latency": 0.197637007
+              "latency": 0.186985788
             },
             {
-              "latency": 0.189414051
+              "latency": 0.191819416
             },
             {
-              "latency": 0.195894723
+              "latency": 0.187017204
             },
             {
-              "latency": 0.187635924
+              "latency": 0.180525031
             },
             {
-              "latency": 0.192089868
+              "latency": 0.190218825
             },
             {
-              "latency": 0.192424422
+              "latency": 0.194038648
             },
             {
-              "latency": 0.194069085
+              "latency": 0.189736294
             },
             {
-              "latency": 0.186444823
+              "latency": 0.187347738
             },
             {
-              "latency": 0.195697424
+              "latency": 0.185712159
             },
             {
-              "latency": 0.195952523
+              "latency": 0.189077661
             },
             {
-              "latency": 0.181829764
+              "latency": 0.189343701
             },
             {
-              "latency": 0.193685271
+              "latency": 0.181625559
             },
             {
-              "latency": 0.184199815
+              "latency": 0.18380183
             },
             {
-              "latency": 0.182238278
+              "latency": 0.190097427
             },
             {
-              "latency": 0.193734906
+              "latency": 0.194085855
             },
             {
-              "latency": 0.1860801
+              "latency": 0.184113634
             },
             {
-              "latency": 0.188219237
+              "latency": 0.196466968
             },
             {
-              "latency": 0.197818951
+              "latency": 0.197207634
             },
             {
-              "latency": 0.191524349
+              "latency": 0.195341437
             },
             {
-              "latency": 0.184980103
+              "latency": 0.194152611
             },
             {
-              "latency": 0.194002343
+              "latency": 0.194161059
             },
             {
-              "latency": 0.195224382
+              "latency": 0.199204775
             },
             {
-              "latency": 0.192980278
+              "latency": 0.196596237
             },
             {
-              "latency": 0.195033335
+              "latency": 0.182694315
             },
             {
-              "latency": 0.196407794
+              "latency": 0.181369987
             },
             {
-              "latency": 0.19318405
+              "latency": 0.194915306
             },
             {
-              "latency": 0.186733665
+              "latency": 0.185637073
             },
             {
-              "latency": 0.189535605
+              "latency": 0.191334952
             },
             {
-              "latency": 0.180817893
+              "latency": 0.199308762
             },
             {
-              "latency": 0.193884384
+              "latency": 0.190862611
             },
             {
-              "latency": 0.189553823
+              "latency": 0.192181917
             },
             {
-              "latency": 0.190276946
+              "latency": 0.198309915
             },
             {
-              "latency": 0.185924209
+              "latency": 0.194234323
             },
             {
-              "latency": 0.192762612
+              "latency": 0.194457609
             },
             {
-              "latency": 0.189759834
+              "latency": 0.178980382
             },
             {
-              "latency": 0.19220735
+              "latency": 0.195979684
             },
             {
-              "latency": 0.188921209
+              "latency": 0.195133588
             },
             {
-              "latency": 0.191440586
+              "latency": 0.197518691
             },
             {
-              "latency": 0.188858439
+              "latency": 0.193979823
             },
             {
-              "latency": 0.196119346
+              "latency": 0.189857769
             },
             {
-              "latency": 0.185606689
+              "latency": 0.195673538
             },
             {
-              "latency": 0.191237226
+              "latency": 0.197155714
             },
             {
-              "latency": 0.1997391
+              "latency": 0.18818351
             },
             {
-              "latency": 0.194520431
+              "latency": 0.179366346
             },
             {
-              "latency": 0.196019876
+              "latency": 0.188544609
             },
             {
-              "latency": 0.192688577
+              "latency": 0.187244039
             },
             {
-              "latency": 0.188636085
+              "latency": 0.185635271
             },
             {
-              "latency": 0.197256893
+              "latency": 0.189034722
             },
             {
-              "latency": 0.19270415
+              "latency": 0.1854126
             }
           ],
           "implementation": "go-libp2p",
@@ -2491,173 +2491,173 @@
   "pings": {
     "unit": "s",
     "results": [
-      0.0638,
-      0.0649,
-      0.0733,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0626,
-      0.0625,
-      0.0628,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0625,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0625,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0625,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0625,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624,
-      0.0624
+      0.073,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.0613,
+      0.06609999999999999,
+      0.06609999999999999,
+      0.06609999999999999,
+      0.06609999999999999,
+      0.06609999999999999,
+      0.0664,
+      0.06609999999999999,
+      0.066,
+      0.066,
+      0.066,
+      0.060899999999999996,
+      0.060899999999999996,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.060899999999999996,
+      0.060899999999999996,
+      0.061,
+      0.061,
+      0.060899999999999996
     ]
   },
   "iperf": {
     "unit": "bit/s",
     "results": [
       3390000000,
+      3390000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3400000000,
+      3360000000,
+      3380000000,
+      3380000000,
+      3390000000,
+      3380000000,
+      3380000000,
+      3380000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3400000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3400000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
       3380000000,
       3380000000,
       3380000000,
       3380000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
+      3390000000,
       3380000000,
       3380000000,
-      3400000000,
-      3400000000,
       3380000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3390000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3350000000,
-      3340000000,
-      3340000000,
-      3350000000,
-      3350000000,
-      3380000000,
-      3400000000,
-      3400000000,
       3390000000,
       3390000000,
-      3400000000,
-      3390000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3390000000,
-      3400000000,
-      3400000000,
-      3330000000,
-      3350000000,
-      3350000000,
-      3340000000,
-      3340000000,
-      3350000000,
       3390000000,
       3380000000,
-      3400000000,
-      3390000000,
-      3390000000,
-      3390000000,
-      3400000000,
-      3390000000,
-      3390000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3400000000,
-      3400000000,
       3390000000,
       3380000000,
-      2950000000
+      3390000000,
+      2980000000
     ]
   }
 }


### PR DESCRIPTION
Instead of exposing the time to establish a connection, the time to upload the bytes and the time to download the bytes, expose a single time including all three.

The rational here is, that differentiation of the three is flawed. E.g. when does one stop the upload timer and start the download timer? When the last byte is sent? When the last byte is flushed? When the first byte is received?

See https://github.com/libp2p/test-plans/pull/184#pullrequestreview-1482600521 for past discussion.

I will update the dashboard once this is merged.

Blocked on https://github.com/libp2p/rust-libp2p/pull/4105 and https://github.com/quic-go/perf/pull/12.