### PR TITLE
Revert "Install playwright in the base image so it is cached (#226)"

### DIFF
--- a/multidim-interop/impl/js/v0.45/BrowserDockerfile
+++ b/multidim-interop/impl/js/v0.45/BrowserDockerfile
@@ -11,6 +11,7 @@ FROM mcr.microsoft.com/playwright
 
 COPY --from=js-libp2p-base /app/ /app/
 WORKDIR /app/interop
+RUN ./node_modules/.bin/playwright install
 ARG BROWSER=chromium # Options: chromium, firefox, webkit
 ENV BROWSER=$BROWSER
 

--- a/multidim-interop/impl/js/v0.45/BrowserDockerfile
+++ b/multidim-interop/impl/js/v0.45/BrowserDockerfile
@@ -11,6 +11,9 @@ FROM mcr.microsoft.com/playwright
 
 COPY --from=js-libp2p-base /app/ /app/
 WORKDIR /app/interop
+# We install browsers here instead of the cached version so that we use the latest browsers at run time.
+# Ideally this would also be pinned, but playwright controls this, so there isn't much we can do about it.
+# By installing here, we avoid installing it at test time.
 RUN ./node_modules/.bin/playwright install
 ARG BROWSER=chromium # Options: chromium, firefox, webkit
 ENV BROWSER=$BROWSER

--- a/multidim-interop/impl/js/v0.45/Dockerfile
+++ b/multidim-interop/impl/js/v0.45/Dockerfile
@@ -7,6 +7,5 @@ RUN npm i && npm run build
 
 WORKDIR /app/interop
 RUN npm i && npm run build
-RUN ./node_modules/.bin/playwright install
 
 ENTRYPOINT [ "npm", "test", "--", "--build", "false", "--types", "false", "-t", "node" ]


### PR DESCRIPTION
Reverts libp2p/test-plans#226

Looking at this run has us downloading browsers on each interop test: https://github.com/libp2p/test-plans/actions/runs/5535076758/jobs/10100889429. I think what's happening is that playwright will helpfully (though not helpful in this case) download the latest browser. If we have an older browser because we cached it earlier then it will download a new one at run time.

By moving this back to the the post-cache build phase we download the browsers on every build yes, but hopefully avoid downloading them on every run.

I'll look at the CI logs to make sure that's the case.