### PR TITLE
fix(perf): increase iterations

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -22,7 +22,7 @@ jobs:
   perf:
     name: Perf
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 120
     defaults:
       run:
         shell: bash

--- a/perf/runner/benchmark-results.json
+++ b/perf/runner/benchmark-results.json
@@ -7,19 +7,34 @@
         {
           "result": [
             {
-              "latency": 1.08094152
+              "latency": 1.110015849
             },
             {
-              "latency": 1.087286254
+              "latency": 1.06853618
             },
             {
-              "latency": 1.052877736
+              "latency": 1.083659713
             },
             {
-              "latency": 1.074129332
+              "latency": 1.08368959
             },
             {
-              "latency": 1.089036911
+              "latency": 1.114899791
+            },
+            {
+              "latency": 1.089188949
+            },
+            {
+              "latency": 1.05511415
+            },
+            {
+              "latency": 1.064944316
+            },
+            {
+              "latency": 1.054797037
+            },
+            {
+              "latency": 1.07427787
             }
           ],
           "implementation": "quic-go",
@@ -29,19 +44,34 @@
         {
           "result": [
             {
-              "latency": 46.275367123
+              "latency": 44.451848119
             },
             {
-              "latency": 44.16152915
+              "latency": 45.546482709
             },
             {
-              "latency": 44.813941029
+              "latency": 44.250178374
             },
             {
-              "latency": 42.987746422
+              "latency": 47.128461139
             },
             {
-              "latency": 45.509402053
+              "latency": 45.719523733
+            },
+            {
+              "latency": 43.572812766
+            },
+            {
+              "latency": 43.067039414
+            },
+            {
+              "latency": 44.878617077
+            },
+            {
+              "latency": 44.620583046
+            },
+            {
+              "latency": 45.48545842
             }
           ],
           "implementation": "rust-libp2p",
@@ -51,19 +81,34 @@
         {
           "result": [
             {
-              "latency": 12.896335487
+              "latency": 20.12893351
             },
             {
-              "latency": 9.694788327
+              "latency": 15.696239333
             },
             {
-              "latency": 15.055043707
+              "latency": 16.574872658
             },
             {
-              "latency": 12.528458517
+              "latency": 25.888998656
             },
             {
-              "latency": 11.922201399
+              "latency": 32.760066036
+            },
+            {
+              "latency": 15.776643952
+            },
+            {
+              "latency": 15.473723174
+            },
+            {
+              "latency": 17.935630635
+            },
+            {
+              "latency": 12.412620368
+            },
+            {
+              "latency": 13.549116502
             }
           ],
           "implementation": "rust-libp2p",
@@ -73,19 +118,34 @@
         {
           "result": [
             {
-              "latency": 1.5015372230000001
+              "latency": 1.462115819
             },
             {
-              "latency": 1.478589693
+              "latency": 1.492634771
             },
             {
-              "latency": 1.488727041
+              "latency": 1.509507029
             },
             {
-              "latency": 1.458797558
+              "latency": 1.4834241750000001
             },
             {
-              "latency": 1.5399592819999999
+              "latency": 1.466191568
+            },
+            {
+              "latency": 1.512127571
+            },
+            {
+              "latency": 1.45902823
+            },
+            {
+              "latency": 1.487984964
+            },
+            {
+              "latency": 1.4787014520000001
+            },
+            {
+              "latency": 1.443173816
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -95,19 +155,34 @@
         {
           "result": [
             {
-              "latency": 2.896000246
+              "latency": 2.78727117
             },
             {
-              "latency": 2.929661431
+              "latency": 2.889091403
             },
             {
-              "latency": 2.662874053
+              "latency": 3.428148244
             },
             {
-              "latency": 2.771636908
+              "latency": 2.93338724
             },
             {
-              "latency": 2.804402263
+              "latency": 2.712044571
+            },
+            {
+              "latency": 2.667577786
+            },
+            {
+              "latency": 2.626632239
+            },
+            {
+              "latency": 2.668642281
+            },
+            {
+              "latency": 3.499114818
+            },
+            {
+              "latency": 2.7744891000000003
             }
           ],
           "implementation": "https",
@@ -117,19 +192,34 @@
         {
           "result": [
             {
-              "latency": 3.2987959780000002
+              "latency": 3.245046774
             },
             {
-              "latency": 3.359852647
+              "latency": 3.151299139
             },
             {
-              "latency": 3.225796396
+              "latency": 3.435955655
             },
             {
-              "latency": 3.040832462
+              "latency": 3.547757592
             },
             {
-              "latency": 3.200671148
+              "latency": 3.290692557
+            },
+            {
+              "latency": 3.200409134
+            },
+            {
+              "latency": 3.532967265
+            },
+            {
+              "latency": 3.286084323
+            },
+            {
+              "latency": 3.283864894
+            },
+            {
+              "latency": 3.366594585
             }
           ],
           "implementation": "go-libp2p",
@@ -139,19 +229,34 @@
         {
           "result": [
             {
-              "latency": 1.536351493
+              "latency": 1.4639789429999999
             },
             {
-              "latency": 1.450335247
+              "latency": 1.5030406109999999
             },
             {
-              "latency": 1.461686524
+              "latency": 1.476044459
             },
             {
-              "latency": 1.50244321
+              "latency": 1.441289234
             },
             {
-              "latency": 1.440298147
+              "latency": 1.453014655
+            },
+            {
+              "latency": 1.439182845
+            },
+            {
+              "latency": 1.405193738
+            },
+            {
+              "latency": 1.5092272759999998
+            },
+            {
+              "latency": 1.507870627
+            },
+            {
+              "latency": 1.460696843
             }
           ],
           "implementation": "go-libp2p",
@@ -161,19 +266,34 @@
         {
           "result": [
             {
-              "latency": 3.292747438
+              "latency": 3.399612047
             },
             {
-              "latency": 3.604178575
+              "latency": 3.400201622
             },
             {
-              "latency": 3.370398934
+              "latency": 3.201630313
             },
             {
-              "latency": 3.04126853
+              "latency": 3.2864637500000002
             },
             {
-              "latency": 3.154630607
+              "latency": 3.303372779
+            },
+            {
+              "latency": 3.347913499
+            },
+            {
+              "latency": 3.185720646
+            },
+            {
+              "latency": 3.054413495
+            },
+            {
+              "latency": 3.527257348
+            },
+            {
+              "latency": 3.206466766
             }
           ],
           "implementation": "go-libp2p",
@@ -183,19 +303,34 @@
         {
           "result": [
             {
-              "latency": 1.472890121
+              "latency": 1.439262344
             },
             {
-              "latency": 1.480030417
+              "latency": 1.480738583
             },
             {
-              "latency": 1.481909157
+              "latency": 1.4762862509999999
             },
             {
-              "latency": 1.505205532
+              "latency": 1.486226804
             },
             {
-              "latency": 1.5185867769999999
+              "latency": 1.403515964
+            },
+            {
+              "latency": 1.48892448
+            },
+            {
+              "latency": 1.454780784
+            },
+            {
+              "latency": 1.4412395359999999
+            },
+            {
+              "latency": 5.412412991
+            },
+            {
+              "latency": 1.5050124710000001
             }
           ],
           "implementation": "go-libp2p",
@@ -215,19 +350,34 @@
         {
           "result": [
             {
-              "latency": 1.160973869
+              "latency": 1.123972335
             },
             {
-              "latency": 1.094158958
+              "latency": 1.11528373
             },
             {
-              "latency": 1.155310345
+              "latency": 1.111287173
             },
             {
-              "latency": 1.130414626
+              "latency": 1.196631869
             },
             {
-              "latency": 1.118341789
+              "latency": 1.085013567
+            },
+            {
+              "latency": 1.098814426
+            },
+            {
+              "latency": 1.1341501
+            },
+            {
+              "latency": 1.163019303
+            },
+            {
+              "latency": 1.110588441
+            },
+            {
+              "latency": 1.099149391
             }
           ],
           "implementation": "quic-go",
@@ -237,19 +387,34 @@
         {
           "result": [
             {
-              "latency": 44.721030184
+              "latency": 46.543711659
             },
             {
-              "latency": 47.431712827
+              "latency": 44.754174544
             },
             {
-              "latency": 48.403507494
+              "latency": 44.81661402
             },
             {
-              "latency": 45.358269306
+              "latency": 47.294616034
             },
             {
-              "latency": 47.727786848
+              "latency": 43.896991168
+            },
+            {
+              "latency": 45.131352316
+            },
+            {
+              "latency": 44.351874773
+            },
+            {
+              "latency": 45.168058087
+            },
+            {
+              "latency": 43.250312417
+            },
+            {
+              "latency": 43.81188098
             }
           ],
           "implementation": "rust-libp2p",
@@ -259,19 +424,34 @@
         {
           "result": [
             {
-              "latency": 11.965871734
+              "latency": 19.263854632
             },
             {
-              "latency": 14.406809825
+              "latency": 14.619606397
             },
             {
-              "latency": 8.30056158
+              "latency": 10.470780997
             },
             {
-              "latency": 5.780795755
+              "latency": 14.99537781
             },
             {
-              "latency": 15.876088915
+              "latency": 11.297294422
+            },
+            {
+              "latency": 13.762540227
+            },
+            {
+              "latency": 13.803161998
+            },
+            {
+              "latency": 12.744302195
+            },
+            {
+              "latency": 9.406983961
+            },
+            {
+              "latency": 13.71729279
             }
           ],
           "implementation": "rust-libp2p",
@@ -281,19 +461,34 @@
         {
           "result": [
             {
-              "latency": 1.478477048
+              "latency": 1.505310956
             },
             {
-              "latency": 1.4088579110000001
+              "latency": 1.453332816
             },
             {
-              "latency": 1.462640778
+              "latency": 1.384030675
             },
             {
-              "latency": 1.519567228
+              "latency": 1.479678444
             },
             {
-              "latency": 1.742330848
+              "latency": 1.4722022799999999
+            },
+            {
+              "latency": 1.451128779
+            },
+            {
+              "latency": 1.434510835
+            },
+            {
+              "latency": 1.493065652
+            },
+            {
+              "latency": 1.483729165
+            },
+            {
+              "latency": 1.485041661
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -303,19 +498,34 @@
         {
           "result": [
             {
-              "latency": 2.7529987030000003
+              "latency": 2.687949937
             },
             {
-              "latency": 2.741991725
+              "latency": 2.781134852
             },
             {
-              "latency": 3.377649911
+              "latency": 2.788072831
             },
             {
-              "latency": 2.716085671
+              "latency": 2.6376898239999997
             },
             {
-              "latency": 2.793655924
+              "latency": 2.758423948
+            },
+            {
+              "latency": 2.70119236
+            },
+            {
+              "latency": 2.996782849
+            },
+            {
+              "latency": 2.722806031
+            },
+            {
+              "latency": 2.969617547
+            },
+            {
+              "latency": 2.928390634
             }
           ],
           "implementation": "https",
@@ -325,19 +535,34 @@
         {
           "result": [
             {
-              "latency": 3.202764361
+              "latency": 3.355657797
             },
             {
-              "latency": 3.24477181
+              "latency": 3.534522917
             },
             {
-              "latency": 3.265170976
+              "latency": 3.33731745
             },
             {
-              "latency": 3.053783908
+              "latency": 3.212282854
             },
             {
-              "latency": 3.157173875
+              "latency": 3.287498133
+            },
+            {
+              "latency": 3.389291447
+            },
+            {
+              "latency": 3.250925123
+            },
+            {
+              "latency": 3.525598589
+            },
+            {
+              "latency": 3.326734848
+            },
+            {
+              "latency": 3.458504393
             }
           ],
           "implementation": "go-libp2p",
@@ -347,19 +572,34 @@
         {
           "result": [
             {
-              "latency": 1.458829041
+              "latency": 1.475588658
             },
             {
-              "latency": 1.416086744
+              "latency": 1.435965338
             },
             {
-              "latency": 1.538248438
+              "latency": 1.4540236690000001
             },
             {
-              "latency": 1.485502811
+              "latency": 1.457411963
             },
             {
-              "latency": 1.4275898790000001
+              "latency": 1.474615931
+            },
+            {
+              "latency": 1.441941172
+            },
+            {
+              "latency": 1.476164672
+            },
+            {
+              "latency": 1.468566773
+            },
+            {
+              "latency": 1.4583796549999999
+            },
+            {
+              "latency": 1.471180968
             }
           ],
           "implementation": "go-libp2p",
@@ -369,19 +609,34 @@
         {
           "result": [
             {
-              "latency": 3.249207329
+              "latency": 3.314199249
             },
             {
-              "latency": 3.264592977
+              "latency": 3.341825275
             },
             {
-              "latency": 3.29566662
+              "latency": 3.23975659
             },
             {
-              "latency": 3.3698549460000002
+              "latency": 3.321874872
             },
             {
-              "latency": 3.311083258
+              "latency": 3.278362254
+            },
+            {
+              "latency": 3.124827864
+            },
+            {
+              "latency": 3.59559021
+            },
+            {
+              "latency": 3.434240535
+            },
+            {
+              "latency": 3.203083186
+            },
+            {
+              "latency": 3.3258810260000002
             }
           ],
           "implementation": "go-libp2p",
@@ -391,19 +646,34 @@
         {
           "result": [
             {
-              "latency": 1.496852642
+              "latency": 1.465734503
             },
             {
-              "latency": 1.509418385
+              "latency": 1.439333846
             },
             {
-              "latency": 1.54601657
+              "latency": 1.377346196
             },
             {
-              "latency": 1.441479083
+              "latency": 1.528710888
             },
             {
-              "latency": 1.471796599
+              "latency": 1.454201563
+            },
+            {
+              "latency": 1.483803386
+            },
+            {
+              "latency": 1.464000648
+            },
+            {
+              "latency": 1.443742365
+            },
+            {
+              "latency": 1.50068669
+            },
+            {
+              "latency": 1.43957931
             }
           ],
           "implementation": "go-libp2p",
@@ -423,304 +693,304 @@
         {
           "result": [
             {
-              "latency": 0.127214229
+              "latency": 0.130262024
             },
             {
-              "latency": 0.12967814
+              "latency": 0.128570716
             },
             {
-              "latency": 0.126023587
+              "latency": 0.126862933
             },
             {
-              "latency": 0.124388557
+              "latency": 0.130186564
             },
             {
-              "latency": 0.129199817
+              "latency": 0.12885931
             },
             {
-              "latency": 0.126108492
+              "latency": 0.12971741
             },
             {
-              "latency": 0.125744101
+              "latency": 0.125179822
             },
             {
-              "latency": 0.125355319
+              "latency": 0.12672114
             },
             {
-              "latency": 0.122530093
+              "latency": 0.127971613
             },
             {
-              "latency": 0.122319334
+              "latency": 0.125393985
             },
             {
-              "latency": 0.127329778
+              "latency": 0.130711889
             },
             {
-              "latency": 0.123965598
+              "latency": 0.131014071
             },
             {
-              "latency": 0.130539887
+              "latency": 0.125222757
             },
             {
-              "latency": 0.130414585
+              "latency": 0.124870324
             },
             {
-              "latency": 0.121935898
+              "latency": 0.129988297
             },
             {
-              "latency": 0.131279504
+              "latency": 0.127460534
             },
             {
-              "latency": 0.123368608
+              "latency": 0.128893046
             },
             {
-              "latency": 0.124856386
+              "latency": 0.121883011
             },
             {
-              "latency": 0.124805535
+              "latency": 0.130329494
             },
             {
-              "latency": 0.127433649
+              "latency": 0.127364074
             },
             {
-              "latency": 0.125869099
+              "latency": 0.13045117
             },
             {
-              "latency": 0.127532621
+              "latency": 0.125690546
             },
             {
-              "latency": 0.130556971
+              "latency": 0.122082991
             },
             {
-              "latency": 0.124882321
+              "latency": 0.130672069
             },
             {
-              "latency": 0.123306999
+              "latency": 0.130197571
             },
             {
-              "latency": 0.122141899
+              "latency": 0.130648577
             },
             {
-              "latency": 0.122460116
+              "latency": 0.129929378
             },
             {
-              "latency": 0.127692498
+              "latency": 0.12633397
             },
             {
-              "latency": 0.12566607
+              "latency": 0.131808107
             },
             {
-              "latency": 0.124917696
+              "latency": 0.12047408
             },
             {
-              "latency": 0.123668866
+              "latency": 0.127954181
             },
             {
-              "latency": 0.132010442
+              "latency": 0.127619743
             },
             {
-              "latency": 0.125565141
+              "latency": 0.130096292
             },
             {
-              "latency": 0.128188401
+              "latency": 0.126727322
             },
             {
-              "latency": 0.12066406
+              "latency": 0.125591198
             },
             {
-              "latency": 0.123627896
+              "latency": 0.122542022
             },
             {
-              "latency": 0.129437242
+              "latency": 0.125694525
             },
             {
-              "latency": 0.127506578
+              "latency": 0.128565465
             },
             {
-              "latency": 0.128856668
+              "latency": 0.12828781
             },
             {
-              "latency": 0.122323995
+              "latency": 0.129473568
             },
             {
-              "latency": 0.126765529
+              "latency": 0.128263606
             },
             {
-              "latency": 0.130829758
+              "latency": 0.128311841
             },
             {
-              "latency": 0.129333306
+              "latency": 0.128146775
             },
             {
-              "latency": 0.128251328
+              "latency": 0.126527598
             },
             {
-              "latency": 0.130188967
+              "latency": 0.128655501
             },
             {
-              "latency": 0.127728835
+              "latency": 0.131148019
             },
             {
-              "latency": 0.123884005
+              "latency": 0.128236922
             },
             {
-              "latency": 0.128842188
+              "latency": 0.125568703
             },
             {
-              "latency": 0.1243371
+              "latency": 0.123293157
             },
             {
-              "latency": 0.130997034
+              "latency": 0.123729779
             },
             {
-              "latency": 0.125506758
+              "latency": 0.123646178
             },
             {
-              "latency": 0.123668427
+              "latency": 0.127332318
             },
             {
-              "latency": 0.118418875
+              "latency": 0.120461926
             },
             {
-              "latency": 0.127604051
+              "latency": 0.129506062
             },
             {
-              "latency": 0.126118876
+              "latency": 0.129605711
             },
             {
-              "latency": 0.128735237
+              "latency": 0.122345694
             },
             {
-              "latency": 0.128599861
+              "latency": 0.125665594
             },
             {
-              "latency": 0.123620402
+              "latency": 0.131128951
             },
             {
-              "latency": 0.132050815
+              "latency": 0.125492891
             },
             {
-              "latency": 0.127509546
+              "latency": 0.122609226
             },
             {
-              "latency": 0.123579832
+              "latency": 0.12350555
             },
             {
-              "latency": 0.124985756
+              "latency": 0.125215957
             },
             {
-              "latency": 0.12946634
+              "latency": 0.127655413
             },
             {
-              "latency": 0.12482751
+              "latency": 0.132042895
             },
             {
-              "latency": 0.12740606
+              "latency": 0.125404215
             },
             {
-              "latency": 0.125454289
+              "latency": 0.128301012
             },
             {
-              "latency": 0.128075006
+              "latency": 0.126813541
             },
             {
-              "latency": 0.127695811
+              "latency": 0.128631773
             },
             {
-              "latency": 0.131702053
+              "latency": 0.125855292
             },
             {
-              "latency": 0.120863586
+              "latency": 0.13063325
             },
             {
-              "latency": 0.126532519
+              "latency": 0.126574586
             },
             {
-              "latency": 0.123704924
+              "latency": 0.12721898
             },
             {
-              "latency": 0.129031513
+              "latency": 0.121913449
             },
             {
-              "latency": 0.129842467
+              "latency": 0.120567864
             },
             {
-              "latency": 0.127760689
+              "latency": 0.130940076
             },
             {
-              "latency": 0.126782328
+              "latency": 0.126946384
             },
             {
-              "latency": 0.130731034
+              "latency": 0.128784035
             },
             {
-              "latency": 0.125804773
+              "latency": 0.122293174
             },
             {
-              "latency": 0.124776056
+              "latency": 0.128062148
             },
             {
-              "latency": 0.127998566
+              "latency": 0.130448344
             },
             {
-              "latency": 0.126827381
+              "latency": 0.126823361
             },
             {
-              "latency": 0.125521345
+              "latency": 0.125018948
             },
             {
-              "latency": 0.127766601
+              "latency": 0.132008636
             },
             {
-              "latency": 0.126236858
+              "latency": 0.127587435
             },
             {
-              "latency": 0.12811796
+              "latency": 0.132168843
             },
             {
-              "latency": 0.125853092
+              "latency": 0.12944629
             },
             {
-              "latency": 0.124899114
+              "latency": 0.128289956
             },
             {
-              "latency": 0.118348427
+              "latency": 0.120022559
             },
             {
-              "latency": 0.128971027
+              "latency": 0.128052099
             },
             {
-              "latency": 0.123859412
+              "latency": 0.129358433
             },
             {
-              "latency": 0.126629613
+              "latency": 0.128798095
             },
             {
-              "latency": 0.12535468
+              "latency": 0.131449192
             },
             {
-              "latency": 0.12941149
+              "latency": 0.127502184
             },
             {
-              "latency": 0.120161196
+              "latency": 0.127299923
             },
             {
-              "latency": 0.126156975
+              "latency": 0.12982847
             },
             {
-              "latency": 0.124165774
+              "latency": 0.128885188
             },
             {
-              "latency": 0.125692929
+              "latency": 0.127014179
             },
             {
-              "latency": 0.126282072
+              "latency": 0.124961623
             },
             {
-              "latency": 0.123441585
+              "latency": 0.129357142
             },
             {
-              "latency": 0.131975019
+              "latency": 0.129624706
             }
           ],
           "implementation": "quic-go",
@@ -730,304 +1000,304 @@
         {
           "result": [
             {
-              "latency": 0.194218846
+              "latency": 0.190627711
             },
             {
-              "latency": 0.186270807
+              "latency": 0.192461208
             },
             {
-              "latency": 0.183646139
+              "latency": 0.184699938
             },
             {
-              "latency": 0.185830033
+              "latency": 0.196103666
             },
             {
-              "latency": 0.187278833
+              "latency": 0.186447106
             },
             {
-              "latency": 0.181990901
+              "latency": 0.188150307
             },
             {
-              "latency": 0.193450157
+              "latency": 0.183440884
             },
             {
-              "latency": 0.175776862
+              "latency": 0.192725548
             },
             {
-              "latency": 0.190179796
+              "latency": 0.185847765
             },
             {
-              "latency": 0.190624762
+              "latency": 0.189352049
             },
             {
-              "latency": 0.188180435
+              "latency": 0.188393425
             },
             {
-              "latency": 0.183160381
+              "latency": 0.190471126
             },
             {
-              "latency": 0.187484724
+              "latency": 0.179008254
             },
             {
-              "latency": 0.189794546
+              "latency": 0.184669307
             },
             {
-              "latency": 0.189438642
+              "latency": 0.189672809
             },
             {
-              "latency": 0.180929822
+              "latency": 0.180466795
             },
             {
-              "latency": 0.197157803
+              "latency": 0.183568394
             },
             {
-              "latency": 0.189698213
+              "latency": 0.18745548
             },
             {
-              "latency": 0.186506144
+              "latency": 0.187142011
             },
             {
-              "latency": 0.189905996
+              "latency": 0.194725339
             },
             {
-              "latency": 0.189516847
+              "latency": 0.18975723
             },
             {
-              "latency": 0.196772492
+              "latency": 0.192530562
             },
             {
-              "latency": 0.194990298
+              "latency": 0.187890396
             },
             {
-              "latency": 0.184398152
+              "latency": 0.194495156
             },
             {
-              "latency": 0.191102594
+              "latency": 0.189081149
             },
             {
-              "latency": 0.186737444
+              "latency": 0.189092973
             },
             {
-              "latency": 0.186918269
+              "latency": 0.185103249
             },
             {
-              "latency": 0.193699948
+              "latency": 0.178672741
             },
             {
-              "latency": 0.193126678
+              "latency": 0.190884524
             },
             {
-              "latency": 0.181771317
+              "latency": 0.1963014
             },
             {
-              "latency": 0.184399188
+              "latency": 0.181284877
             },
             {
-              "latency": 0.186927694
+              "latency": 0.188341011
             },
             {
-              "latency": 0.188242836
+              "latency": 0.193323246
             },
             {
-              "latency": 0.185699879
+              "latency": 0.180606598
             },
             {
-              "latency": 0.194061017
+              "latency": 0.192197745
             },
             {
-              "latency": 0.175540397
+              "latency": 0.192513894
             },
             {
-              "latency": 0.185716205
+              "latency": 0.186287672
             },
             {
-              "latency": 0.187396906
+              "latency": 0.189049462
             },
             {
-              "latency": 0.195113239
+              "latency": 0.191357348
             },
             {
-              "latency": 0.178656007
+              "latency": 0.184460139
             },
             {
-              "latency": 0.186962654
+              "latency": 0.187911831
             },
             {
-              "latency": 0.184946524
+              "latency": 0.18223307
             },
             {
-              "latency": 0.193068853
+              "latency": 0.182647927
             },
             {
-              "latency": 0.192602635
+              "latency": 0.184045463
             },
             {
-              "latency": 0.190662601
+              "latency": 0.183323835
             },
             {
-              "latency": 0.18034776
+              "latency": 0.195029594
             },
             {
-              "latency": 0.183423135
+              "latency": 0.192443444
             },
             {
-              "latency": 0.1944447
+              "latency": 0.186025571
             },
             {
-              "latency": 0.183802957
+              "latency": 0.194878416
             },
             {
-              "latency": 0.190416596
+              "latency": 0.183901758
             },
             {
-              "latency": 0.192492188
+              "latency": 0.19151601
             },
             {
-              "latency": 0.187679272
+              "latency": 0.192196279
             },
             {
-              "latency": 0.186440217
+              "latency": 0.19209992
             },
             {
-              "latency": 0.18658919
+              "latency": 0.178886997
             },
             {
-              "latency": 0.185341831
+              "latency": 0.190636188
             },
             {
-              "latency": 0.191869498
+              "latency": 0.192396
             },
             {
-              "latency": 0.191670622
+              "latency": 0.188706102
             },
             {
-              "latency": 0.184572974
+              "latency": 0.191122847
             },
             {
-              "latency": 0.181995951
+              "latency": 0.189538745
             },
             {
-              "latency": 0.191530767
+              "latency": 0.186768028
             },
             {
-              "latency": 0.188200087
+              "latency": 0.184977304
             },
             {
-              "latency": 0.186270991
+              "latency": 0.191114897
             },
             {
-              "latency": 0.182059885
+              "latency": 0.189272909
             },
             {
-              "latency": 0.184166603
+              "latency": 0.188183916
             },
             {
-              "latency": 0.19452269
+              "latency": 0.194458635
             },
             {
-              "latency": 0.18574282
+              "latency": 0.177477909
             },
             {
-              "latency": 0.179038632
+              "latency": 0.182083439
             },
             {
-              "latency": 0.186057472
+              "latency": 0.182500637
             },
             {
-              "latency": 0.189575057
+              "latency": 0.188213349
             },
             {
-              "latency": 0.189817901
+              "latency": 0.18330841
             },
             {
-              "latency": 0.187481631
+              "latency": 0.193262952
             },
             {
-              "latency": 0.189836409
+              "latency": 0.182102041
             },
             {
-              "latency": 0.196472354
+              "latency": 0.191740153
             },
             {
-              "latency": 0.192609945
+              "latency": 0.192991738
             },
             {
-              "latency": 0.188032994
+              "latency": 0.187311541
             },
             {
-              "latency": 0.192258865
+              "latency": 0.196941648
             },
             {
-              "latency": 0.191789064
+              "latency": 0.186569112
             },
             {
-              "latency": 0.192438002
+              "latency": 0.192079676
             },
             {
-              "latency": 0.188946734
+              "latency": 0.186736134
             },
             {
-              "latency": 0.180480858
+              "latency": 0.193077851
             },
             {
-              "latency": 0.194344815
+              "latency": 0.183890304
             },
             {
-              "latency": 0.176782124
+              "latency": 0.192201036
             },
             {
-              "latency": 0.182507605
+              "latency": 0.190774525
             },
             {
-              "latency": 0.191957028
+              "latency": 0.190619875
             },
             {
-              "latency": 0.182256689
+              "latency": 0.189988623
             },
             {
-              "latency": 0.189126101
+              "latency": 0.186696314
             },
             {
-              "latency": 0.195205855
+              "latency": 0.187875347
             },
             {
-              "latency": 0.184396175
+              "latency": 0.18271451
             },
             {
-              "latency": 0.192468737
+              "latency": 0.19413555
             },
             {
-              "latency": 0.188096391
+              "latency": 0.192522298
             },
             {
-              "latency": 0.186463049
+              "latency": 0.193670934
             },
             {
-              "latency": 0.185754725
+              "latency": 0.19405851
             },
             {
-              "latency": 0.193951898
+              "latency": 0.191250438
             },
             {
-              "latency": 0.1791366
+              "latency": 0.188142223
             },
             {
-              "latency": 0.183296858
+              "latency": 0.184133286
             },
             {
-              "latency": 0.188009287
+              "latency": 0.18360838
             },
             {
-              "latency": 0.193217943
+              "latency": 0.189272956
             },
             {
-              "latency": 0.189667543
+              "latency": 0.190088723
             },
             {
-              "latency": 0.189932026
+              "latency": 0.195036277
             },
             {
-              "latency": 0.192134304
+              "latency": 0.19352322
             }
           ],
           "implementation": "rust-libp2p",
@@ -1037,304 +1307,304 @@
         {
           "result": [
             {
-              "latency": 0.124422348
+              "latency": 0.12811597
             },
             {
-              "latency": 0.128469898
+              "latency": 0.124789475
             },
             {
-              "latency": 0.122740617
+              "latency": 0.126372035
             },
             {
-              "latency": 0.125794005
+              "latency": 0.120904417
             },
             {
-              "latency": 0.12376399
+              "latency": 0.120637727
             },
             {
-              "latency": 0.121100156
+              "latency": 0.124564962
             },
             {
-              "latency": 0.123656405
+              "latency": 0.126052878
             },
             {
-              "latency": 0.125634038
+              "latency": 0.123387739
             },
             {
-              "latency": 0.126343672
+              "latency": 0.127165814
             },
             {
-              "latency": 0.123708389
+              "latency": 0.129210673
             },
             {
-              "latency": 0.123466185
+              "latency": 0.128519468
             },
             {
-              "latency": 0.123998982
+              "latency": 0.128606975
             },
             {
-              "latency": 0.127201393
+              "latency": 0.130144053
             },
             {
-              "latency": 0.131684383
+              "latency": 0.125917781
             },
             {
-              "latency": 0.129670856
+              "latency": 0.127613788
             },
             {
-              "latency": 0.125362863
+              "latency": 0.122052662
             },
             {
-              "latency": 0.124611248
+              "latency": 0.126564038
             },
             {
-              "latency": 0.124736388
+              "latency": 0.126545969
             },
             {
-              "latency": 0.129027205
+              "latency": 0.131982157
             },
             {
-              "latency": 0.127344316
+              "latency": 0.123469897
             },
             {
-              "latency": 0.129790943
+              "latency": 0.125012163
             },
             {
-              "latency": 0.1314637
+              "latency": 0.129327936
             },
             {
-              "latency": 0.123408672
+              "latency": 0.127819515
             },
             {
-              "latency": 0.123703759
+              "latency": 0.126892772
             },
             {
-              "latency": 0.125894415
+              "latency": 0.123688768
             },
             {
-              "latency": 0.128975593
+              "latency": 0.120817009
             },
             {
-              "latency": 0.125036905
+              "latency": 0.122784964
             },
             {
-              "latency": 0.129354022
+              "latency": 0.129384255
             },
             {
-              "latency": 0.118937645
+              "latency": 0.129411816
             },
             {
-              "latency": 0.129224489
+              "latency": 0.123783164
             },
             {
-              "latency": 0.129317175
+              "latency": 0.131267888
             },
             {
-              "latency": 0.128769443
+              "latency": 0.126201517
             },
             {
-              "latency": 0.126839206
+              "latency": 0.131795042
             },
             {
-              "latency": 0.124418321
+              "latency": 0.123604161
             },
             {
-              "latency": 0.128423534
+              "latency": 0.128827126
             },
             {
-              "latency": 0.127623403
+              "latency": 0.127628664
             },
             {
-              "latency": 0.131072762
+              "latency": 0.127149104
             },
             {
-              "latency": 0.127136292
+              "latency": 0.125795177
             },
             {
-              "latency": 0.125761341
+              "latency": 0.123961378
             },
             {
-              "latency": 0.128604717
+              "latency": 0.130157567
             },
             {
-              "latency": 0.132533274
+              "latency": 0.127715946
             },
             {
-              "latency": 0.121593657
+              "latency": 0.126049754
             },
             {
-              "latency": 0.125712261
+              "latency": 0.131163836
             },
             {
-              "latency": 0.119539386
+              "latency": 0.126612671
             },
             {
-              "latency": 0.129331714
+              "latency": 0.125683501
             },
             {
-              "latency": 0.127079257
+              "latency": 0.126244319
             },
             {
-              "latency": 0.12717244
+              "latency": 0.124873839
             },
             {
-              "latency": 0.124905121
+              "latency": 0.125944204
             },
             {
-              "latency": 0.127886053
+              "latency": 0.125651046
             },
             {
-              "latency": 0.128452179
+              "latency": 0.130966918
             },
             {
-              "latency": 0.131175414
+              "latency": 0.128671877
             },
             {
-              "latency": 0.129458151
+              "latency": 0.123691527
             },
             {
-              "latency": 0.126836744
+              "latency": 0.126546251
             },
             {
-              "latency": 0.129528068
+              "latency": 0.1280334
             },
             {
-              "latency": 0.125625299
+              "latency": 0.132062006
             },
             {
-              "latency": 0.129838575
+              "latency": 0.124649123
             },
             {
-              "latency": 0.128960195
+              "latency": 0.12923521
             },
             {
-              "latency": 0.131218908
+              "latency": 0.127839869
             },
             {
-              "latency": 0.128908431
+              "latency": 0.127954902
             },
             {
-              "latency": 0.129193336
+              "latency": 0.128401955
             },
             {
-              "latency": 0.124709245
+              "latency": 0.127036005
             },
             {
-              "latency": 0.129313288
+              "latency": 0.120606084
             },
             {
-              "latency": 0.124344085
+              "latency": 0.127859652
             },
             {
-              "latency": 0.13272023
+              "latency": 0.130724177
             },
             {
-              "latency": 0.126641877
+              "latency": 0.127733868
             },
             {
-              "latency": 0.124574939
+              "latency": 0.119746556
             },
             {
-              "latency": 0.130392053
+              "latency": 0.119545276
             },
             {
-              "latency": 0.12693028
+              "latency": 0.127724803
             },
             {
-              "latency": 0.129333498
+              "latency": 0.124970079
             },
             {
-              "latency": 0.127630704
+              "latency": 0.129390577
             },
             {
-              "latency": 0.123781629
+              "latency": 0.12161423
             },
             {
-              "latency": 0.129552236
+              "latency": 0.127261176
             },
             {
-              "latency": 0.120754165
+              "latency": 0.126943644
             },
             {
-              "latency": 0.129194029
+              "latency": 0.12669572
             },
             {
-              "latency": 0.127300747
+              "latency": 0.127627133
             },
             {
-              "latency": 0.121427091
+              "latency": 0.128413166
             },
             {
-              "latency": 0.122446841
+              "latency": 0.129163169
             },
             {
-              "latency": 0.127639393
+              "latency": 0.124688259
             },
             {
-              "latency": 0.122742835
+              "latency": 0.119536477
             },
             {
-              "latency": 0.127814323
+              "latency": 0.125807408
             },
             {
-              "latency": 0.123929297
+              "latency": 0.129775072
             },
             {
-              "latency": 0.130611874
+              "latency": 0.123357854
             },
             {
-              "latency": 0.128481455
+              "latency": 0.127696742
             },
             {
-              "latency": 0.127287811
+              "latency": 0.12963761
             },
             {
-              "latency": 0.127163738
+              "latency": 0.125889972
             },
             {
-              "latency": 0.129490084
+              "latency": 0.126748994
             },
             {
-              "latency": 0.125295056
+              "latency": 0.128127017
             },
             {
-              "latency": 0.12614799
+              "latency": 0.129970545
             },
             {
-              "latency": 0.130459294
+              "latency": 0.126708109
             },
             {
-              "latency": 0.129585409
+              "latency": 0.128519504
             },
             {
-              "latency": 0.124837699
+              "latency": 0.129591682
             },
             {
-              "latency": 0.122643763
+              "latency": 0.126517701
             },
             {
-              "latency": 0.127213107
+              "latency": 0.127782152
             },
             {
-              "latency": 0.127683216
+              "latency": 0.128583472
             },
             {
-              "latency": 0.125516267
+              "latency": 0.130039502
             },
             {
-              "latency": 0.128976354
+              "latency": 0.129614569
             },
             {
-              "latency": 0.127309003
+              "latency": 0.123534188
             },
             {
-              "latency": 0.122446634
+              "latency": 0.128357387
             },
             {
-              "latency": 0.125789073
+              "latency": 0.121480009
             },
             {
-              "latency": 0.122456029
+              "latency": 0.124135706
             }
           ],
           "implementation": "rust-libp2p",
@@ -1344,304 +1614,304 @@
         {
           "result": [
             {
-              "latency": 0.127854274
+              "latency": 0.129253225
             },
             {
-              "latency": 0.126604244
+              "latency": 0.120992426
             },
             {
-              "latency": 0.130133431
+              "latency": 0.127794513
             },
             {
-              "latency": 0.129782494
+              "latency": 0.125173785
             },
             {
-              "latency": 0.129890867
+              "latency": 0.123004431
             },
             {
-              "latency": 0.119488005
+              "latency": 0.126255492
             },
             {
-              "latency": 0.128429649
+              "latency": 0.129611755
             },
             {
-              "latency": 0.121970348
+              "latency": 0.132357179
             },
             {
-              "latency": 0.129158356
+              "latency": 0.124956746
             },
             {
-              "latency": 0.126287628
+              "latency": 0.12974081
             },
             {
-              "latency": 0.127952601
+              "latency": 0.127849058
             },
             {
-              "latency": 0.122574773
+              "latency": 0.128518586
             },
             {
-              "latency": 0.120958912
+              "latency": 0.127843881
             },
             {
-              "latency": 0.130814822
+              "latency": 0.12553246
             },
             {
-              "latency": 0.127160071
+              "latency": 0.126804165
             },
             {
-              "latency": 0.123849408
+              "latency": 0.126786534
             },
             {
-              "latency": 0.127908574
+              "latency": 0.124032901
             },
             {
-              "latency": 0.12547734
+              "latency": 0.127235531
             },
             {
-              "latency": 0.127583973
+              "latency": 0.124136607
             },
             {
-              "latency": 0.128796662
+              "latency": 0.130733362
             },
             {
-              "latency": 0.128329001
+              "latency": 0.127513688
             },
             {
-              "latency": 0.126682669
+              "latency": 0.124025611
             },
             {
-              "latency": 0.127354983
+              "latency": 0.128925818
             },
             {
-              "latency": 0.132450679
+              "latency": 0.127735785
             },
             {
-              "latency": 0.127982619
+              "latency": 0.121851315
             },
             {
-              "latency": 0.128506449
+              "latency": 0.126414577
             },
             {
-              "latency": 0.132420053
+              "latency": 0.129566059
             },
             {
-              "latency": 0.124381227
+              "latency": 0.123036983
             },
             {
-              "latency": 0.12730083
+              "latency": 0.123159631
             },
             {
-              "latency": 0.122720312
+              "latency": 0.129174664
             },
             {
-              "latency": 0.125738658
+              "latency": 0.126903441
             },
             {
-              "latency": 0.128260817
+              "latency": 0.126550001
             },
             {
-              "latency": 0.129488023
+              "latency": 0.126527184
             },
             {
-              "latency": 0.126414291
+              "latency": 0.124334898
             },
             {
-              "latency": 0.125207541
+              "latency": 0.12970265
             },
             {
-              "latency": 0.1270317
+              "latency": 0.125648769
             },
             {
-              "latency": 0.124218078
+              "latency": 0.120883942
             },
             {
-              "latency": 0.124418406
+              "latency": 0.124703726
             },
             {
-              "latency": 0.119992763
+              "latency": 0.127792299
             },
             {
-              "latency": 0.127331204
+              "latency": 0.130565845
             },
             {
-              "latency": 0.127992107
+              "latency": 0.126723846
             },
             {
-              "latency": 0.12585886
+              "latency": 0.129773542
             },
             {
-              "latency": 0.126330241
+              "latency": 0.11981029
             },
             {
-              "latency": 0.129532065
+              "latency": 0.12806726
             },
             {
-              "latency": 0.121945126
+              "latency": 0.12379312
             },
             {
-              "latency": 0.131264237
+              "latency": 0.128898187
             },
             {
-              "latency": 0.125884237
+              "latency": 0.128392173
             },
             {
-              "latency": 0.127923409
+              "latency": 0.127855439
             },
             {
-              "latency": 0.129023979
+              "latency": 0.129039942
             },
             {
-              "latency": 0.126420962
+              "latency": 0.122275896
             },
             {
-              "latency": 0.120945096
+              "latency": 0.130721956
             },
             {
-              "latency": 0.126158449
+              "latency": 0.13245085
             },
             {
-              "latency": 0.125590734
+              "latency": 0.131739374
             },
             {
-              "latency": 0.128716671
+              "latency": 0.123994691
             },
             {
-              "latency": 0.12202694
+              "latency": 0.126573789
             },
             {
-              "latency": 0.123708109
+              "latency": 0.129863538
             },
             {
-              "latency": 0.125295792
+              "latency": 0.125176607
             },
             {
-              "latency": 0.128585705
+              "latency": 0.126310235
             },
             {
-              "latency": 0.128638405
+              "latency": 0.130172198
             },
             {
-              "latency": 0.121670141
+              "latency": 0.120050381
             },
             {
-              "latency": 0.128867665
+              "latency": 0.125403436
             },
             {
-              "latency": 0.127401355
+              "latency": 0.123432653
             },
             {
-              "latency": 0.129501587
+              "latency": 0.127454803
             },
             {
-              "latency": 0.127179087
+              "latency": 0.126785744
             },
             {
-              "latency": 0.128178943
+              "latency": 0.129909776
             },
             {
-              "latency": 0.125564376
+              "latency": 0.129760822
             },
             {
-              "latency": 0.131506077
+              "latency": 0.130975282
             },
             {
-              "latency": 0.130142083
+              "latency": 0.120186959
             },
             {
-              "latency": 0.126315225
+              "latency": 0.120669694
             },
             {
-              "latency": 0.129986442
+              "latency": 0.130480812
             },
             {
-              "latency": 0.130725803
+              "latency": 0.126076557
             },
             {
-              "latency": 0.118661672
+              "latency": 0.129603203
             },
             {
-              "latency": 0.131110509
+              "latency": 0.132276156
             },
             {
-              "latency": 0.13121567
+              "latency": 0.126123828
             },
             {
-              "latency": 0.132200892
+              "latency": 0.125318682
             },
             {
-              "latency": 0.123009734
+              "latency": 0.125005129
             },
             {
-              "latency": 0.122810849
+              "latency": 0.130904236
             },
             {
-              "latency": 0.128636313
+              "latency": 0.123956473
             },
             {
-              "latency": 0.128488534
+              "latency": 0.130915569
             },
             {
-              "latency": 0.128147351
+              "latency": 0.127342703
             },
             {
-              "latency": 0.132623881
+              "latency": 0.128647742
             },
             {
-              "latency": 0.12833436
+              "latency": 0.124434508
             },
             {
-              "latency": 0.119751982
+              "latency": 0.127443945
             },
             {
-              "latency": 0.127531919
+              "latency": 0.13229918
             },
             {
-              "latency": 0.129668764
+              "latency": 0.12698574
             },
             {
-              "latency": 0.12423661
+              "latency": 0.124051809
             },
             {
-              "latency": 0.126120563
+              "latency": 0.13257902
             },
             {
-              "latency": 0.125938925
+              "latency": 0.122781578
             },
             {
-              "latency": 0.131111285
+              "latency": 0.123931942
             },
             {
-              "latency": 0.125216571
+              "latency": 0.126152322
             },
             {
-              "latency": 0.125298742
+              "latency": 0.124101892
             },
             {
-              "latency": 0.126177718
+              "latency": 0.125560839
             },
             {
-              "latency": 0.130609737
+              "latency": 0.126037549
             },
             {
-              "latency": 0.121083056
+              "latency": 0.126684446
             },
             {
-              "latency": 0.123775449
+              "latency": 0.124384805
             },
             {
-              "latency": 0.127904692
+              "latency": 0.128106469
             },
             {
-              "latency": 0.12994176
+              "latency": 0.127840571
             },
             {
-              "latency": 0.129256643
+              "latency": 0.119714762
             },
             {
-              "latency": 0.125665206
+              "latency": 0.12732267
             },
             {
-              "latency": 0.128888732
+              "latency": 0.129027661
             }
           ],
           "implementation": "rust-libp2p-quinn",
@@ -1651,304 +1921,304 @@
         {
           "result": [
             {
-              "latency": 0.193485727
+              "latency": 0.190357888
             },
             {
-              "latency": 0.178787526
+              "latency": 0.18823835
             },
             {
-              "latency": 0.185131576
+              "latency": 0.193502129
             },
             {
-              "latency": 0.184677244
+              "latency": 0.186944677
             },
             {
-              "latency": 0.183953805
+              "latency": 0.185398405
             },
             {
-              "latency": 0.184522364
+              "latency": 0.184677343
             },
             {
-              "latency": 0.191940658
+              "latency": 0.188721728
             },
             {
-              "latency": 0.186185203
+              "latency": 0.19007251
             },
             {
-              "latency": 0.195981677
+              "latency": 0.183344695
             },
             {
-              "latency": 0.187777759
+              "latency": 0.194370641
             },
             {
-              "latency": 0.184021804
+              "latency": 0.186728883
             },
             {
-              "latency": 0.188955789
+              "latency": 0.193721346
             },
             {
-              "latency": 0.195498468
+              "latency": 0.190081454
             },
             {
-              "latency": 0.191022241
+              "latency": 0.185290636
             },
             {
-              "latency": 0.181700182
+              "latency": 0.190866474
             },
             {
-              "latency": 0.193937848
+              "latency": 0.192710336
             },
             {
-              "latency": 0.187702698
+              "latency": 0.182961764
             },
             {
-              "latency": 0.187177
+              "latency": 0.184200087
             },
             {
-              "latency": 0.180069192
+              "latency": 0.188721432
             },
             {
-              "latency": 0.190953312
+              "latency": 0.180243319
             },
             {
-              "latency": 0.185279035
+              "latency": 0.187193472
             },
             {
-              "latency": 0.191860281
+              "latency": 0.188730645
             },
             {
-              "latency": 0.185055697
+              "latency": 0.18116596
             },
             {
-              "latency": 0.195068544
+              "latency": 0.187692769
             },
             {
-              "latency": 0.193263621
+              "latency": 0.188529491
             },
             {
-              "latency": 0.189028456
+              "latency": 0.177264229
             },
             {
-              "latency": 0.182690179
+              "latency": 0.184251306
             },
             {
-              "latency": 0.19163827
+              "latency": 0.191826205
             },
             {
-              "latency": 0.191376091
+              "latency": 0.189384189
             },
             {
-              "latency": 0.192894997
+              "latency": 0.181575856
             },
             {
-              "latency": 0.178761463
+              "latency": 0.1868405
             },
             {
-              "latency": 0.181762188
+              "latency": 0.185685798
             },
             {
-              "latency": 0.18931091
+              "latency": 0.194558269
             },
             {
-              "latency": 0.192077317
+              "latency": 0.188638303
             },
             {
-              "latency": 0.1900432
+              "latency": 0.183394177
             },
             {
-              "latency": 0.181576168
+              "latency": 0.186840281
             },
             {
-              "latency": 0.188925779
+              "latency": 0.191976025
             },
             {
-              "latency": 0.186857773
+              "latency": 0.189662876
             },
             {
-              "latency": 0.191990926
+              "latency": 0.188344154
             },
             {
-              "latency": 0.190410558
+              "latency": 0.187463016
             },
             {
-              "latency": 0.184876576
+              "latency": 0.180032957
             },
             {
-              "latency": 0.192006206
+              "latency": 0.187019743
             },
             {
-              "latency": 0.193694983
+              "latency": 0.192867798
             },
             {
-              "latency": 0.192546055
+              "latency": 0.184519393
             },
             {
-              "latency": 0.18566961
+              "latency": 0.184530488
             },
             {
-              "latency": 0.185789311
+              "latency": 0.179558167
             },
             {
-              "latency": 0.193343491
+              "latency": 0.185009052
             },
             {
-              "latency": 0.189039576
+              "latency": 0.187063552
             },
             {
-              "latency": 0.183330458
+              "latency": 0.187622824
             },
             {
-              "latency": 0.184559011
+              "latency": 0.187156578
             },
             {
-              "latency": 0.192230705
+              "latency": 0.18454719
             },
             {
-              "latency": 0.184778843
+              "latency": 0.193381061
             },
             {
-              "latency": 0.181408323
+              "latency": 0.190439189
             },
             {
-              "latency": 0.188857879
+              "latency": 0.186133751
             },
             {
-              "latency": 0.176708632
+              "latency": 0.191378424
             },
             {
-              "latency": 0.192941697
+              "latency": 0.196597466
             },
             {
-              "latency": 0.182559502
+              "latency": 0.181620943
             },
             {
-              "latency": 0.188710699
+              "latency": 0.185391704
             },
             {
-              "latency": 0.181543066
+              "latency": 0.187016833
             },
             {
-              "latency": 0.181610281
+              "latency": 0.193064583
             },
             {
-              "latency": 0.176637296
+              "latency": 0.193513044
             },
             {
-              "latency": 0.188493714
+              "latency": 0.192763077
             },
             {
-              "latency": 0.193581343
+              "latency": 0.188394843
             },
             {
-              "latency": 0.184383793
+              "latency": 0.19299158
             },
             {
-              "latency": 0.19149086
+              "latency": 0.196268045
             },
             {
-              "latency": 0.188605219
+              "latency": 0.185137267
             },
             {
-              "latency": 0.184762157
+              "latency": 0.192111754
             },
             {
-              "latency": 0.191397637
+              "latency": 0.182977219
             },
             {
-              "latency": 0.190275274
+              "latency": 0.19555567
             },
             {
-              "latency": 0.181586179
+              "latency": 0.178604788
             },
             {
-              "latency": 0.193266514
+              "latency": 0.190717233
             },
             {
-              "latency": 0.190714509
+              "latency": 0.189826225
             },
             {
-              "latency": 0.190301564
+              "latency": 0.185693551
             },
             {
-              "latency": 0.187424962
+              "latency": 0.187102689
             },
             {
-              "latency": 0.181221166
+              "latency": 0.182994043
             },
             {
-              "latency": 0.18737125
+              "latency": 0.185836346
             },
             {
-              "latency": 0.17757263
+              "latency": 0.181381291
             },
             {
-              "latency": 0.187213395
+              "latency": 0.182340175
             },
             {
-              "latency": 0.188529349
+              "latency": 0.193260226
             },
             {
-              "latency": 0.185056356
+              "latency": 0.185036795
             },
             {
-              "latency": 0.188851428
+              "latency": 0.184272997
             },
             {
-              "latency": 0.184771385
+              "latency": 0.1955738
             },
             {
-              "latency": 0.184787911
+              "latency": 0.194294429
             },
             {
-              "latency": 0.184758304
+              "latency": 0.187636176
             },
             {
-              "latency": 0.184929213
+              "latency": 0.191573772
             },
             {
-              "latency": 0.191497547
+              "latency": 0.183214692
             },
             {
-              "latency": 0.191787333
+              "latency": 0.185317688
             },
             {
-              "latency": 0.191561316
+              "latency": 0.189071558
             },
             {
-              "latency": 0.191863766
+              "latency": 0.184966647
             },
             {
-              "latency": 0.185653866
+              "latency": 0.183713326
             },
             {
-              "latency": 0.187978077
+              "latency": 0.187418733
             },
             {
-              "latency": 0.191816017
+              "latency": 0.187445519
             },
             {
-              "latency": 0.188855038
+              "latency": 0.193242968
             },
             {
-              "latency": 0.177263273
+              "latency": 0.19235868
             },
             {
-              "latency": 0.194472491
+              "latency": 0.188826084
             },
             {
-              "latency": 0.181256762
+              "latency": 0.189070575
             },
             {
-              "latency": 0.19174606
+              "latency": 0.190957977
             },
             {
-              "latency": 0.193407689
+              "latency": 0.195550153
             },
             {
-              "latency": 0.18576596
+              "latency": 0.190161924
             },
             {
-              "latency": 0.188573789
+              "latency": 0.19499978
             }
           ],
           "implementation": "https",
@@ -1958,304 +2228,304 @@
         {
           "result": [
             {
-              "latency": 0.38077505
+              "latency": 0.326050436
             },
             {
-              "latency": 0.309419301
+              "latency": 0.321465816
             },
             {
-              "latency": 0.309326292
+              "latency": 0.298936022
             },
             {
-              "latency": 0.375324091
+              "latency": 0.323471226
             },
             {
-              "latency": 0.379457538
+              "latency": 0.375144506
             },
             {
-              "latency": 0.377940969
+              "latency": 0.320176246
             },
             {
-              "latency": 0.321994407
+              "latency": 0.32011952
             },
             {
-              "latency": 0.320266785
+              "latency": 0.315361864
             },
             {
-              "latency": 0.376563966
+              "latency": 0.304203379
             },
             {
-              "latency": 0.323063854
+              "latency": 0.311985032
             },
             {
-              "latency": 0.319768672
+              "latency": 0.364894052
             },
             {
-              "latency": 0.306688627
+              "latency": 0.321872657
             },
             {
-              "latency": 0.320838538
+              "latency": 0.306352253
             },
             {
-              "latency": 0.319597099
+              "latency": 0.312132562
             },
             {
-              "latency": 0.38238837
+              "latency": 0.365266471
             },
             {
-              "latency": 0.376296811
+              "latency": 0.313693717
             },
             {
-              "latency": 0.316491497
+              "latency": 0.326262565
             },
             {
-              "latency": 0.32028804
+              "latency": 0.309983976
             },
             {
-              "latency": 0.359127047
+              "latency": 0.319658684
             },
             {
-              "latency": 0.317116585
+              "latency": 0.314874256
             },
             {
-              "latency": 0.329328375
+              "latency": 0.373173575
             },
             {
-              "latency": 0.314887205
+              "latency": 0.316812908
             },
             {
-              "latency": 0.321134772
+              "latency": 0.371435108
             },
             {
-              "latency": 0.311074203
+              "latency": 0.381003299
             },
             {
-              "latency": 0.378318307
+              "latency": 0.314622443
             },
             {
-              "latency": 0.316557243
+              "latency": 0.30252086
             },
             {
-              "latency": 0.304199255
+              "latency": 0.313830389
             },
             {
-              "latency": 0.373833145
+              "latency": 0.382093678
             },
             {
-              "latency": 0.295940542
+              "latency": 0.328794401
             },
             {
-              "latency": 0.320181249
+              "latency": 0.30983641
             },
             {
-              "latency": 0.381780932
+              "latency": 0.300746238
             },
             {
-              "latency": 0.382544379
+              "latency": 0.380255262
             },
             {
-              "latency": 0.314091961
+              "latency": 0.317449205
             },
             {
-              "latency": 0.376240639
+              "latency": 0.388565518
             },
             {
-              "latency": 0.378874757
+              "latency": 0.318744369
             },
             {
-              "latency": 0.310700958
+              "latency": 0.30944637
             },
             {
-              "latency": 0.305296353
+              "latency": 0.312542088
             },
             {
-              "latency": 0.364721967
+              "latency": 0.326019548
             },
             {
-              "latency": 0.315092968
+              "latency": 0.321992163
             },
             {
-              "latency": 0.327965471
+              "latency": 0.308456047
             },
             {
-              "latency": 0.37509162
+              "latency": 0.315039179
             },
             {
-              "latency": 0.377422774
+              "latency": 0.387239405
             },
             {
-              "latency": 0.373808225
+              "latency": 0.378909875
             },
             {
-              "latency": 0.369594122
+              "latency": 0.325765132
             },
             {
-              "latency": 0.306337882
+              "latency": 0.319556877
             },
             {
-              "latency": 0.375444785
+              "latency": 0.380319829
             },
             {
-              "latency": 0.298726073
+              "latency": 0.325162899
             },
             {
-              "latency": 0.360520035
+              "latency": 0.309129603
             },
             {
-              "latency": 0.379319989
+              "latency": 0.379201575
             },
             {
-              "latency": 0.368048255
+              "latency": 0.307652423
             },
             {
-              "latency": 0.311691436
+              "latency": 0.325099643
             },
             {
-              "latency": 0.317495582
+              "latency": 0.309546144
             },
             {
-              "latency": 0.312252292
+              "latency": 0.310207336
             },
             {
-              "latency": 0.373468338
+              "latency": 0.297443081
             },
             {
-              "latency": 0.364248443
+              "latency": 0.370208092
             },
             {
-              "latency": 0.316937654
+              "latency": 0.306246285
             },
             {
-              "latency": 0.316913965
+              "latency": 0.295339911
             },
             {
-              "latency": 0.304222588
+              "latency": 0.377288627
             },
             {
-              "latency": 0.392912795
+              "latency": 0.313219661
             },
             {
-              "latency": 0.377576599
+              "latency": 0.310047679
             },
             {
-              "latency": 0.319979818
+              "latency": 0.364992418
             },
             {
-              "latency": 0.308048928
+              "latency": 0.373543668
             },
             {
-              "latency": 0.314377428
+              "latency": 0.379574957
             },
             {
-              "latency": 0.375666383
+              "latency": 0.376620639
             },
             {
-              "latency": 0.304390635
+              "latency": 0.367233648
             },
             {
-              "latency": 0.307329312
+              "latency": 0.324175824
             },
             {
-              "latency": 0.3222666
+              "latency": 0.314308542
             },
             {
-              "latency": 0.317670487
+              "latency": 0.30697509
             },
             {
-              "latency": 0.31934422
+              "latency": 0.314128405
             },
             {
-              "latency": 0.320887917
+              "latency": 0.327109905
             },
             {
-              "latency": 0.297535694
+              "latency": 0.307860412
             },
             {
-              "latency": 0.30569929
+              "latency": 0.317412139
             },
             {
-              "latency": 0.323138368
+              "latency": 0.365031424
             },
             {
-              "latency": 0.312043621
+              "latency": 0.323764823
             },
             {
-              "latency": 0.372526959
+              "latency": 0.312581808
             },
             {
-              "latency": 0.303863038
+              "latency": 0.307257137
             },
             {
-              "latency": 0.382970318
+              "latency": 0.370555528
             },
             {
-              "latency": 0.304913383
+              "latency": 0.309686327
             },
             {
-              "latency": 0.388146935
+              "latency": 0.312925728
             },
             {
-              "latency": 0.30481386
+              "latency": 0.293482291
             },
             {
-              "latency": 0.373349994
+              "latency": 0.316757158
             },
             {
-              "latency": 0.378817139
+              "latency": 0.319754722
             },
             {
-              "latency": 0.305681207
+              "latency": 0.304695639
             },
             {
-              "latency": 0.314268736
+              "latency": 0.313447389
             },
             {
-              "latency": 0.318265443
+              "latency": 0.359050115
             },
             {
-              "latency": 0.302294148
+              "latency": 0.383777424
             },
             {
-              "latency": 0.389977972
+              "latency": 0.323298775
             },
             {
-              "latency": 0.326494914
+              "latency": 0.370884695
             },
             {
-              "latency": 0.318249367
+              "latency": 0.312745787
             },
             {
-              "latency": 0.323189649
+              "latency": 0.388327693
             },
             {
-              "latency": 0.315443137
+              "latency": 0.364309733
             },
             {
-              "latency": 0.381208979
+              "latency": 0.305372356
             },
             {
-              "latency": 0.367951604
+              "latency": 0.302948051
             },
             {
-              "latency": 0.314612321
+              "latency": 0.31731025
             },
             {
-              "latency": 0.310367895
+              "latency": 0.390864063
             },
             {
-              "latency": 0.317875574
+              "latency": 0.30699603
             },
             {
-              "latency": 0.312287519
+              "latency": 0.372380398
             },
             {
-              "latency": 0.373540369
+              "latency": 0.306033349
             },
             {
-              "latency": 0.316710681
+              "latency": 0.387492617
             },
             {
-              "latency": 0.304437416
+              "latency": 0.314043603
             }
           ],
           "implementation": "go-libp2p",
@@ -2265,304 +2535,304 @@
         {
           "result": [
             {
-              "latency": 0.187555845
+              "latency": 0.187676313
             },
             {
-              "latency": 0.194649522
+              "latency": 0.190409229
             },
             {
-              "latency": 0.188361929
+              "latency": 0.192623745
             },
             {
-              "latency": 0.195345023
+              "latency": 0.19995602
             },
             {
-              "latency": 0.185826778
+              "latency": 0.181316326
             },
             {
-              "latency": 0.19490548
+              "latency": 0.189393077
             },
             {
-              "latency": 0.187847498
+              "latency": 0.196016487
             },
             {
-              "latency": 0.19622459
+              "latency": 0.195605248
             },
             {
-              "latency": 0.196618772
+              "latency": 0.197272961
             },
             {
-              "latency": 0.19129429
+              "latency": 0.187416307
             },
             {
-              "latency": 0.187560352
+              "latency": 0.186176318
             },
             {
-              "latency": 0.190586502
+              "latency": 0.19054266
             },
             {
-              "latency": 0.190775065
+              "latency": 0.196823749
             },
             {
-              "latency": 0.191844167
+              "latency": 0.191685195
             },
             {
-              "latency": 0.198609934
+              "latency": 0.184714035
             },
             {
-              "latency": 0.184273535
+              "latency": 0.187517292
             },
             {
-              "latency": 0.191871565
+              "latency": 0.196389712
             },
             {
-              "latency": 0.193277312
+              "latency": 0.192413513
             },
             {
-              "latency": 0.182333444
+              "latency": 0.18111163
             },
             {
-              "latency": 0.182497462
+              "latency": 0.192413486
             },
             {
-              "latency": 0.191340946
+              "latency": 0.192204384
             },
             {
-              "latency": 0.194394664
+              "latency": 0.187182031
             },
             {
-              "latency": 0.183802688
+              "latency": 0.197210905
             },
             {
-              "latency": 0.192732576
+              "latency": 0.197615163
             },
             {
-              "latency": 0.197727245
+              "latency": 0.191114326
             },
             {
-              "latency": 0.18524811
+              "latency": 0.191491498
             },
             {
-              "latency": 0.196155602
+              "latency": 0.198809708
             },
             {
-              "latency": 0.182879433
+              "latency": 0.190754913
             },
             {
-              "latency": 0.191622072
+              "latency": 0.186212846
             },
             {
-              "latency": 0.194512004
+              "latency": 0.18887227
             },
             {
-              "latency": 0.199675084
+              "latency": 0.190742777
             },
             {
-              "latency": 0.193545846
+              "latency": 0.182765967
             },
             {
-              "latency": 0.1857358
+              "latency": 0.195690525
             },
             {
-              "latency": 0.196606761
+              "latency": 0.193844519
             },
             {
-              "latency": 0.197466231
+              "latency": 0.190155182
             },
             {
-              "latency": 0.187884861
+              "latency": 0.195596666
             },
             {
-              "latency": 0.18660263
+              "latency": 0.185982905
             },
             {
-              "latency": 0.193555081
+              "latency": 0.18473411
             },
             {
-              "latency": 0.188345579
+              "latency": 0.196661771
             },
             {
-              "latency": 0.1934835
+              "latency": 0.194355388
             },
             {
-              "latency": 0.189691951
+              "latency": 0.190106204
             },
             {
-              "latency": 0.194888993
+              "latency": 0.192036382
             },
             {
-              "latency": 0.18621049
+              "latency": 0.191494383
             },
             {
-              "latency": 0.188464942
+              "latency": 0.192001484
             },
             {
-              "latency": 0.187443824
+              "latency": 0.182183531
             },
             {
-              "latency": 0.194078624
+              "latency": 0.19379002
             },
             {
-              "latency": 0.195573126
+              "latency": 0.18466775
             },
             {
-              "latency": 0.185675481
+              "latency": 0.193188464
             },
             {
-              "latency": 0.193329368
+              "latency": 0.186430827
             },
             {
-              "latency": 0.189259478
+              "latency": 0.189765056
             },
             {
-              "latency": 0.189907448
+              "latency": 0.187649605
             },
             {
-              "latency": 0.195668638
+              "latency": 0.194008086
             },
             {
-              "latency": 0.196273809
+              "latency": 0.19165928
             },
             {
-              "latency": 0.186386937
+              "latency": 0.19486679
             },
             {
-              "latency": 0.194431277
+              "latency": 0.190038909
             },
             {
-              "latency": 0.179613554
+              "latency": 0.187870003
             },
             {
-              "latency": 0.193102712
+              "latency": 0.189779825
             },
             {
-              "latency": 0.198107363
+              "latency": 0.193836213
             },
             {
-              "latency": 0.185996302
+              "latency": 0.187179711
             },
             {
-              "latency": 0.187608135
+              "latency": 0.198318771
             },
             {
-              "latency": 0.192875318
+              "latency": 0.182425274
             },
             {
-              "latency": 0.189888902
+              "latency": 0.192005037
             },
             {
-              "latency": 0.193434819
+              "latency": 0.198630455
             },
             {
-              "latency": 0.190617372
+              "latency": 0.188898744
             },
             {
-              "latency": 0.183958823
+              "latency": 0.188548895
             },
             {
-              "latency": 0.184297903
+              "latency": 0.19580443
             },
             {
-              "latency": 0.182108608
+              "latency": 0.195029299
             },
             {
-              "latency": 0.193839825
+              "latency": 0.193536721
             },
             {
-              "latency": 0.187657363
+              "latency": 0.192748671
             },
             {
-              "latency": 0.196739125
+              "latency": 0.194712479
             },
             {
-              "latency": 0.188374865
+              "latency": 0.191752226
             },
             {
-              "latency": 0.196007177
+              "latency": 0.192627121
             },
             {
-              "latency": 0.191799573
+              "latency": 0.185247623
             },
             {
-              "latency": 0.194788158
+              "latency": 0.182523467
             },
             {
-              "latency": 0.18157022
+              "latency": 0.190368387
             },
             {
-              "latency": 0.19594082
+              "latency": 0.198116267
             },
             {
-              "latency": 0.185963458
+              "latency": 0.197969026
             },
             {
-              "latency": 0.188550319
+              "latency": 0.196522942
             },
             {
-              "latency": 0.191942366
+              "latency": 0.188757736
             },
             {
-              "latency": 0.191500148
+              "latency": 0.194882113
             },
             {
-              "latency": 0.190548668
+              "latency": 0.188954366
             },
             {
-              "latency": 0.18431213
+              "latency": 0.1980138
             },
             {
-              "latency": 0.184969108
+              "latency": 0.194511948
             },
             {
-              "latency": 0.187292332
+              "latency": 0.188261594
             },
             {
-              "latency": 0.184247665
+              "latency": 0.19151217
             },
             {
-              "latency": 0.193372242
+              "latency": 0.190293816
             },
             {
-              "latency": 0.189036926
+              "latency": 0.187815219
             },
             {
-              "latency": 0.196409805
+              "latency": 0.195969768
             },
             {
-              "latency": 0.188765088
+              "latency": 0.196263694
             },
             {
-              "latency": 0.189666767
+              "latency": 0.195500956
             },
             {
-              "latency": 0.189620087
+              "latency": 0.184429374
             },
             {
-              "latency": 0.194291593
+              "latency": 0.192985611
             },
             {
-              "latency": 0.189304864
+              "latency": 0.195947339
             },
             {
-              "latency": 0.188276581
+              "latency": 0.187336236
             },
             {
-              "latency": 0.19125438
+              "latency": 0.188309938
             },
             {
-              "latency": 0.195411869
+              "latency": 0.187476013
             },
             {
-              "latency": 0.185658262
+              "latency": 0.19508168
             },
             {
-              "latency": 0.185550191
+              "latency": 0.183761048
             },
             {
-              "latency": 0.19459812
+              "latency": 0.189063628
             },
             {
-              "latency": 0.19467783
+              "latency": 0.181893644
             }
           ],
           "implementation": "go-libp2p",
@@ -2572,304 +2842,304 @@
         {
           "result": [
             {
-              "latency": 0.381976095
+              "latency": 0.322095526
             },
             {
-              "latency": 0.388421996
+              "latency": 0.389898207
             },
             {
-              "latency": 0.314998237
+              "latency": 0.312318107
             },
             {
-              "latency": 0.30666595
+              "latency": 0.376407473
             },
             {
-              "latency": 0.384121226
+              "latency": 0.305338694
             },
             {
-              "latency": 0.313345733
+              "latency": 0.303020314
             },
             {
-              "latency": 0.382000327
+              "latency": 0.391743185
             },
             {
-              "latency": 0.35678173
+              "latency": 0.325070357
             },
             {
-              "latency": 0.318936242
+              "latency": 0.376367984
             },
             {
-              "latency": 0.316071814
+              "latency": 0.297863816
             },
             {
-              "latency": 0.384377304
+              "latency": 0.316890484
             },
             {
-              "latency": 0.309711269
+              "latency": 0.375338847
             },
             {
-              "latency": 0.315730141
+              "latency": 0.310513246
             },
             {
-              "latency": 0.377659754
+              "latency": 0.31026073
             },
             {
-              "latency": 0.386775756
+              "latency": 0.374401538
             },
             {
-              "latency": 0.306763601
+              "latency": 0.311895523
             },
             {
-              "latency": 0.30611268
+              "latency": 0.366626939
             },
             {
-              "latency": 0.314938517
+              "latency": 0.310329916
             },
             {
-              "latency": 0.312148778
+              "latency": 0.321399364
             },
             {
-              "latency": 0.32489782
+              "latency": 0.367594349
             },
             {
-              "latency": 0.310574859
+              "latency": 0.317458647
             },
             {
-              "latency": 0.375526198
+              "latency": 0.365666652
             },
             {
-              "latency": 0.30600953
+              "latency": 0.319748752
             },
             {
-              "latency": 0.37204659
+              "latency": 0.361446351
             },
             {
-              "latency": 0.306998386
+              "latency": 0.317036795
             },
             {
-              "latency": 0.378596719
+              "latency": 0.388038669
             },
             {
-              "latency": 0.321667032
+              "latency": 0.305357005
             },
             {
-              "latency": 0.367487915
+              "latency": 0.378954423
             },
             {
-              "latency": 0.29994641
+              "latency": 0.321933909
             },
             {
-              "latency": 0.380195512
+              "latency": 0.316205445
             },
             {
-              "latency": 0.369756684
+              "latency": 0.309178669
             },
             {
-              "latency": 0.367430031
+              "latency": 0.325515382
             },
             {
-              "latency": 0.391773247
+              "latency": 0.311399903
             },
             {
-              "latency": 0.306468842
+              "latency": 0.371194362
             },
             {
-              "latency": 0.314642703
+              "latency": 0.35760961
             },
             {
-              "latency": 0.375836617
+              "latency": 0.321657138
             },
             {
-              "latency": 0.354676969
+              "latency": 0.311322814
             },
             {
-              "latency": 0.378259833
+              "latency": 0.364895364
             },
             {
-              "latency": 0.319224093
+              "latency": 0.329283816
             },
             {
-              "latency": 0.312061335
+              "latency": 0.38321979
             },
             {
-              "latency": 0.313881545
+              "latency": 0.323692495
             },
             {
-              "latency": 0.316823084
+              "latency": 0.371252312
             },
             {
-              "latency": 0.309436658
+              "latency": 0.365849638
             },
             {
-              "latency": 0.320342644
+              "latency": 0.310116211
             },
             {
-              "latency": 0.307271137
+              "latency": 0.363079214
             },
             {
-              "latency": 0.313912376
+              "latency": 0.312767459
             },
             {
-              "latency": 0.383294544
+              "latency": 0.304283451
             },
             {
-              "latency": 0.393827984
+              "latency": 0.300706291
             },
             {
-              "latency": 0.298470881
+              "latency": 0.31244721
             },
             {
-              "latency": 0.307941596
+              "latency": 0.311689531
             },
             {
-              "latency": 0.37986379
+              "latency": 0.323532409
             },
             {
-              "latency": 0.306612038
+              "latency": 0.382956809
             },
             {
-              "latency": 0.373852621
+              "latency": 0.308890662
             },
             {
-              "latency": 0.31321951
+              "latency": 0.382392654
             },
             {
-              "latency": 0.321650215
+              "latency": 0.387841514
             },
             {
-              "latency": 0.376083602
+              "latency": 0.374595857
             },
             {
-              "latency": 0.365972218
+              "latency": 0.36873485
             },
             {
-              "latency": 0.36697194
+              "latency": 0.312099463
             },
             {
-              "latency": 0.370598447
+              "latency": 0.377632135
             },
             {
-              "latency": 0.379219303
+              "latency": 0.384443223
             },
             {
-              "latency": 0.378572639
+              "latency": 0.371549473
             },
             {
-              "latency": 0.355113728
+              "latency": 0.368404801
             },
             {
-              "latency": 0.307856214
+              "latency": 0.385665284
             },
             {
-              "latency": 0.374550108
+              "latency": 0.312060371
             },
             {
-              "latency": 0.380934151
+              "latency": 0.307304189
             },
             {
-              "latency": 0.375804538
+              "latency": 0.314482872
             },
             {
-              "latency": 0.324704486
+              "latency": 0.321751887
             },
             {
-              "latency": 0.367457458
+              "latency": 0.32350549
             },
             {
-              "latency": 0.354711916
+              "latency": 0.324856532
             },
             {
-              "latency": 0.373137612
+              "latency": 0.309585529
             },
             {
-              "latency": 0.374149394
+              "latency": 0.372204257
             },
             {
-              "latency": 0.321420194
+              "latency": 0.379137627
             },
             {
-              "latency": 0.315573401
+              "latency": 0.384314552
             },
             {
-              "latency": 0.320520272
+              "latency": 0.391407162
             },
             {
-              "latency": 0.31988208
+              "latency": 0.323068412
             },
             {
-              "latency": 0.320916676
+              "latency": 0.382161433
             },
             {
-              "latency": 0.32045819
+              "latency": 0.316834166
             },
             {
-              "latency": 0.309036219
+              "latency": 0.381922617
             },
             {
-              "latency": 0.381350043
+              "latency": 0.299156647
             },
             {
-              "latency": 0.322851203
+              "latency": 0.317062113
             },
             {
-              "latency": 0.373255379
+              "latency": 0.321726073
             },
             {
-              "latency": 0.306422312
+              "latency": 0.299786745
             },
             {
-              "latency": 0.305499071
+              "latency": 0.305965062
             },
             {
-              "latency": 0.382520274
+              "latency": 0.369086537
             },
             {
-              "latency": 0.318721288
+              "latency": 0.323708953
             },
             {
-              "latency": 0.309728361
+              "latency": 0.319602516
             },
             {
-              "latency": 0.3197926
+              "latency": 0.30684364
             },
             {
-              "latency": 0.318740938
+              "latency": 0.392938646
             },
             {
-              "latency": 0.370230375
+              "latency": 0.323649106
             },
             {
-              "latency": 0.30655263
+              "latency": 0.300303114
             },
             {
-              "latency": 0.311775446
+              "latency": 0.322643974
             },
             {
-              "latency": 0.319539193
+              "latency": 0.38782807
             },
             {
-              "latency": 0.327993488
+              "latency": 0.372826347
             },
             {
-              "latency": 0.370378279
+              "latency": 0.324443189
             },
             {
-              "latency": 0.387199909
+              "latency": 0.321847358
             },
             {
-              "latency": 0.306670253
+              "latency": 0.314805405
             },
             {
-              "latency": 0.306674852
+              "latency": 0.364599532
             },
             {
-              "latency": 0.384419293
+              "latency": 0.328773459
             },
             {
-              "latency": 0.304681448
+              "latency": 0.366378146
             },
             {
-              "latency": 0.350981323
+              "latency": 0.355116109
             }
           ],
           "implementation": "go-libp2p",
@@ -2879,304 +3149,304 @@
         {
           "result": [
             {
-              "latency": 0.186311059
+              "latency": 0.19940627
             },
             {
-              "latency": 0.196648954
+              "latency": 0.194840203
             },
             {
-              "latency": 0.193700927
+              "latency": 0.191649464
             },
             {
-              "latency": 0.190631161
+              "latency": 0.195518659
             },
             {
-              "latency": 0.186892775
+              "latency": 0.192554155
             },
             {
-              "latency": 0.184459086
+              "latency": 0.192348151
             },
             {
-              "latency": 0.190601658
+              "latency": 0.190422594
             },
             {
-              "latency": 0.195114493
+              "latency": 0.193668276
             },
             {
-              "latency": 0.186942435
+              "latency": 0.192605304
             },
             {
-              "latency": 0.18633947
+              "latency": 0.194994542
             },
             {
-              "latency": 0.19104879
+              "latency": 0.194017318
             },
             {
-              "latency": 0.195739795
+              "latency": 0.192098206
             },
             {
-              "latency": 0.189644434
+              "latency": 0.181735775
             },
             {
-              "latency": 0.193556342
+              "latency": 0.187360733
             },
             {
-              "latency": 0.192624521
+              "latency": 0.194512113
             },
             {
-              "latency": 0.182337592
+              "latency": 0.185052551
             },
             {
-              "latency": 0.200432124
+              "latency": 0.194088844
             },
             {
-              "latency": 0.187505939
+              "latency": 0.186856688
             },
             {
-              "latency": 0.195163839
+              "latency": 0.192246118
             },
             {
-              "latency": 0.180970648
+              "latency": 0.190805678
             },
             {
-              "latency": 0.19398862
+              "latency": 0.187575587
             },
             {
-              "latency": 0.19281069
+              "latency": 0.182382271
             },
             {
-              "latency": 0.194532022
+              "latency": 0.192873835
             },
             {
-              "latency": 0.182461219
+              "latency": 0.194688397
             },
             {
-              "latency": 0.193724691
+              "latency": 0.182865246
             },
             {
-              "latency": 0.196562422
+              "latency": 0.190404963
             },
             {
-              "latency": 0.190147356
+              "latency": 0.193694983
             },
             {
-              "latency": 0.188199387
+              "latency": 0.198156019
             },
             {
-              "latency": 0.195775206
+              "latency": 0.19232954
             },
             {
-              "latency": 0.189697723
+              "latency": 0.18967734
             },
             {
-              "latency": 0.178781448
+              "latency": 0.199029462
             },
             {
-              "latency": 0.196553312
+              "latency": 0.190115753
             },
             {
-              "latency": 0.200363132
+              "latency": 0.18504963
             },
             {
-              "latency": 0.188273686
+              "latency": 0.188003551
             },
             {
-              "latency": 0.185453707
+              "latency": 0.200021265
             },
             {
-              "latency": 0.198476424
+              "latency": 0.187926409
             },
             {
-              "latency": 0.183962225
+              "latency": 0.182084261
             },
             {
-              "latency": 0.189314083
+              "latency": 0.189866931
             },
             {
-              "latency": 0.185425601
+              "latency": 0.177360564
             },
             {
-              "latency": 0.18764165
+              "latency": 0.185915684
             },
             {
-              "latency": 0.191309844
+              "latency": 0.187882735
             },
             {
-              "latency": 0.193602466
+              "latency": 0.19482441
             },
             {
-              "latency": 0.191913686
+              "latency": 0.199587329
             },
             {
-              "latency": 0.185651733
+              "latency": 0.184758204
             },
             {
-              "latency": 0.187969163
+              "latency": 0.191375317
             },
             {
-              "latency": 0.192658546
+              "latency": 0.19645699
             },
             {
-              "latency": 0.192593554
+              "latency": 0.188623725
             },
             {
-              "latency": 0.183614734
+              "latency": 0.185708324
             },
             {
-              "latency": 0.183444784
+              "latency": 0.197600722
             },
             {
-              "latency": 0.195290564
+              "latency": 0.196474085
             },
             {
-              "latency": 0.188301101
+              "latency": 0.193476503
             },
             {
-              "latency": 0.200191282
+              "latency": 0.19610699
             },
             {
-              "latency": 0.192903128
+              "latency": 0.192061751
             },
             {
-              "latency": 0.188173193
+              "latency": 0.19798014
             },
             {
-              "latency": 0.187117968
+              "latency": 0.188362713
             },
             {
-              "latency": 0.196261849
+              "latency": 0.194394588
             },
             {
-              "latency": 0.19213049
+              "latency": 0.1938588
             },
             {
-              "latency": 0.182656264
+              "latency": 0.189359534
             },
             {
-              "latency": 0.186959789
+              "latency": 0.195038534
             },
             {
-              "latency": 0.190296812
+              "latency": 0.191846769
             },
             {
-              "latency": 0.188710495
+              "latency": 0.191728773
             },
             {
-              "latency": 0.185964276
+              "latency": 0.187035309
             },
             {
-              "latency": 0.186716416
+              "latency": 0.19113272
             },
             {
-              "latency": 0.196717275
+              "latency": 0.188001002
             },
             {
-              "latency": 0.188735842
+              "latency": 0.201291144
             },
             {
-              "latency": 0.187452722
+              "latency": 0.192941494
             },
             {
-              "latency": 0.195243861
+              "latency": 0.192776246
             },
             {
-              "latency": 0.185405673
+              "latency": 0.193533496
             },
             {
-              "latency": 0.195080126
+              "latency": 0.195864445
             },
             {
-              "latency": 0.190215933
+              "latency": 0.193450188
             },
             {
-              "latency": 0.190867951
+              "latency": 0.184563011
             },
             {
-              "latency": 0.18714863
+              "latency": 0.19775847
             },
             {
-              "latency": 0.184043494
+              "latency": 0.195688601
             },
             {
-              "latency": 0.190686364
+              "latency": 0.194527744
             },
             {
-              "latency": 0.194521419
+              "latency": 0.185889925
             },
             {
-              "latency": 0.185027564
+              "latency": 0.182487552
             },
             {
-              "latency": 0.189530625
+              "latency": 0.195986811
             },
             {
-              "latency": 0.197132308
+              "latency": 0.194080919
             },
             {
-              "latency": 0.188887776
+              "latency": 0.19165157
             },
             {
-              "latency": 0.188597256
+              "latency": 0.185732301
             },
             {
-              "latency": 0.196821528
+              "latency": 0.197163146
             },
             {
-              "latency": 0.186942456
+              "latency": 0.190511161
             },
             {
-              "latency": 0.194099729
+              "latency": 0.191606668
             },
             {
-              "latency": 0.195538021
+              "latency": 0.189950188
             },
             {
-              "latency": 0.180316568
+              "latency": 0.192171887
             },
             {
-              "latency": 0.197607335
+              "latency": 0.185022907
             },
             {
-              "latency": 0.191586027
+              "latency": 0.189248034
             },
             {
-              "latency": 0.19043404
+              "latency": 0.191340581
             },
             {
-              "latency": 0.198957321
+              "latency": 0.192103788
             },
             {
-              "latency": 0.198734671
+              "latency": 0.189318694
             },
             {
-              "latency": 0.19174692
+              "latency": 0.190715348
             },
             {
-              "latency": 0.190891778
+              "latency": 0.194176327
             },
             {
-              "latency": 0.200139445
+              "latency": 0.198508661
             },
             {
-              "latency": 0.19059226
+              "latency": 0.189494466
             },
             {
-              "latency": 0.19128885
+              "latency": 0.189995122
             },
             {
-              "latency": 0.188878835
+              "latency": 0.19323147
             },
             {
-              "latency": 0.191215858
+              "latency": 0.177528627
             },
             {
-              "latency": 0.195318744
+              "latency": 0.188930185
             },
             {
-              "latency": 0.1926736
+              "latency": 0.186890998
             },
             {
-              "latency": 0.188789734
+              "latency": 0.18942271
             }
           ],
           "implementation": "go-libp2p",
@@ -3193,173 +3463,173 @@
   "pings": {
     "unit": "s",
     "results": [
-      0.103,
-      0.0632,
-      0.0632,
-      0.0636,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0633,
-      0.0633,
-      0.0632,
-      0.0632,
-      0.0633,
-      0.0635,
-      0.0633,
-      0.0633,
-      0.0632,
-      0.0632,
-      0.0635,
-      0.0633,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0633,
-      0.0632,
-      0.0633,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0633,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0633,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0633,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0633,
-      0.0638,
-      0.0633,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632,
-      0.0632
+      0.0694,
+      0.0606,
+      0.0606,
+      0.0605,
+      0.0605,
+      0.0606,
+      0.060899999999999996,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0606,
+      0.0643,
+      0.064,
+      0.064,
+      0.064,
+      0.0643,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.0693,
+      0.0693,
+      0.0694,
+      0.0694,
+      0.0693,
+      0.0693,
+      0.0693,
+      0.0693,
+      0.0693,
+      0.0693,
+      0.0693,
+      0.0693,
+      0.0632,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.06409999999999999,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.06409999999999999,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064,
+      0.064
     ]
   },
   "iperf": {
     "unit": "bit/s",
     "results": [
-      3380000000,
-      3380000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3360000000,
+      3370000000,
+      3370000000,
+      3370000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3370000000,
+      3370000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
       3370000000,
       3370000000,
       3370000000,
       3370000000,
-      3380000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3380000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3390000000,
-      3380000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3380000000,
-      3380000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3380000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3380000000,
-      3370000000,
-      3320000000,
-      3310000000,
-      3320000000,
-      3310000000,
-      3320000000,
-      3380000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3370000000,
-      3380000000,
-      3370000000,
-      3370000000,
-      3380000000,
-      3380000000,
-      3380000000,
-      3370000000,
-      2810000000
+      3350000000,
+      3360000000,
+      3350000000,
+      3360000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3350000000,
+      3360000000,
+      3350000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3360000000,
+      3000000000
     ]
   }
 }

--- a/perf/runner/src/index.ts
+++ b/perf/runner/src/index.ts
@@ -19,7 +19,7 @@ async function main(clientPublicIP: string, serverPublicIP: string) {
                  uploadBytes: 100 << 20,
                  downloadBytes: 0,
                  unit: "bit/s",
-                 iterations: 5,
+                 iterations: 10,
              }),
              runBenchmarkAcrossVersions({
                  name: "Single Connection throughput – Download 100 MiB",
@@ -28,7 +28,7 @@ async function main(clientPublicIP: string, serverPublicIP: string) {
                  uploadBytes: 0,
                  downloadBytes: 100 << 20,
                  unit: "bit/s",
-                 iterations: 5,
+                 iterations: 10,
              }),
              runBenchmarkAcrossVersions({
                  name: "Connection establishment + 1 byte round trip latencies",
@@ -37,7 +37,7 @@ async function main(clientPublicIP: string, serverPublicIP: string) {
                  uploadBytes: 1,
                  downloadBytes: 1,
                  unit: "s",
-                 iterations: 100,
+                 iterations: 1000,
              }),
     ];
 

--- a/perf/runner/src/index.ts
+++ b/perf/runner/src/index.ts
@@ -37,7 +37,7 @@ async function main(clientPublicIP: string, serverPublicIP: string) {
                  uploadBytes: 1,
                  downloadBytes: 1,
                  unit: "s",
-                 iterations: 1000,
+                 iterations: 100,
              }),
     ];
 


### PR DESCRIPTION
- Increase upload/download benchmark iterations. Still conservative value of `10` due to slow rust-libp2p tcp. See https://github.com/libp2p/rust-yamux/issues/162. Note however that this is 10x an upload of 100MB.
- Increase latency benchmark iterations.