### PR TITLE
multidim-interop: Update rust-libp2p .gitignore with chromium-image.json

### DIFF
--- a/.github/actions/run-interop-ping-test/action.yml
+++ b/.github/actions/run-interop-ping-test/action.yml
@@ -77,6 +77,16 @@ runs:
       run: npm run cache -- load
       shell: bash
 
+    - name: Assert Git tree is clean.
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      shell: bash
+      run: |
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo "Git tree is dirty. This means that building an impl generated something that should probably be .gitignore'd"
+          git status
+          exit 1
+        fi
+
     - name: Push the image cache
       if: env.PUSH_CACHE == 'true'
       working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}

--- a/multidim-interop/impl/rust/.gitignore
+++ b/multidim-interop/impl/rust/.gitignore
@@ -2,3 +2,4 @@ rust-libp2p-*.zip
 rust-libp2p-*
 rust-libp2p-*/*
 image.json
+chromium-image.json


### PR DESCRIPTION
The cache works by mapping a set of inputs to a set out outputs. It fingerprints the inputs by looking at everything in the folder that isn't gitignored. The idea being that if it's ignored it's a build artifact and if it isn't than it is a build input. Since we didn't gitignore chromium-image.json it got treated as an input when we generated the fingerprint. This meant that the cache-key was different before the build and after the build.

I've added a check that will fail CI early if we detect a dirty Git tree after building. That should catch this class of errors.

This should fix the cache misses we've been seeing with rust-libp2p v0.52