### PR TITLE
Less error-prone way of defining image IDs and other quality of life improvements

### DIFF
--- a/multidim-interop/testplans.ts
+++ b/multidim-interop/testplans.ts
@@ -55,12 +55,12 @@ import path from "path";
         extraVersions.push(JSON.parse(contents.toString()))
     }
 
-    let testSpecs = await buildTestSpecs(versions.concat(extraVersions))
 
-    const nameFilter = argv["name-filter"]
-    if (nameFilter !== "") {
-        testSpecs = testSpecs.filter((testSpec) => testSpec.name?.includes(nameFilter))
+    let nameFilter: string | null = argv["name-filter"]
+    if (nameFilter === "") {
+        nameFilter = null
     }
+    let testSpecs = await buildTestSpecs(versions.concat(extraVersions), nameFilter)
 
 
     if (argv["emit-only"]) {

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -1,30 +1,10 @@
-import gov028 from "./impl/go/v0.28/image.json"
-import gov027 from "./impl/go/v0.27/image.json"
-import gov026 from "./impl/go/v0.26/image.json"
-import gov025 from "./impl/go/v0.25/image.json"
-import gov024 from "./impl/go/v0.24/image.json"
-import gov023 from "./impl/go/v0.23/image.json"
-import gov022 from "./impl/go/v0.22/image.json"
-import rustv049 from "./impl/rust/v0.49/image.json"
-import rustv050 from "./impl/rust/v0.50/image.json"
-import rustv051 from "./impl/rust/v0.51/image.json"
-import rustv052 from "./impl/rust/v0.52/image.json"
-import jsV041 from "./impl/js/v0.41/node-image.json"
-import jsV042 from "./impl/js/v0.42/node-image.json"
-import jsV044 from "./impl/js/v0.44/node-image.json"
-import jsV045 from "./impl/js/v0.45/image.json"
-import nimv10 from "./impl/nim/v1.0/image.json"
-import chromiumJsV041 from "./impl/js/v0.41/chromium-image.json"
-import chromiumJsV042 from "./impl/js/v0.42/chromium-image.json"
-import chromiumJsV044 from "./impl/js/v0.44/chromium-image.json"
-import chromiumJsV045 from "./impl/js/v0.45/chromium-image.json"
-import firefoxJsV045 from "./impl/js/v0.45/firefox-image.json"
-import zigv001 from "./impl/zig/v0.0.1/image.json"
-import javav001 from "./impl/java/v0.0.1/image.json"
+import fs from "fs"
 
 export type Version = {
     id: string,
-    containerImageID: string,
+    // This can be the image ID, or a function that takes the version ID and returns the image ID.
+    // By default it uses the canonicalImageIDLookup.
+    containerImageID?: string | ((id: string) => string),
     // If defined, this will increase the timeout for tests using this version
     timeoutSecs?: number,
     transports: Array<(string | { name: string, onlyDial: boolean })>,
@@ -32,166 +12,162 @@ export type Version = {
     muxers: string[]
 }
 
+// Loads the container image id for the given version id. Expects the form of
+// "<impl>-vX.Y.Z" or "<impl>vX.Y" and the image id to be in the file
+// "./impl/<impl>/vX.Y/image.json" or "./impl/<impl>/v0.0.Z/image.json"
+function canonicalImageIDLookup(id: string): string {
+    // Split by implementation and version
+    const [impl, version] = id.split("-v")
+    // Drop the patch version
+    const [major, minor, patch] = version.split(".")
+    let versionFolder = `v${major}.${minor}`
+    if (major === "0" && minor === "0") {
+        // We're still in the 0.0.x phase, so we use the patch version
+        versionFolder = `v0.0.${patch}`
+    }
+    // Read the image ID from the JSON file on the filesystem
+    const imageIDJSON = fs.readFileSync(`./impl/${impl}/${versionFolder}/image.json`, "utf8")
+    const imageID = JSON.parse(imageIDJSON).imageID
+    return imageID
+}
+
 export const versions: Array<Version> = [
     {
         id: "rust-v0.49.0",
-        containerImageID: rustv049.imageID,
         transports: ["ws", "tcp"],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "rust-v0.50.0",
-        containerImageID: rustv050.imageID,
         transports: ["ws", "tcp", "quic-v1"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "rust-v0.51.0",
-        containerImageID: rustv051.imageID,
         transports: ["ws", "tcp", "quic-v1", "webrtc-direct"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "rust-v0.52.0",
-        containerImageID: rustv052.imageID,
         transports: ["ws", "tcp", "quic-v1", "webrtc-direct"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "js-v0.41.0",
-        containerImageID: jsV041.imageID,
         transports: ["tcp", "ws"],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "js-v0.42.0",
-        containerImageID: jsV042.imageID,
         transports: ["tcp", "ws", { name: "wss", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "js-v0.44.0",
-        containerImageID: jsV044.imageID,
         transports: ["tcp", "ws", { name: "wss", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "js-v0.45.0",
-        containerImageID: jsV045.imageID,
         transports: ["tcp", "ws", { name: "wss", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "chromium-js-v0.41.0",
-        containerImageID: chromiumJsV041.imageID,
         transports: [{ name: "webtransport", onlyDial: true }],
         secureChannels: [],
         muxers: []
     },
     {
         id: "chromium-js-v0.42.0",
-        containerImageID: chromiumJsV042.imageID,
         transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"]
     },
     {
         id: "chromium-js-v0.44.0",
-        containerImageID: chromiumJsV044.imageID,
         transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }, { name: "webrtc-direct", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "chromium-js-v0.45.0",
-        containerImageID: chromiumJsV045.imageID,
         transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }, { name: "webrtc-direct", onlyDial: true }, "webrtc"],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "firefox-js-v0.45.0",
-        containerImageID: firefoxJsV045.imageID,
         transports: [{ name: "wss", onlyDial: true }, { name: "webrtc-direct", onlyDial: true }, "webrtc"],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.28.0",
-        containerImageID: gov028.imageID,
         transports: ["tcp", "ws", "quic", "quic-v1", "webtransport"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.27.6",
-        containerImageID: gov027.imageID,
         transports: ["tcp", "ws", "quic", "quic-v1", "webtransport"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.26.4",
-        containerImageID: gov026.imageID,
         transports: ["tcp", "ws", "quic", "quic-v1", "webtransport"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.25.1",
-        containerImageID: gov025.imageID,
         transports: ["tcp", "ws", "quic", "quic-v1", "webtransport"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.24.2",
-        containerImageID: gov024.imageID,
         transports: ["tcp", "ws", "quic", "quic-v1", "webtransport", "wss"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.23.4",
-        containerImageID: gov023.imageID,
         transports: ["tcp", "ws", "quic"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "go-v0.22.0",
-        containerImageID: gov022.imageID,
         transports: ["tcp", "ws", "quic"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "nim-v1.0",
-        containerImageID: nimv10.imageID,
         transports: ["tcp", "ws"],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "zig-v0.0.1",
-        containerImageID: zigv001.imageID,
         transports: ["quic-v1"],
         secureChannels: [],
         muxers: [],
     },
     {
         id: "java-v0.0.1",
-        containerImageID: javav001.imageID,
         transports: ["tcp"],
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
-    },    
-]
+    },
+].map((v: Version) => (typeof v.containerImageID === "undefined" ? ({ ...v, containerImageID: canonicalImageIDLookup }) : v))


### PR DESCRIPTION
Changes how imageIDs are loaded for a given version.

* imageID can now be a function that returns an imageID rather than directly a string.
* Defines a new canonical lookup function which matches how all current implementations are defined. A new implementation is not required to lay things out like this, but if it does it can reuse this function.
* imageIDs are now lazily loaded _after_ running the name-filter. This means, for example, if you only want to test WebTransport you don't have to build every implementation first.

This should make errors like [this](https://github.com/libp2p/test-plans/pull/206#discussion_r1240153895) harder to make. (I've made this error several times as well).