### PR TITLE
interop: Install playwright in the base image so it is cached

### DIFF
--- a/multidim-interop/impl/js/v0.45/BrowserDockerfile
+++ b/multidim-interop/impl/js/v0.45/BrowserDockerfile
@@ -11,7 +11,6 @@ FROM mcr.microsoft.com/playwright
 
 COPY --from=js-libp2p-base /app/ /app/
 WORKDIR /app/interop
-RUN ./node_modules/.bin/playwright install
 ARG BROWSER=chromium # Options: chromium, firefox, webkit
 ENV BROWSER=$BROWSER
 

--- a/multidim-interop/impl/js/v0.45/Dockerfile
+++ b/multidim-interop/impl/js/v0.45/Dockerfile
@@ -7,5 +7,6 @@ RUN npm i && npm run build
 
 WORKDIR /app/interop
 RUN npm i && npm run build
+RUN ./node_modules/.bin/playwright install
 
 ENTRYPOINT [ "npm", "test", "--", "--build", "false", "--types", "false", "-t", "node" ]


### PR DESCRIPTION
Improves caching for browsers on js-libp2p by installing playwright and browsers in the base image. This is the image that gets cached.