### PR TITLE
fix(perf): run iperf on TCP and set TCP send/receive window to bdp

### DIFF
--- a/perf/runner/src/index.ts
+++ b/perf/runner/src/index.ts
@@ -72,7 +72,8 @@ function runPing(clientPublicIP: string, serverPublicIP: string): PingResults {
 }
 
 function runIPerf(clientPublicIP: string, serverPublicIP: string): IperfResults {
-    console.error(`= run 60 iPerf UDP from client to server`);
+    const iterations = 60;
+    console.error(`= run ${iterations} iPerf TCP from client to server`);
 
     const killCMD = `ssh -o StrictHostKeyChecking=no ec2-user@${serverPublicIP} 'kill $(cat pidfile); rm pidfile; rm server.log || true'`;
     const killSTDOUT = execCommand(killCMD);
@@ -82,7 +83,7 @@ function runIPerf(clientPublicIP: string, serverPublicIP: string): IperfResults 
     const serverSTDOUT = execCommand(serverCMD);
     console.error(serverSTDOUT);
 
-    const cmd = `ssh -o StrictHostKeyChecking=no ec2-user@${clientPublicIP} 'iperf3 -c ${serverPublicIP} -u -b 25g -t 60'`;
+    const cmd = `ssh -o StrictHostKeyChecking=no ec2-user@${clientPublicIP} 'iperf3 -c ${serverPublicIP} -b 25g -t ${iterations}'`;
     const stdout = execSync(cmd).toString();
 
     // Extract the bitrate from each relevant line

--- a/perf/terraform/modules/long_lived/files/user-data.sh
+++ b/perf/terraform/modules/long_lived/files/user-data.sh
@@ -7,6 +7,14 @@ sudo yum -y install iperf3
 # Bump UDP receive buffer size. See https://github.com/quic-go/quic-go/wiki/UDP-Receive-Buffer-Size.
 sudo sysctl -w net.core.rmem_max=2500000
 
+# Set maximum TCP send and receive window to bandwidth-delay-product.
+#
+# With a bandwidth of 25 Gbit/s per machine and a ping of 60 ms between the two
+# machines, the bandwidth-delay-product is ~178.81 MiB. Set send and receive
+# window to 200 MiB.
+sudo sysctl -w net.ipv4.tcp_rmem='4096 131072 200000000'
+sudo sysctl -w net.ipv4.tcp_wmem='4096 20480 200000000'
+
 sudo yum update -y
 sudo yum install docker -y
 sudo systemctl enable docker


### PR DESCRIPTION
This commit makes iperf use TCP instead of UDP. Using UDP allows the sender to send as much data as they can, not as much data as the receiver can handle. Using TCP measures the actual bandwidth of the connection.

This commit sets the TCP send and receive window to the bandwidth-delay-product. In order to exhaust the whole bandwidth between the two nodes, TCP needs to be able to buffer all bytes on the wire in the case of packet loss.