### PR TITLE
multidim interop: Add debug logging if JSON parse fails

### DIFF
--- a/multidim-interop/src/compose-runner.ts
+++ b/multidim-interop/src/compose-runner.ts
@@ -55,8 +55,19 @@ export async function run(namespace: string, compose: ComposeSpecification, opts
         if (testResults === null || testResults.length < 2) {
             throw new Error("Test JSON results not found")
         }
-        const testResultsParsed = JSON.parse(testResults[1])
-        console.log("Finished:", namespace, testResultsParsed)
+        try {
+            const testResultsParsed = JSON.parse(testResults[1])
+            console.log("Finished:", namespace, testResultsParsed)
+        } catch (e) {
+            console.log("Failed to parse test results:", testResults[1])
+            console.log("stdout:")
+            console.log(stdout)
+            console.log("")
+            console.log("stderr:")
+            console.log(stderr)
+            console.log("")
+            throw e
+        }
     } catch (e: any) {
         console.log("Failure", e)
         return e


### PR DESCRIPTION
Ran into this new error: https://github.com/libp2p/test-plans/actions/runs/5466576345/jobs/9951702544#step:3:1256

The JSON.parse failed. Hard to debug if I don't know what the input was and the stdout of the nodes. This adds some helpful debug code.