### PR TITLE
feat(interop): allow specifying port to bind to

### DIFF
--- a/multidim-interop/README.md
+++ b/multidim-interop/README.md
@@ -23,6 +23,7 @@ environment variables. The current parameters are:
 | security             | The security channel to use                                  | no, except when transport is one of quic, quic-v1, webtransport |
 | is_dialer            | Should you dial or listen                                    | no                                                              |
 | ip                   | IP address to bind the listener to                           | yes, default to "0.0.0.0"                                       |
+| port                 | TCP/UDP (transport-dependent) port to bind the listener to   | yes, default to "0"                                       |
 | redis_addr           | A different address to connect to redis (default redis:6379) | yes, default to the `redis` host on port 6379                   |
 | test_timeout_seconds | Control the timeout of test.                                 | yes, default to 180 seconds.                                    |
 


### PR DESCRIPTION
Ping listeners implementations seem to all bind to random ports during test runs, then report their multiaddr to redis.  Dialers receive the multiaddr from redis and dial it.

This is great when everything is under Docker.

If you are trying to run one half of the test from locally running code and the other from a docker container in order to debug things you need to know the port the docker half will be listening on when you build the container in order to `EXPOSE` the port and make it available to the host machine, so the docker half can't use random ports.

Running the non-local half of the test as a Docker image is preferable to building from source since it reduces the amount of assumed knowledge the developer has about how to build a rust/nim/zig/go/js/java project and doesn't require them to set up esoteric toolchains for what is hopefully an infrequent task.

The change here is to specify a `port` env var that can be used to control this, defaulting to `'0'`, the value that seems to be used everywhere currently.