### PR TITLE
fix(perf): increase root volume size

### DIFF
--- a/perf/runner/benchmark-results.json
+++ b/perf/runner/benchmark-results.json
@@ -7,34 +7,34 @@
         {
           "result": [
             {
-              "latency": 1.051427353
+              "latency": 1.112042404
             },
             {
-              "latency": 0.995972487
+              "latency": 1.040904815
             },
             {
-              "latency": 1.035934128
+              "latency": 1.0686287
             },
             {
-              "latency": 1.042920777
+              "latency": 1.046221104
             },
             {
-              "latency": 1.029231984
+              "latency": 1.081287741
             },
             {
-              "latency": 1.055336326
+              "latency": 1.039672874
             },
             {
-              "latency": 1.10629724
+              "latency": 1.113648805
             },
             {
-              "latency": 1.053236875
+              "latency": 1.015741139
             },
             {
-              "latency": 1.015635713
+              "latency": 1.042960858
             },
             {
-              "latency": 1.013370505
+              "latency": 1.062364092
             }
           ],
           "implementation": "quic-go",
@@ -44,34 +44,34 @@
         {
           "result": [
             {
-              "latency": 44.359394466
+              "latency": 45.260004173
             },
             {
-              "latency": 44.920176243
+              "latency": 48.395110584
             },
             {
-              "latency": 41.868508628
+              "latency": 42.53477564
             },
             {
-              "latency": 42.618698815
+              "latency": 47.229432791
             },
             {
-              "latency": 46.079809744
+              "latency": 46.004655432
             },
             {
-              "latency": 41.763000484
+              "latency": 46.134159882
             },
             {
-              "latency": 42.596384716
+              "latency": 48.283460022
             },
             {
-              "latency": 43.769469557
+              "latency": 45.017688501
             },
             {
-              "latency": 51.403041133
+              "latency": 44.037586273
             },
             {
-              "latency": 51.749461416
+              "latency": 44.879217676
             }
           ],
           "implementation": "rust-libp2p",
@@ -81,34 +81,34 @@
         {
           "result": [
             {
-              "latency": 11.792054282
+              "latency": 11.092959903
             },
             {
-              "latency": 10.930826850999999
+              "latency": 10.358886645
             },
             {
-              "latency": 9.886363374
+              "latency": 9.407897071
             },
             {
-              "latency": 8.885369533
+              "latency": 12.42272799
             },
             {
-              "latency": 12.768294592
+              "latency": 6.378903829
             },
             {
-              "latency": 7.795186441
+              "latency": 8.435240077
             },
             {
-              "latency": 5.897066551
+              "latency": 8.182064314
             },
             {
-              "latency": 4.05865465
+              "latency": 7.358208135
             },
             {
-              "latency": 5.565399111
+              "latency": 8.235037151
             },
             {
-              "latency": 16.849529372
+              "latency": 8.091133249
             }
           ],
           "implementation": "rust-libp2p",
@@ -118,34 +118,34 @@
         {
           "result": [
             {
-              "latency": 45.771689999
+              "latency": 44.623240087
             },
             {
-              "latency": 47.85951239
+              "latency": 46.959591138
             },
             {
-              "latency": 46.307242418
+              "latency": 43.817789138
             },
             {
-              "latency": 43.406571979
+              "latency": 46.266781036
             },
             {
-              "latency": 45.565801948
+              "latency": 41.474235628
             },
             {
-              "latency": 44.975914397
+              "latency": 45.872058847
             },
             {
-              "latency": 45.936294735
+              "latency": 47.805469825
             },
             {
-              "latency": 45.690696329
+              "latency": 46.896982856
             },
             {
-              "latency": 47.370274846
+              "latency": 45.331136385
             },
             {
-              "latency": 43.365424145
+              "latency": 45.922625293
             }
           ],
           "implementation": "rust-libp2p",
@@ -155,34 +155,34 @@
         {
           "result": [
             {
-              "latency": 1.418617392
+              "latency": 1.436209786
             },
             {
-              "latency": 1.508136827
+              "latency": 1.490708842
             },
             {
-              "latency": 1.414380389
+              "latency": 1.450257599
             },
             {
-              "latency": 1.441180265
+              "latency": 1.508362704
             },
             {
-              "latency": 1.482332569
+              "latency": 1.441874859
             },
             {
-              "latency": 1.499526473
+              "latency": 1.507737002
             },
             {
-              "latency": 1.5101854540000001
+              "latency": 1.516731305
             },
             {
-              "latency": 1.491891595
+              "latency": 1.432129312
             },
             {
-              "latency": 1.453330839
+              "latency": 1.463953129
             },
             {
-              "latency": 1.502945736
+              "latency": 1.486910093
             }
           ],
           "implementation": "rust-libp2p",
@@ -192,34 +192,34 @@
         {
           "result": [
             {
-              "latency": 1.124233876
+              "latency": 1.000792633
             },
             {
-              "latency": 1.090168673
+              "latency": 1.067742801
             },
             {
-              "latency": 1.1214214
+              "latency": 1.074019847
             },
             {
-              "latency": 1.041021032
+              "latency": 1.070208927
             },
             {
-              "latency": 1.2067489949999999
+              "latency": 1.030300038
             },
             {
-              "latency": 1.017832194
+              "latency": 1.063309417
             },
             {
-              "latency": 1.039983036
+              "latency": 1.131723965
             },
             {
-              "latency": 1.037412417
+              "latency": 1.026816626
             },
             {
-              "latency": 1.010971061
+              "latency": 1.072785453
             },
             {
-              "latency": 1.04085805
+              "latency": 1.040764109
             }
           ],
           "implementation": "https",
@@ -229,34 +229,34 @@
         {
           "result": [
             {
-              "latency": 1.903110829
+              "latency": 1.996814653
             },
             {
-              "latency": 2.063310092
+              "latency": 2.277546952
             },
             {
-              "latency": 1.860419045
+              "latency": 2.005660241
             },
             {
-              "latency": 1.874080365
+              "latency": 1.998867582
             },
             {
-              "latency": 2.004585035
+              "latency": 2.07851598
             },
             {
-              "latency": 2.200406905
+              "latency": 2.168026242
             },
             {
-              "latency": 2.054574649
+              "latency": 1.917925734
             },
             {
-              "latency": 2.257247274
+              "latency": 2.066869461
             },
             {
-              "latency": 1.8861308490000002
+              "latency": 2.084749114
             },
             {
-              "latency": 2.090354244
+              "latency": 1.9320118819999998
             }
           ],
           "implementation": "go-libp2p",
@@ -266,34 +266,34 @@
         {
           "result": [
             {
-              "latency": 1.441403731
+              "latency": 1.484297921
             },
             {
-              "latency": 1.5341460489999998
+              "latency": 1.379805408
             },
             {
-              "latency": 1.367645523
+              "latency": 1.397722855
             },
             {
-              "latency": 1.513804784
+              "latency": 1.452930908
             },
             {
-              "latency": 1.373327726
+              "latency": 1.474663539
             },
             {
-              "latency": 1.39006564
+              "latency": 1.5304581160000001
             },
             {
-              "latency": 1.380830074
+              "latency": 1.518420351
             },
             {
-              "latency": 1.720485534
+              "latency": 1.452696631
             },
             {
-              "latency": 1.360641873
+              "latency": 1.459257176
             },
             {
-              "latency": 1.531253298
+              "latency": 1.448748649
             }
           ],
           "implementation": "go-libp2p",
@@ -303,34 +303,34 @@
         {
           "result": [
             {
-              "latency": 2.064843742
+              "latency": 1.73399728
             },
             {
-              "latency": 2.045754145
+              "latency": 1.953186395
             },
             {
-              "latency": 2.12129688
+              "latency": 2.089665255
             },
             {
-              "latency": 1.93548402
+              "latency": 1.910508345
             },
             {
-              "latency": 2.026797822
+              "latency": 1.838861197
             },
             {
-              "latency": 1.883760694
+              "latency": 2.10595773
             },
             {
-              "latency": 1.9869477309999999
+              "latency": 1.9942206420000002
             },
             {
-              "latency": 2.004600073
+              "latency": 1.927580396
             },
             {
-              "latency": 1.8833221070000001
+              "latency": 1.8339864110000001
             },
             {
-              "latency": 1.981849247
+              "latency": 2.032794671
             }
           ],
           "implementation": "go-libp2p",
@@ -340,34 +340,34 @@
         {
           "result": [
             {
-              "latency": 1.464471492
+              "latency": 1.479239691
             },
             {
-              "latency": 1.646166849
+              "latency": 1.495454027
             },
             {
-              "latency": 1.549028651
+              "latency": 1.543158678
             },
             {
-              "latency": 1.375234214
+              "latency": 1.387968645
             },
             {
-              "latency": 1.523535799
+              "latency": 1.398235748
             },
             {
-              "latency": 1.486895515
+              "latency": 1.4706398
             },
             {
-              "latency": 1.477958987
+              "latency": 1.460899138
             },
             {
-              "latency": 1.5110977490000002
+              "latency": 1.506342492
             },
             {
-              "latency": 1.357541426
+              "latency": 1.443469619
             },
             {
-              "latency": 1.449437284
+              "latency": 1.436209574
             }
           ],
           "implementation": "go-libp2p",
@@ -377,34 +377,34 @@
         {
           "result": [
             {
-              "latency": 2.018705007
+              "latency": 2.312588858
             },
             {
-              "latency": 2.205271901
+              "latency": 1.8135068890000001
             },
             {
-              "latency": 1.875197105
+              "latency": 2.010186869
             },
             {
-              "latency": 1.9492049919999999
+              "latency": 2.069603199
             },
             {
-              "latency": 2.172217963
+              "latency": 2.2007226
             },
             {
-              "latency": 1.790509831
+              "latency": 1.851196675
             },
             {
-              "latency": 2.066066328
+              "latency": 1.873183739
             },
             {
-              "latency": 2.127069499
+              "latency": 2.005022895
             },
             {
-              "latency": 2.199366253
+              "latency": 2.169229945
             },
             {
-              "latency": 2.02337442
+              "latency": 1.9769121649999999
             }
           ],
           "implementation": "go-libp2p",
@@ -414,34 +414,34 @@
         {
           "result": [
             {
-              "latency": 1.360082542
+              "latency": 1.453551709
             },
             {
-              "latency": 1.614930852
+              "latency": 1.438258721
             },
             {
-              "latency": 1.459651049
+              "latency": 1.427642681
             },
             {
-              "latency": 1.434296974
+              "latency": 1.470681919
             },
             {
-              "latency": 1.45599981
+              "latency": 1.445951805
             },
             {
-              "latency": 1.521592548
+              "latency": 1.425751155
             },
             {
-              "latency": 1.465209879
+              "latency": 1.447851201
             },
             {
-              "latency": 1.469233908
+              "latency": 1.469297955
             },
             {
-              "latency": 1.3831039920000001
+              "latency": 1.407125846
             },
             {
-              "latency": 1.49660148
+              "latency": 1.4423235939999999
             }
           ],
           "implementation": "go-libp2p",
@@ -461,34 +461,34 @@
         {
           "result": [
             {
-              "latency": 1.052711226
+              "latency": 1.110850124
             },
             {
-              "latency": 1.106637015
+              "latency": 1.093080731
             },
             {
-              "latency": 1.10235819
+              "latency": 1.076443205
             },
             {
-              "latency": 1.13685017
+              "latency": 1.160912817
             },
             {
-              "latency": 1.094158472
+              "latency": 1.179046732
             },
             {
-              "latency": 1.115617119
+              "latency": 1.142859698
             },
             {
-              "latency": 1.05855534
+              "latency": 1.147417751
             },
             {
-              "latency": 1.059915528
+              "latency": 1.174676316
             },
             {
-              "latency": 1.14400357
+              "latency": 1.127742135
             },
             {
-              "latency": 1.046556727
+              "latency": 1.080442361
             }
           ],
           "implementation": "quic-go",
@@ -498,34 +498,34 @@
         {
           "result": [
             {
-              "latency": 44.189043237
+              "latency": 44.364867506
             },
             {
-              "latency": 46.017607387
+              "latency": 43.693930473
             },
             {
-              "latency": 46.835128831
+              "latency": 48.210922296
             },
             {
-              "latency": 44.527516704
+              "latency": 45.937198162
             },
             {
-              "latency": 45.312086775
+              "latency": 45.051868171
             },
             {
-              "latency": 45.099816526
+              "latency": 46.447137472
             },
             {
-              "latency": 44.433620973000004
+              "latency": 43.37108255
             },
             {
-              "latency": 46.741620035
+              "latency": 48.145707393
             },
             {
-              "latency": 48.230934612
+              "latency": 45.796887394
             },
             {
-              "latency": 43.595089886
+              "latency": 43.830320226
             }
           ],
           "implementation": "rust-libp2p",
@@ -535,34 +535,34 @@
         {
           "result": [
             {
-              "latency": 15.652261237
+              "latency": 14.320809405
             },
             {
-              "latency": 7.947064658
+              "latency": 7.549444058
             },
             {
-              "latency": 7.077419924
+              "latency": 13.946676377
             },
             {
-              "latency": 11.331557602
+              "latency": 6.044759483
             },
             {
-              "latency": 9.994933148
+              "latency": 12.942239565
             },
             {
-              "latency": 10.316869588
+              "latency": 22.411561057
             },
             {
-              "latency": 13.94562922
+              "latency": 12.029670458
             },
             {
-              "latency": 12.819279434
+              "latency": 7.40864408
             },
             {
-              "latency": 12.408833946
+              "latency": 10.056136359
             },
             {
-              "latency": 31.014608697
+              "latency": 10.791029753
             }
           ],
           "implementation": "rust-libp2p",
@@ -572,34 +572,34 @@
         {
           "result": [
             {
-              "latency": 43.376245808
+              "latency": 46.452801501
             },
             {
-              "latency": 42.123360079
+              "latency": 44.537785066
             },
             {
-              "latency": 47.205545496
+              "latency": 46.706174282
             },
             {
-              "latency": 47.100681952
+              "latency": 46.787322998
             },
             {
-              "latency": 42.680950627
+              "latency": 48.316330198
             },
             {
-              "latency": 43.251499952
+              "latency": 46.993861273
             },
             {
-              "latency": 48.156068026
+              "latency": 46.216835815
             },
             {
-              "latency": 43.649919589
+              "latency": 44.39827094
             },
             {
-              "latency": 43.764319518
+              "latency": 43.080621074
             },
             {
-              "latency": 45.679938034
+              "latency": 45.626667655
             }
           ],
           "implementation": "rust-libp2p",
@@ -609,34 +609,34 @@
         {
           "result": [
             {
-              "latency": 1.361376924
+              "latency": 1.522142557
             },
             {
-              "latency": 1.444832453
+              "latency": 1.417729633
             },
             {
-              "latency": 1.385131079
+              "latency": 1.393034921
             },
             {
-              "latency": 1.406373889
+              "latency": 1.507490663
             },
             {
-              "latency": 1.386205645
+              "latency": 1.461791297
             },
             {
-              "latency": 1.552124798
+              "latency": 1.482142431
             },
             {
-              "latency": 1.4161227109999999
+              "latency": 1.511302416
             },
             {
-              "latency": 1.461454255
+              "latency": 1.452599762
             },
             {
-              "latency": 1.436909221
+              "latency": 1.435318631
             },
             {
-              "latency": 1.452308048
+              "latency": 1.5063716870000001
             }
           ],
           "implementation": "rust-libp2p",
@@ -646,34 +646,34 @@
         {
           "result": [
             {
-              "latency": 1.185601755
+              "latency": 1.145026897
             },
             {
-              "latency": 1.165772552
+              "latency": 1.145951311
             },
             {
-              "latency": 1.063414907
+              "latency": 1.150830815
             },
             {
-              "latency": 1.109245559
+              "latency": 1.137472304
             },
             {
-              "latency": 1.110226386
+              "latency": 1.081245166
             },
             {
-              "latency": 1.103383598
+              "latency": 1.59943716
             },
             {
-              "latency": 1.040592955
+              "latency": 1.060731481
             },
             {
-              "latency": 1.232942926
+              "latency": 1.131600641
             },
             {
-              "latency": 1.104929008
+              "latency": 1.131655602
             },
             {
-              "latency": 0.976347483
+              "latency": 1.136339963
             }
           ],
           "implementation": "https",
@@ -683,34 +683,34 @@
         {
           "result": [
             {
-              "latency": 2.077971987
+              "latency": 2.191642927
             },
             {
-              "latency": 1.8873562659999998
+              "latency": 2.171334143
             },
             {
-              "latency": 1.93204855
+              "latency": 2.070586889
             },
             {
-              "latency": 1.816154999
+              "latency": 1.9550119879999999
             },
             {
-              "latency": 2.125903718
+              "latency": 1.921357032
             },
             {
-              "latency": 1.98538342
+              "latency": 1.882647205
             },
             {
-              "latency": 2.178254538
+              "latency": 2.072018102
             },
             {
-              "latency": 1.915706497
+              "latency": 2.334024597
             },
             {
-              "latency": 1.8129293290000001
+              "latency": 1.995596629
             },
             {
-              "latency": 1.785036046
+              "latency": 2.278014819
             }
           ],
           "implementation": "go-libp2p",
@@ -720,34 +720,34 @@
         {
           "result": [
             {
-              "latency": 1.456396087
+              "latency": 1.435999635
             },
             {
-              "latency": 1.55948145
+              "latency": 1.484398551
             },
             {
-              "latency": 1.429993666
+              "latency": 1.511891909
             },
             {
-              "latency": 1.475595513
+              "latency": 1.445660573
             },
             {
-              "latency": 1.455210913
+              "latency": 1.409702654
             },
             {
-              "latency": 1.439339672
+              "latency": 1.467694494
             },
             {
-              "latency": 1.455488411
+              "latency": 1.472078119
             },
             {
-              "latency": 1.450869037
+              "latency": 1.507179595
             },
             {
-              "latency": 1.4634842479999999
+              "latency": 1.510345096
             },
             {
-              "latency": 1.406223714
+              "latency": 1.447301909
             }
           ],
           "implementation": "go-libp2p",
@@ -757,34 +757,34 @@
         {
           "result": [
             {
-              "latency": 1.891688032
+              "latency": 2.146156173
             },
             {
-              "latency": 1.826480878
+              "latency": 2.075221552
             },
             {
-              "latency": 2.176262132
+              "latency": 2.047962941
             },
             {
-              "latency": 1.787163068
+              "latency": 2.249664773
             },
             {
-              "latency": 2.143787734
+              "latency": 2.082968832
             },
             {
-              "latency": 2.036426824
+              "latency": 1.948727663
             },
             {
-              "latency": 2.153567288
+              "latency": 1.896993062
             },
             {
-              "latency": 2.102646353
+              "latency": 2.135594046
             },
             {
-              "latency": 2.30729609
+              "latency": 1.915084453
             },
             {
-              "latency": 1.876771172
+              "latency": 2.082567107
             }
           ],
           "implementation": "go-libp2p",
@@ -794,34 +794,34 @@
         {
           "result": [
             {
-              "latency": 1.367729613
+              "latency": 1.474809036
             },
             {
-              "latency": 1.537972816
+              "latency": 1.428106063
             },
             {
-              "latency": 1.545354938
+              "latency": 1.3917085359999999
             },
             {
-              "latency": 1.527829026
+              "latency": 1.432570517
             },
             {
-              "latency": 1.445019079
+              "latency": 1.525072228
             },
             {
-              "latency": 1.37550288
+              "latency": 1.402286782
             },
             {
-              "latency": 1.393168849
+              "latency": 1.507586734
             },
             {
-              "latency": 1.39269708
+              "latency": 1.437731482
             },
             {
-              "latency": 1.358792462
+              "latency": 1.441406052
             },
             {
-              "latency": 1.44861547
+              "latency": 1.398794559
             }
           ],
           "implementation": "go-libp2p",
@@ -831,34 +831,34 @@
         {
           "result": [
             {
-              "latency": 1.897285547
+              "latency": 1.918366026
             },
             {
-              "latency": 1.8296080209999999
+              "latency": 1.946368828
             },
             {
-              "latency": 2.065692726
+              "latency": 2.073719545
             },
             {
-              "latency": 2.011362229
+              "latency": 2.679087171
             },
             {
-              "latency": 1.746627843
+              "latency": 1.882131083
             },
             {
-              "latency": 2.113045679
+              "latency": 2.085750025
             },
             {
-              "latency": 1.904791965
+              "latency": 1.904573458
             },
             {
-              "latency": 1.850703615
+              "latency": 1.89405567
             },
             {
-              "latency": 1.731479748
+              "latency": 2.100214433
             },
             {
-              "latency": 1.816241225
+              "latency": 2.328335638
             }
           ],
           "implementation": "go-libp2p",
@@ -868,34 +868,34 @@
         {
           "result": [
             {
-              "latency": 1.414166477
+              "latency": 1.524044261
             },
             {
-              "latency": 1.3971645879999999
+              "latency": 1.459599945
             },
             {
-              "latency": 1.4686444650000001
+              "latency": 1.404364793
             },
             {
-              "latency": 1.441575261
+              "latency": 1.409729418
             },
             {
-              "latency": 1.3966375260000001
+              "latency": 1.48881558
             },
             {
-              "latency": 1.458479644
+              "latency": 1.4973210780000001
             },
             {
-              "latency": 1.454862314
+              "latency": 1.524865366
             },
             {
-              "latency": 1.464597975
+              "latency": 1.3740197140000001
             },
             {
-              "latency": 1.492310995
+              "latency": 1.360551944
             },
             {
-              "latency": 1.457037737
+              "latency": 1.432704833
             }
           ],
           "implementation": "go-libp2p",
@@ -915,304 +915,304 @@
         {
           "result": [
             {
-              "latency": 0.118382774
+              "latency": 0.124246247
             },
             {
-              "latency": 0.126314268
+              "latency": 0.129494685
             },
             {
-              "latency": 0.119532101
+              "latency": 0.117853665
             },
             {
-              "latency": 0.122468278
+              "latency": 0.124624591
             },
             {
-              "latency": 0.12354697
+              "latency": 0.126743944
             },
             {
-              "latency": 0.141124749
+              "latency": 0.127912663
             },
             {
-              "latency": 0.11933069
+              "latency": 0.132551522
             },
             {
-              "latency": 0.117468761
+              "latency": 0.117061497
             },
             {
-              "latency": 0.130647118
+              "latency": 0.129191266
             },
             {
-              "latency": 0.122751041
+              "latency": 0.125381281
             },
             {
-              "latency": 0.130443393
+              "latency": 0.125025389
             },
             {
-              "latency": 0.127488281
+              "latency": 0.128306711
             },
             {
-              "latency": 0.126644657
+              "latency": 0.127611785
             },
             {
-              "latency": 0.121846666
+              "latency": 0.12772622
             },
             {
-              "latency": 0.124986691
+              "latency": 0.127774628
             },
             {
-              "latency": 0.128967859
+              "latency": 0.128915143
             },
             {
-              "latency": 0.127316042
+              "latency": 0.119983678
             },
             {
-              "latency": 0.118567413
+              "latency": 0.124435906
             },
             {
-              "latency": 0.127004099
+              "latency": 0.123187389
             },
             {
-              "latency": 0.124980617
+              "latency": 0.128720933
             },
             {
-              "latency": 0.12529295
+              "latency": 0.125328242
             },
             {
-              "latency": 0.119579045
+              "latency": 0.131169863
             },
             {
-              "latency": 0.123890648
+              "latency": 0.119821383
             },
             {
-              "latency": 0.130910636
+              "latency": 0.129323549
             },
             {
-              "latency": 0.116502172
+              "latency": 0.122529144
             },
             {
-              "latency": 0.124890106
+              "latency": 0.129483228
             },
             {
-              "latency": 0.124881143
+              "latency": 0.123473249
             },
             {
-              "latency": 0.122498765
+              "latency": 0.124785337
             },
             {
-              "latency": 0.117701317
+              "latency": 0.129274754
             },
             {
-              "latency": 0.125367406
+              "latency": 0.129046192
             },
             {
-              "latency": 0.120759835
+              "latency": 0.13113493
             },
             {
-              "latency": 0.127309183
+              "latency": 0.127342624
             },
             {
-              "latency": 0.115243121
+              "latency": 0.121070875
             },
             {
-              "latency": 0.118780655
+              "latency": 0.127219784
             },
             {
-              "latency": 0.125407737
+              "latency": 0.129278852
             },
             {
-              "latency": 0.119957466
+              "latency": 0.128990921
             },
             {
-              "latency": 0.121468509
+              "latency": 0.125117716
             },
             {
-              "latency": 0.126967724
+              "latency": 0.119551292
             },
             {
-              "latency": 0.118646339
+              "latency": 0.120414643
             },
             {
-              "latency": 0.12928761
+              "latency": 0.124542201
             },
             {
-              "latency": 0.119811699
+              "latency": 0.129823602
             },
             {
-              "latency": 0.120734281
+              "latency": 0.130420942
             },
             {
-              "latency": 0.122594836
+              "latency": 0.124031798
             },
             {
-              "latency": 0.117273278
+              "latency": 0.125097723
             },
             {
-              "latency": 0.13094243
+              "latency": 0.123260582
             },
             {
-              "latency": 0.130068
+              "latency": 0.129411106
             },
             {
-              "latency": 0.124756041
+              "latency": 0.124655781
             },
             {
-              "latency": 0.125206299
+              "latency": 0.124401481
             },
             {
-              "latency": 0.122088204
+              "latency": 0.127885914
             },
             {
-              "latency": 0.126978775
+              "latency": 0.128420281
             },
             {
-              "latency": 0.12475851
+              "latency": 0.126077545
             },
             {
-              "latency": 0.126408729
+              "latency": 0.118406288
             },
             {
-              "latency": 0.124569339
+              "latency": 0.123879802
             },
             {
-              "latency": 0.118331671
+              "latency": 0.126691883
             },
             {
-              "latency": 0.126127746
+              "latency": 0.119523982
             },
             {
-              "latency": 0.129411033
+              "latency": 0.125946407
             },
             {
-              "latency": 0.125365753
+              "latency": 0.130923777
             },
             {
-              "latency": 0.131428248
+              "latency": 0.124614335
             },
             {
-              "latency": 0.132034041
+              "latency": 0.131977811
             },
             {
-              "latency": 0.125335033
+              "latency": 0.122793368
             },
             {
-              "latency": 0.12557887
+              "latency": 0.129722405
             },
             {
-              "latency": 0.125016586
+              "latency": 0.120739302
             },
             {
-              "latency": 0.124652561
+              "latency": 0.130658315
             },
             {
-              "latency": 0.116976964
+              "latency": 0.120502544
             },
             {
-              "latency": 0.127069177
+              "latency": 0.126421406
             },
             {
-              "latency": 0.119537729
+              "latency": 0.123581155
             },
             {
-              "latency": 0.121654031
+              "latency": 0.127533772
             },
             {
-              "latency": 0.129816975
+              "latency": 0.124842633
             },
             {
-              "latency": 0.124911468
+              "latency": 0.123605808
             },
             {
-              "latency": 0.123418301
+              "latency": 0.130614831
             },
             {
-              "latency": 0.131002766
+              "latency": 0.127723109
             },
             {
-              "latency": 0.119397708
+              "latency": 0.124950639
             },
             {
-              "latency": 0.124054496
+              "latency": 0.125220007
             },
             {
-              "latency": 0.129012711
+              "latency": 0.12279533
             },
             {
-              "latency": 0.125958381
+              "latency": 0.129191733
             },
             {
-              "latency": 0.125052753
+              "latency": 0.129570249
             },
             {
-              "latency": 0.129578594
+              "latency": 0.12557528
             },
             {
-              "latency": 0.119548671
+              "latency": 0.121980542
             },
             {
-              "latency": 0.120477213
+              "latency": 0.12592364
             },
             {
-              "latency": 0.124158756
+              "latency": 0.130537319
             },
             {
-              "latency": 0.122558764
+              "latency": 0.126267656
             },
             {
-              "latency": 0.130364317
+              "latency": 0.129660961
             },
             {
-              "latency": 0.122444475
+              "latency": 0.131168635
             },
             {
-              "latency": 0.120305352
+              "latency": 0.1311578
             },
             {
-              "latency": 0.117054411
+              "latency": 0.120304684
             },
             {
-              "latency": 0.118714156
+              "latency": 0.121703085
             },
             {
-              "latency": 0.131292757
+              "latency": 0.118102561
             },
             {
-              "latency": 0.126087095
+              "latency": 0.127291005
             },
             {
-              "latency": 0.124503646
+              "latency": 0.124620954
             },
             {
-              "latency": 0.130913358
+              "latency": 0.127855618
             },
             {
-              "latency": 0.126414574
+              "latency": 0.132339447
             },
             {
-              "latency": 0.129530429
+              "latency": 0.127238333
             },
             {
-              "latency": 0.117886637
+              "latency": 0.129451661
             },
             {
-              "latency": 0.124254572
+              "latency": 0.120896661
             },
             {
-              "latency": 0.12612291
+              "latency": 0.126870447
             },
             {
-              "latency": 0.120076502
+              "latency": 0.127443842
             },
             {
-              "latency": 0.117970831
+              "latency": 0.124271851
             },
             {
-              "latency": 0.125172913
+              "latency": 0.124324532
             },
             {
-              "latency": 0.124405736
+              "latency": 0.129094137
             },
             {
-              "latency": 0.118817339
+              "latency": 0.130064921
             }
           ],
           "implementation": "quic-go",
@@ -1222,304 +1222,304 @@
         {
           "result": [
             {
-              "latency": 0.184481879
+              "latency": 0.187885427
             },
             {
-              "latency": 0.183877997
+              "latency": 0.173766773
             },
             {
-              "latency": 0.184048352
+              "latency": 0.186285448
             },
             {
-              "latency": 0.192352796
+              "latency": 0.176405942
             },
             {
-              "latency": 0.184225847
+              "latency": 0.185432008
             },
             {
-              "latency": 0.179505524
+              "latency": 0.176347023
             },
             {
-              "latency": 0.185387614
+              "latency": 0.186065336
             },
             {
-              "latency": 0.194697684
+              "latency": 0.18308146
             },
             {
-              "latency": 0.177726317
+              "latency": 0.185387647
             },
             {
-              "latency": 0.17499669
+              "latency": 0.174663199
             },
             {
-              "latency": 0.186213129
+              "latency": 0.190888998
             },
             {
-              "latency": 0.185472659
+              "latency": 0.186559259
             },
             {
-              "latency": 0.184266978
+              "latency": 0.193872109
             },
             {
-              "latency": 0.177460775
+              "latency": 0.187497267
             },
             {
-              "latency": 0.187146263
+              "latency": 0.194882763
             },
             {
-              "latency": 0.185709647
+              "latency": 0.1942011
             },
             {
-              "latency": 0.179915198
+              "latency": 0.180603789
             },
             {
-              "latency": 0.185943157
+              "latency": 0.190207711
             },
             {
-              "latency": 0.175547977
+              "latency": 0.192680613
             },
             {
-              "latency": 0.18914268
+              "latency": 0.191513062
             },
             {
-              "latency": 0.196148518
+              "latency": 0.189225212
             },
             {
-              "latency": 0.183315915
+              "latency": 0.188399391
             },
             {
-              "latency": 0.185815534
+              "latency": 0.189106909
             },
             {
-              "latency": 0.185750918
+              "latency": 0.175074515
             },
             {
-              "latency": 0.185879965
+              "latency": 0.184608229
             },
             {
-              "latency": 0.183203405
+              "latency": 0.189089824
             },
             {
-              "latency": 0.172747215
+              "latency": 0.192654121
             },
             {
-              "latency": 0.185917692
+              "latency": 0.177505065
             },
             {
-              "latency": 0.178456189
+              "latency": 0.18629863
             },
             {
-              "latency": 0.175666813
+              "latency": 0.186561763
             },
             {
-              "latency": 0.194435929
+              "latency": 0.177427279
             },
             {
-              "latency": 0.179307645
+              "latency": 0.195853172
             },
             {
-              "latency": 0.181533307
+              "latency": 0.190934272
             },
             {
-              "latency": 0.184903574
+              "latency": 0.190450403
             },
             {
-              "latency": 0.183678435
+              "latency": 0.183818528
             },
             {
-              "latency": 0.185905642
+              "latency": 0.187952646
             },
             {
-              "latency": 0.183980391
+              "latency": 0.192112249
             },
             {
-              "latency": 0.188247606
+              "latency": 0.179524853
             },
             {
-              "latency": 0.177679495
+              "latency": 0.19325288
             },
             {
-              "latency": 0.186623663
+              "latency": 0.196650124
             },
             {
-              "latency": 0.179030216
+              "latency": 0.193748149
             },
             {
-              "latency": 0.180082765
+              "latency": 0.196006019
             },
             {
-              "latency": 0.182057009
+              "latency": 0.183118388
             },
             {
-              "latency": 0.186531783
+              "latency": 0.19490404
             },
             {
-              "latency": 0.187470399
+              "latency": 0.190942743
             },
             {
-              "latency": 0.183470785
+              "latency": 0.191771953
             },
             {
-              "latency": 0.177917125
+              "latency": 0.190220998
             },
             {
-              "latency": 0.177168703
+              "latency": 0.186876802
             },
             {
-              "latency": 0.188026786
+              "latency": 0.185027346
             },
             {
-              "latency": 0.182447097
+              "latency": 0.184701586
             },
             {
-              "latency": 0.192089574
+              "latency": 0.180249303
             },
             {
-              "latency": 0.175057986
+              "latency": 0.186354886
             },
             {
-              "latency": 0.193050074
+              "latency": 0.187893121
             },
             {
-              "latency": 0.193907317
+              "latency": 0.195664788
             },
             {
-              "latency": 0.185331985
+              "latency": 0.182966189
             },
             {
-              "latency": 0.185006767
+              "latency": 0.177966943
             },
             {
-              "latency": 0.18762286
+              "latency": 0.187846701
             },
             {
-              "latency": 0.188808733
+              "latency": 0.192007943
             },
             {
-              "latency": 0.177665423
+              "latency": 0.184897233
             },
             {
-              "latency": 0.185319508
+              "latency": 0.182273479
             },
             {
-              "latency": 0.181776
+              "latency": 0.184454299
             },
             {
-              "latency": 0.184266663
+              "latency": 0.186888274
             },
             {
-              "latency": 0.183581556
+              "latency": 0.186191167
             },
             {
-              "latency": 0.175493976
+              "latency": 0.190498346
             },
             {
-              "latency": 0.184301602
+              "latency": 0.189539205
             },
             {
-              "latency": 0.18579278
+              "latency": 0.192143847
             },
             {
-              "latency": 0.184151908
+              "latency": 0.1894574
             },
             {
-              "latency": 0.184887505
+              "latency": 0.187743951
             },
             {
-              "latency": 0.173466622
+              "latency": 0.186148253
             },
             {
-              "latency": 0.18727849
+              "latency": 0.182013175
             },
             {
-              "latency": 0.184081177
+              "latency": 0.189546266
             },
             {
-              "latency": 0.183890072
+              "latency": 0.183328261
             },
             {
-              "latency": 0.185149604
+              "latency": 0.192722045
             },
             {
-              "latency": 0.178640094
+              "latency": 0.192479726
             },
             {
-              "latency": 0.177901059
+              "latency": 0.194023483
             },
             {
-              "latency": 0.183213113
+              "latency": 0.180465866
             },
             {
-              "latency": 0.187069605
+              "latency": 0.18451437
             },
             {
-              "latency": 0.178414243
+              "latency": 0.18689978
             },
             {
-              "latency": 0.183587467
+              "latency": 0.191362332
             },
             {
-              "latency": 0.173712031
+              "latency": 0.181416606
             },
             {
-              "latency": 0.187876302
+              "latency": 0.194491003
             },
             {
-              "latency": 0.194274064
+              "latency": 0.177738279
             },
             {
-              "latency": 0.192829785
+              "latency": 0.192290574
             },
             {
-              "latency": 0.188542354
+              "latency": 0.178150788
             },
             {
-              "latency": 0.174954997
+              "latency": 0.193302716
             },
             {
-              "latency": 0.188254456
+              "latency": 0.189608437
             },
             {
-              "latency": 0.176294839
+              "latency": 0.184163772
             },
             {
-              "latency": 0.194953691
+              "latency": 0.187736359
             },
             {
-              "latency": 0.183160924
+              "latency": 0.191293837
             },
             {
-              "latency": 0.173495216
+              "latency": 0.194335151
             },
             {
-              "latency": 0.184510753
+              "latency": 0.184020802
             },
             {
-              "latency": 0.194094018
+              "latency": 0.196517381
             },
             {
-              "latency": 0.194969716
+              "latency": 0.185730992
             },
             {
-              "latency": 0.185826254
+              "latency": 0.182074276
             },
             {
-              "latency": 0.179318967
+              "latency": 0.184172047
             },
             {
-              "latency": 0.183717279
+              "latency": 0.193337752
             },
             {
-              "latency": 0.181907615
+              "latency": 0.185052817
             },
             {
-              "latency": 0.187466021
+              "latency": 0.182572869
             },
             {
-              "latency": 0.185306483
+              "latency": 0.191465903
             },
             {
-              "latency": 0.17846535
+              "latency": 0.181616939
             }
           ],
           "implementation": "rust-libp2p",
@@ -1529,304 +1529,304 @@
         {
           "result": [
             {
-              "latency": 0.125658039
+              "latency": 0.119845998
             },
             {
-              "latency": 0.121906029
+              "latency": 0.130142466
             },
             {
-              "latency": 0.131179267
+              "latency": 0.128370475
             },
             {
-              "latency": 0.122702971
+              "latency": 0.129222369
             },
             {
-              "latency": 0.125245899
+              "latency": 0.122353241
             },
             {
-              "latency": 0.129632207
+              "latency": 0.121593614
             },
             {
-              "latency": 0.126715188
+              "latency": 0.122236919
             },
             {
-              "latency": 0.127463341
+              "latency": 0.128402913
             },
             {
-              "latency": 0.123708081
+              "latency": 0.132424013
             },
             {
-              "latency": 0.127489087
+              "latency": 0.124329404
             },
             {
-              "latency": 0.120858437
+              "latency": 0.124243355
             },
             {
-              "latency": 0.120643572
+              "latency": 0.128347501
             },
             {
-              "latency": 0.120596534
+              "latency": 0.131018757
             },
             {
-              "latency": 0.12377814
+              "latency": 0.129350357
             },
             {
-              "latency": 0.130864656
+              "latency": 0.121616748
             },
             {
-              "latency": 0.131351792
+              "latency": 0.12960626
             },
             {
-              "latency": 0.126452991
+              "latency": 0.125121356
             },
             {
-              "latency": 0.126257088
+              "latency": 0.127564224
             },
             {
-              "latency": 0.130974796
+              "latency": 0.125380162
             },
             {
-              "latency": 0.126398578
+              "latency": 0.123578812
             },
             {
-              "latency": 0.118344873
+              "latency": 0.127403748
             },
             {
-              "latency": 0.125190273
+              "latency": 0.129620302
             },
             {
-              "latency": 0.124900386
+              "latency": 0.125642955
             },
             {
-              "latency": 0.130042464
+              "latency": 0.124485655
             },
             {
-              "latency": 0.119522695
+              "latency": 0.124489648
             },
             {
-              "latency": 0.12538898
+              "latency": 0.124281894
             },
             {
-              "latency": 0.122594987
+              "latency": 0.115382267
             },
             {
-              "latency": 0.130755356
+              "latency": 0.126949023
             },
             {
-              "latency": 0.118790803
+              "latency": 0.124708411
             },
             {
-              "latency": 0.132375069
+              "latency": 0.127284515
             },
             {
-              "latency": 0.12981169
+              "latency": 0.1275802
             },
             {
-              "latency": 0.116881945
+              "latency": 0.121152718
             },
             {
-              "latency": 0.125115382
+              "latency": 0.122635073
             },
             {
-              "latency": 0.117634161
+              "latency": 0.125914965
             },
             {
-              "latency": 0.122509121
+              "latency": 0.121389974
             },
             {
-              "latency": 0.129870363
+              "latency": 0.123763368
             },
             {
-              "latency": 0.124729155
+              "latency": 0.120778608
             },
             {
-              "latency": 0.12161994
+              "latency": 0.122173008
             },
             {
-              "latency": 0.121503659
+              "latency": 0.126302877
             },
             {
-              "latency": 0.124027068
+              "latency": 0.125574487
             },
             {
-              "latency": 0.122763
+              "latency": 0.126255944
             },
             {
-              "latency": 0.128752466
+              "latency": 0.120185703
             },
             {
-              "latency": 0.126437446
+              "latency": 0.12581047
             },
             {
-              "latency": 0.132192805
+              "latency": 0.12097257
             },
             {
-              "latency": 0.119246995
+              "latency": 0.130527281
             },
             {
-              "latency": 0.123769615
+              "latency": 0.125371829
             },
             {
-              "latency": 0.118513416
+              "latency": 0.124272672
             },
             {
-              "latency": 0.124021449
+              "latency": 0.128551076
             },
             {
-              "latency": 0.116726303
+              "latency": 0.127083617
             },
             {
-              "latency": 0.129936601
+              "latency": 0.130898498
             },
             {
-              "latency": 0.117701926
+              "latency": 0.131964743
             },
             {
-              "latency": 0.120691215
+              "latency": 0.123922107
             },
             {
-              "latency": 0.124308091
+              "latency": 0.129761968
             },
             {
-              "latency": 0.125147432
+              "latency": 0.121467433
             },
             {
-              "latency": 0.120597655
+              "latency": 0.124291374
             },
             {
-              "latency": 0.130946474
+              "latency": 0.125832092
             },
             {
-              "latency": 0.124626717
+              "latency": 0.12098134
             },
             {
-              "latency": 0.125592996
+              "latency": 0.123958307
             },
             {
-              "latency": 0.131927166
+              "latency": 0.125526771
             },
             {
-              "latency": 0.12726339
+              "latency": 0.119141488
             },
             {
-              "latency": 0.122968626
+              "latency": 0.12858195
             },
             {
-              "latency": 0.126686409
+              "latency": 0.129935553
             },
             {
-              "latency": 0.118952187
+              "latency": 0.130833251
             },
             {
-              "latency": 0.125829781
+              "latency": 0.127976841
             },
             {
-              "latency": 0.125185004
+              "latency": 0.125755947
             },
             {
-              "latency": 0.123821298
+              "latency": 0.128658794
             },
             {
-              "latency": 0.121825541
+              "latency": 0.125333435
             },
             {
-              "latency": 0.12633669
+              "latency": 0.12177683
             },
             {
-              "latency": 0.129828618
+              "latency": 0.125108404
             },
             {
-              "latency": 0.130935105
+              "latency": 0.118920529
             },
             {
-              "latency": 0.123886824
+              "latency": 0.124151757
             },
             {
-              "latency": 0.130997878
+              "latency": 0.125573485
             },
             {
-              "latency": 0.119830614
+              "latency": 0.120217338
             },
             {
-              "latency": 0.119266511
+              "latency": 0.121248553
             },
             {
-              "latency": 0.125308313
+              "latency": 0.126122559
             },
             {
-              "latency": 0.127479513
+              "latency": 0.129720037
             },
             {
-              "latency": 0.118010318
+              "latency": 0.124818587
             },
             {
-              "latency": 0.123893179
+              "latency": 0.130848584
             },
             {
-              "latency": 0.125530045
+              "latency": 0.121945795
             },
             {
-              "latency": 0.120130327
+              "latency": 0.123748736
             },
             {
-              "latency": 0.117226966
+              "latency": 0.127744861
             },
             {
-              "latency": 0.125369673
+              "latency": 0.132332068
             },
             {
-              "latency": 0.126833924
+              "latency": 0.127574218
             },
             {
-              "latency": 0.125407204
+              "latency": 0.124493355
             },
             {
-              "latency": 0.115442786
+              "latency": 0.123166008
             },
             {
-              "latency": 0.123786071
+              "latency": 0.123632322
             },
             {
-              "latency": 0.12716485
+              "latency": 0.125838976
             },
             {
-              "latency": 0.122650111
+              "latency": 0.12742818
             },
             {
-              "latency": 0.126416975
+              "latency": 0.125742046
             },
             {
-              "latency": 0.125086207
+              "latency": 0.117168981
             },
             {
-              "latency": 0.123544174
+              "latency": 0.123137113
             },
             {
-              "latency": 0.124371267
+              "latency": 0.127353258
             },
             {
-              "latency": 0.132170116
+              "latency": 0.130367638
             },
             {
-              "latency": 0.118894014
+              "latency": 0.122569134
             },
             {
-              "latency": 0.127384745
+              "latency": 0.12102493
             },
             {
-              "latency": 0.124614283
+              "latency": 0.123774089
             },
             {
-              "latency": 0.124731107
+              "latency": 0.129964187
             },
             {
-              "latency": 0.124440915
+              "latency": 0.1228657
             },
             {
-              "latency": 0.11797077
+              "latency": 0.124129161
             },
             {
-              "latency": 0.124043267
+              "latency": 0.126898652
             }
           ],
           "implementation": "rust-libp2p",
@@ -1836,304 +1836,304 @@
         {
           "result": [
             {
-              "latency": 0.184198666
+              "latency": 0.180485473
             },
             {
-              "latency": 0.175607129
+              "latency": 0.186150166
             },
             {
-              "latency": 0.185886591
+              "latency": 0.183508665
             },
             {
-              "latency": 0.196434302
+              "latency": 0.184443951
             },
             {
-              "latency": 0.184264052
+              "latency": 0.188579424
             },
             {
-              "latency": 0.194190389
+              "latency": 0.189311749
             },
             {
-              "latency": 0.18917558
+              "latency": 0.186439114
             },
             {
-              "latency": 0.19512122
+              "latency": 0.185801274
             },
             {
-              "latency": 0.185503129
+              "latency": 0.191357691
             },
             {
-              "latency": 0.184881111
+              "latency": 0.188070199
             },
             {
-              "latency": 0.183371874
+              "latency": 0.188785144
             },
             {
-              "latency": 0.193709325
+              "latency": 0.182515775
             },
             {
-              "latency": 0.194792782
+              "latency": 0.19444946
             },
             {
-              "latency": 0.193821733
+              "latency": 0.186693664
             },
             {
-              "latency": 0.184164378
+              "latency": 0.181292031
             },
             {
-              "latency": 0.193194402
+              "latency": 0.193358963
             },
             {
-              "latency": 0.192719673
+              "latency": 0.188223368
             },
             {
-              "latency": 0.185489511
+              "latency": 0.190050935
             },
             {
-              "latency": 0.177804074
+              "latency": 0.186398448
             },
             {
-              "latency": 0.193102462
+              "latency": 0.190177538
             },
             {
-              "latency": 0.18891022
+              "latency": 0.181634344
             },
             {
-              "latency": 0.177216022
+              "latency": 0.183086376
             },
             {
-              "latency": 0.179008123
+              "latency": 0.195224724
             },
             {
-              "latency": 0.187879522
+              "latency": 0.194217032
             },
             {
-              "latency": 0.185608979
+              "latency": 0.185407557
             },
             {
-              "latency": 0.185801052
+              "latency": 0.177636831
             },
             {
-              "latency": 0.178895407
+              "latency": 0.176245609
             },
             {
-              "latency": 0.185892252
+              "latency": 0.183935824
             },
             {
-              "latency": 0.177760085
+              "latency": 0.178156484
             },
             {
-              "latency": 0.194921038
+              "latency": 0.189046508
             },
             {
-              "latency": 0.182307811
+              "latency": 0.179509317
             },
             {
-              "latency": 0.175590963
+              "latency": 0.184415695
             },
             {
-              "latency": 0.185771371
+              "latency": 0.184135375
             },
             {
-              "latency": 0.185434662
+              "latency": 0.191983537
             },
             {
-              "latency": 0.19455861
+              "latency": 0.185772459
             },
             {
-              "latency": 0.171264199
+              "latency": 0.185631514
             },
             {
-              "latency": 0.192427981
+              "latency": 0.194776269
             },
             {
-              "latency": 0.18736357
+              "latency": 0.18652965
             },
             {
-              "latency": 0.174979753
+              "latency": 0.191994324
             },
             {
-              "latency": 0.189246132
+              "latency": 0.189056933
             },
             {
-              "latency": 0.186527405
+              "latency": 0.194223088
             },
             {
-              "latency": 0.1861386
+              "latency": 0.186121544
             },
             {
-              "latency": 0.185618415
+              "latency": 0.176073501
             },
             {
-              "latency": 0.1848249
+              "latency": 0.18118799
             },
             {
-              "latency": 0.177089086
+              "latency": 0.18604319
             },
             {
-              "latency": 0.196733653
+              "latency": 0.185310662
             },
             {
-              "latency": 0.18565983
+              "latency": 0.19347909
             },
             {
-              "latency": 0.185411248
+              "latency": 0.190198112
             },
             {
-              "latency": 0.183179235
+              "latency": 0.184895716
             },
             {
-              "latency": 0.184589502
+              "latency": 0.194417191
             },
             {
-              "latency": 0.195556917
+              "latency": 0.181301792
             },
             {
-              "latency": 0.188674987
+              "latency": 0.174577958
             },
             {
-              "latency": 0.178023923
+              "latency": 0.187663332
             },
             {
-              "latency": 0.1811543
+              "latency": 0.193901354
             },
             {
-              "latency": 0.196881829
+              "latency": 0.191457223
             },
             {
-              "latency": 0.185717558
+              "latency": 0.187550297
             },
             {
-              "latency": 0.185939547
+              "latency": 0.193505168
             },
             {
-              "latency": 0.176438601
+              "latency": 0.175543758
             },
             {
-              "latency": 0.187448646
+              "latency": 0.184956693
             },
             {
-              "latency": 0.177027509
+              "latency": 0.184967182
             },
             {
-              "latency": 0.192325982
+              "latency": 0.185784003
             },
             {
-              "latency": 0.188921354
+              "latency": 0.174491883
             },
             {
-              "latency": 0.185373882
+              "latency": 0.188142003
             },
             {
-              "latency": 0.186273568
+              "latency": 0.189713152
             },
             {
-              "latency": 0.184646968
+              "latency": 0.18795817
             },
             {
-              "latency": 0.196223855
+              "latency": 0.183549492
             },
             {
-              "latency": 0.175539784
+              "latency": 0.175936926
             },
             {
-              "latency": 0.184333204
+              "latency": 0.187805179
             },
             {
-              "latency": 0.176701526
+              "latency": 0.190370684
             },
             {
-              "latency": 0.178685666
+              "latency": 0.190526952
             },
             {
-              "latency": 0.184110019
+              "latency": 0.191537369
             },
             {
-              "latency": 0.183703385
+              "latency": 0.182199145
             },
             {
-              "latency": 0.192888319
+              "latency": 0.190720383
             },
             {
-              "latency": 0.185849201
+              "latency": 0.189024631
             },
             {
-              "latency": 0.172936262
+              "latency": 0.191143403
             },
             {
-              "latency": 0.183497159
+              "latency": 0.176173754
             },
             {
-              "latency": 0.178797365
+              "latency": 0.183611064
             },
             {
-              "latency": 0.19289618
+              "latency": 0.186337569
             },
             {
-              "latency": 0.177306384
+              "latency": 0.183304273
             },
             {
-              "latency": 0.178259784
+              "latency": 0.19310219
             },
             {
-              "latency": 0.175819247
+              "latency": 0.188705496
             },
             {
-              "latency": 0.18723048
+              "latency": 0.183240372
             },
             {
-              "latency": 0.186219924
+              "latency": 0.175390484
             },
             {
-              "latency": 0.194288384
+              "latency": 0.181669703
             },
             {
-              "latency": 0.186068123
+              "latency": 0.18704744
             },
             {
-              "latency": 0.18626629
+              "latency": 0.186297405
             },
             {
-              "latency": 0.186565998
+              "latency": 0.181500429
             },
             {
-              "latency": 0.18568103
+              "latency": 0.184474763
             },
             {
-              "latency": 0.193053106
+              "latency": 0.191667047
             },
             {
-              "latency": 0.195285799
+              "latency": 0.182959952
             },
             {
-              "latency": 0.187511213
+              "latency": 0.192005956
             },
             {
-              "latency": 0.172959545
+              "latency": 0.187195933
             },
             {
-              "latency": 0.185925114
+              "latency": 0.190582209
             },
             {
-              "latency": 0.177632998
+              "latency": 0.186385877
             },
             {
-              "latency": 0.184373183
+              "latency": 0.196791502
             },
             {
-              "latency": 0.187707558
+              "latency": 0.189300867
             },
             {
-              "latency": 0.180663056
+              "latency": 0.180051982
             },
             {
-              "latency": 0.183322955
+              "latency": 0.189286262
             },
             {
-              "latency": 0.17865667
+              "latency": 0.18272447
             },
             {
-              "latency": 0.17930585
+              "latency": 0.189204956
             }
           ],
           "implementation": "rust-libp2p",
@@ -2143,304 +2143,304 @@
         {
           "result": [
             {
-              "latency": 0.132209146
+              "latency": 0.13157223
             },
             {
-              "latency": 0.120348831
+              "latency": 0.123848467
             },
             {
-              "latency": 0.125859095
+              "latency": 0.132563273
             },
             {
-              "latency": 0.118557278
+              "latency": 0.122516475
             },
             {
-              "latency": 0.119598099
+              "latency": 0.126803353
             },
             {
-              "latency": 0.130966534
+              "latency": 0.124881153
             },
             {
-              "latency": 0.123032641
+              "latency": 0.127646164
             },
             {
-              "latency": 0.119754847
+              "latency": 0.127391157
             },
             {
-              "latency": 0.119367829
+              "latency": 0.125065177
             },
             {
-              "latency": 0.124955654
+              "latency": 0.119116634
             },
             {
-              "latency": 0.119375971
+              "latency": 0.126306771
             },
             {
-              "latency": 0.124137614
+              "latency": 0.127982877
             },
             {
-              "latency": 0.125290755
+              "latency": 0.124149431
             },
             {
-              "latency": 0.126749463
+              "latency": 0.116876198
             },
             {
-              "latency": 0.124540123
+              "latency": 0.131855722
             },
             {
-              "latency": 0.124477444
+              "latency": 0.127334863
             },
             {
-              "latency": 0.123823103
+              "latency": 0.128639766
             },
             {
-              "latency": 0.131038193
+              "latency": 0.122401963
             },
             {
-              "latency": 0.126422374
+              "latency": 0.121553947
             },
             {
-              "latency": 0.117420113
+              "latency": 0.12594812
             },
             {
-              "latency": 0.129585245
+              "latency": 0.128334748
             },
             {
-              "latency": 0.123252431
+              "latency": 0.120064975
             },
             {
-              "latency": 0.11822168
+              "latency": 0.130498457
             },
             {
-              "latency": 0.118267698
+              "latency": 0.130438126
             },
             {
-              "latency": 0.130356318
+              "latency": 0.129234311
             },
             {
-              "latency": 0.126469622
+              "latency": 0.123784775
             },
             {
-              "latency": 0.12579092
+              "latency": 0.123613866
             },
             {
-              "latency": 0.125635205
+              "latency": 0.123485357
             },
             {
-              "latency": 0.13209394
+              "latency": 0.124333363
             },
             {
-              "latency": 0.125212252
+              "latency": 0.121002628
             },
             {
-              "latency": 0.125533416
+              "latency": 0.12247266
             },
             {
-              "latency": 0.118365848
+              "latency": 0.119991224
             },
             {
-              "latency": 0.125336924
+              "latency": 0.125649333
             },
             {
-              "latency": 0.12753912
+              "latency": 0.124897657
             },
             {
-              "latency": 0.126543444
+              "latency": 0.124924898
             },
             {
-              "latency": 0.131293654
+              "latency": 0.122758444
             },
             {
-              "latency": 0.125671978
+              "latency": 0.127004029
             },
             {
-              "latency": 0.126568589
+              "latency": 0.125453277
             },
             {
-              "latency": 0.121061381
+              "latency": 0.127184156
             },
             {
-              "latency": 0.120829863
+              "latency": 0.122909104
             },
             {
-              "latency": 0.119382552
+              "latency": 0.130525106
             },
             {
-              "latency": 0.123017021
+              "latency": 0.126600769
             },
             {
-              "latency": 0.127080482
+              "latency": 0.126561531
             },
             {
-              "latency": 0.122856588
+              "latency": 0.128304498
             },
             {
-              "latency": 0.122644076
+              "latency": 0.122456948
             },
             {
-              "latency": 0.119673424
+              "latency": 0.123660483
             },
             {
-              "latency": 0.128788899
+              "latency": 0.128908627
             },
             {
-              "latency": 0.117434763
+              "latency": 0.127027495
             },
             {
-              "latency": 0.13094373
+              "latency": 0.124844664
             },
             {
-              "latency": 0.125233173
+              "latency": 0.131118911
             },
             {
-              "latency": 0.12445445
+              "latency": 0.129338571
             },
             {
-              "latency": 0.1198079
+              "latency": 0.130025975
             },
             {
-              "latency": 0.122891231
+              "latency": 0.130427722
             },
             {
-              "latency": 0.12554887
+              "latency": 0.115631164
             },
             {
-              "latency": 0.125121374
+              "latency": 0.131228222
             },
             {
-              "latency": 0.11832346
+              "latency": 0.122708113
             },
             {
-              "latency": 0.131319598
+              "latency": 0.124963875
             },
             {
-              "latency": 0.124042138
+              "latency": 0.130570201
             },
             {
-              "latency": 0.117169815
+              "latency": 0.124979494
             },
             {
-              "latency": 0.118155345
+              "latency": 0.126649047
             },
             {
-              "latency": 0.127048449
+              "latency": 0.12935314
             },
             {
-              "latency": 0.124993518
+              "latency": 0.12056468
             },
             {
-              "latency": 0.132095299
+              "latency": 0.123971523
             },
             {
-              "latency": 0.124505839
+              "latency": 0.125357388
             },
             {
-              "latency": 0.129047376
+              "latency": 0.124928547
             },
             {
-              "latency": 0.119227605
+              "latency": 0.123874147
             },
             {
-              "latency": 0.132555542
+              "latency": 0.122598622
             },
             {
-              "latency": 0.12100953
+              "latency": 0.127058844
             },
             {
-              "latency": 0.120813514
+              "latency": 0.119779108
             },
             {
-              "latency": 0.13172424
+              "latency": 0.127789556
             },
             {
-              "latency": 0.122635634
+              "latency": 0.125032086
             },
             {
-              "latency": 0.11977331
+              "latency": 0.127388559
             },
             {
-              "latency": 0.131206728
+              "latency": 0.126140948
             },
             {
-              "latency": 0.129745325
+              "latency": 0.124460125
             },
             {
-              "latency": 0.131325457
+              "latency": 0.123929923
             },
             {
-              "latency": 0.118847459
+              "latency": 0.126760272
             },
             {
-              "latency": 0.125741618
+              "latency": 0.124115006
             },
             {
-              "latency": 0.129890198
+              "latency": 0.125762218
             },
             {
-              "latency": 0.131212357
+              "latency": 0.123419162
             },
             {
-              "latency": 0.124322291
+              "latency": 0.129520247
             },
             {
-              "latency": 0.124270981
+              "latency": 0.122425398
             },
             {
-              "latency": 0.124420089
+              "latency": 0.122067045
             },
             {
-              "latency": 0.120728288
+              "latency": 0.125524727
             },
             {
-              "latency": 0.12071411
+              "latency": 0.12318089
             },
             {
-              "latency": 0.119141685
+              "latency": 0.125489802
             },
             {
-              "latency": 0.126847451
+              "latency": 0.130312235
             },
             {
-              "latency": 0.126496625
+              "latency": 0.125918248
             },
             {
-              "latency": 0.128832107
+              "latency": 0.120572033
             },
             {
-              "latency": 0.124328064
+              "latency": 0.11807764
             },
             {
-              "latency": 0.124382522
+              "latency": 0.12493122
             },
             {
-              "latency": 0.120301693
+              "latency": 0.130435669
             },
             {
-              "latency": 0.12098633
+              "latency": 0.11962244
             },
             {
-              "latency": 0.12171115
+              "latency": 0.124535759
             },
             {
-              "latency": 0.123140921
+              "latency": 0.130132873
             },
             {
-              "latency": 0.118283106
+              "latency": 0.125300416
             },
             {
-              "latency": 0.124966412
+              "latency": 0.122831343
             },
             {
-              "latency": 0.126675192
+              "latency": 0.121365586
             },
             {
-              "latency": 0.131718486
+              "latency": 0.123445417
             },
             {
-              "latency": 0.131484024
+              "latency": 0.122592537
             },
             {
-              "latency": 0.130664716
+              "latency": 0.122297784
             }
           ],
           "implementation": "rust-libp2p",
@@ -2450,304 +2450,304 @@
         {
           "result": [
             {
-              "latency": 0.186798619
+              "latency": 0.185103189
             },
             {
-              "latency": 0.176283725
+              "latency": 0.188694883
             },
             {
-              "latency": 0.18383554
+              "latency": 0.188597605
             },
             {
-              "latency": 0.183264538
+              "latency": 0.19301797
             },
             {
-              "latency": 0.1871228
+              "latency": 0.187378076
             },
             {
-              "latency": 0.174068448
+              "latency": 0.19142034
             },
             {
-              "latency": 0.178191225
+              "latency": 0.185358784
             },
             {
-              "latency": 0.184369711
+              "latency": 0.179558898
             },
             {
-              "latency": 0.179617725
+              "latency": 0.189891228
             },
             {
-              "latency": 0.1860829
+              "latency": 0.176503108
             },
             {
-              "latency": 0.179161428
+              "latency": 0.180154453
             },
             {
-              "latency": 0.175125146
+              "latency": 0.193373753
             },
             {
-              "latency": 0.194302261
+              "latency": 0.183361574
             },
             {
-              "latency": 0.174585516
+              "latency": 0.175585704
             },
             {
-              "latency": 0.18333979
+              "latency": 0.179226581
             },
             {
-              "latency": 0.187437305
+              "latency": 0.182209775
             },
             {
-              "latency": 0.183487425
+              "latency": 0.191560021
             },
             {
-              "latency": 0.182708884
+              "latency": 0.189236235
             },
             {
-              "latency": 0.181236539
+              "latency": 0.185626315
             },
             {
-              "latency": 0.187450191
+              "latency": 0.187206367
             },
             {
-              "latency": 0.17947898
+              "latency": 0.187751323
             },
             {
-              "latency": 0.179661134
+              "latency": 0.191988954
             },
             {
-              "latency": 0.181105757
+              "latency": 0.190150548
             },
             {
-              "latency": 0.172860276
+              "latency": 0.191200187
             },
             {
-              "latency": 0.172090219
+              "latency": 0.182548148
             },
             {
-              "latency": 0.183379151
+              "latency": 0.185461038
             },
             {
-              "latency": 0.184188429
+              "latency": 0.18518695
             },
             {
-              "latency": 0.182457127
+              "latency": 0.190265888
             },
             {
-              "latency": 0.185547431
+              "latency": 0.193448759
             },
             {
-              "latency": 0.187004723
+              "latency": 0.189384
             },
             {
-              "latency": 0.183621372
+              "latency": 0.184453226
             },
             {
-              "latency": 0.176363375
+              "latency": 0.189993669
             },
             {
-              "latency": 0.185397231
+              "latency": 0.183245476
             },
             {
-              "latency": 0.183571303
+              "latency": 0.17764358
             },
             {
-              "latency": 0.177048554
+              "latency": 0.180633104
             },
             {
-              "latency": 0.181695408
+              "latency": 0.183508428
             },
             {
-              "latency": 0.185526187
+              "latency": 0.184267867
             },
             {
-              "latency": 0.195580424
+              "latency": 0.187276065
             },
             {
-              "latency": 0.191516224
+              "latency": 0.182137428
             },
             {
-              "latency": 0.186563425
+              "latency": 0.193781775
             },
             {
-              "latency": 0.177830145
+              "latency": 0.172662395
             },
             {
-              "latency": 0.18497788
+              "latency": 0.181634671
             },
             {
-              "latency": 0.185370396
+              "latency": 0.194044304
             },
             {
-              "latency": 0.192099121
+              "latency": 0.186855084
             },
             {
-              "latency": 0.17788344
+              "latency": 0.179433531
             },
             {
-              "latency": 0.183990947
+              "latency": 0.181049535
             },
             {
-              "latency": 0.185198887
+              "latency": 0.1856744
             },
             {
-              "latency": 0.194211255
+              "latency": 0.189222782
             },
             {
-              "latency": 0.184273608
+              "latency": 0.175861652
             },
             {
-              "latency": 0.17851811
+              "latency": 0.191689304
             },
             {
-              "latency": 0.18757511
+              "latency": 0.18812646
             },
             {
-              "latency": 0.185575259
+              "latency": 0.191178252
             },
             {
-              "latency": 0.194677729
+              "latency": 0.190583972
             },
             {
-              "latency": 0.174913222
+              "latency": 0.178512175
             },
             {
-              "latency": 0.176643735
+              "latency": 0.184659856
             },
             {
-              "latency": 0.174662701
+              "latency": 0.178716709
             },
             {
-              "latency": 0.172139263
+              "latency": 0.180439508
             },
             {
-              "latency": 0.183176013
+              "latency": 0.18560001
             },
             {
-              "latency": 0.183928061
+              "latency": 0.187271667
             },
             {
-              "latency": 0.175202161
+              "latency": 0.182626845
             },
             {
-              "latency": 0.19356246
+              "latency": 0.193704512
             },
             {
-              "latency": 0.186878093
+              "latency": 0.194319702
             },
             {
-              "latency": 0.185019391
+              "latency": 0.192920897
             },
             {
-              "latency": 0.182746035
+              "latency": 0.194231974
             },
             {
-              "latency": 0.19382577
+              "latency": 0.174012121
             },
             {
-              "latency": 0.183191763
+              "latency": 0.191511569
             },
             {
-              "latency": 0.181026634
+              "latency": 0.185713405
             },
             {
-              "latency": 0.183070049
+              "latency": 0.185075832
             },
             {
-              "latency": 0.186617931
+              "latency": 0.195798471
             },
             {
-              "latency": 0.185147806
+              "latency": 0.174768264
             },
             {
-              "latency": 0.185891221
+              "latency": 0.190303276
             },
             {
-              "latency": 0.175663807
+              "latency": 0.184872402
             },
             {
-              "latency": 0.176124282
+              "latency": 0.185001426
             },
             {
-              "latency": 0.176914379
+              "latency": 0.189920774
             },
             {
-              "latency": 0.184654302
+              "latency": 0.185214084
             },
             {
-              "latency": 0.188789387
+              "latency": 0.184582448
             },
             {
-              "latency": 0.189949195
+              "latency": 0.187735052
             },
             {
-              "latency": 0.181471889
+              "latency": 0.188610502
             },
             {
-              "latency": 0.186116293
+              "latency": 0.180589916
             },
             {
-              "latency": 0.183813082
+              "latency": 0.19192717
             },
             {
-              "latency": 0.185709206
+              "latency": 0.19602933
             },
             {
-              "latency": 0.174797877
+              "latency": 0.193350282
             },
             {
-              "latency": 0.191817516
+              "latency": 0.181196561
             },
             {
-              "latency": 0.196203407
+              "latency": 0.174655644
             },
             {
-              "latency": 0.174425295
+              "latency": 0.191128316
             },
             {
-              "latency": 0.174502529
+              "latency": 0.183366416
             },
             {
-              "latency": 0.182795335
+              "latency": 0.190008769
             },
             {
-              "latency": 0.184983073
+              "latency": 0.185273161
             },
             {
-              "latency": 0.190506638
+              "latency": 0.191561015
             },
             {
-              "latency": 0.183410839
+              "latency": 0.185720607
             },
             {
-              "latency": 0.18303843
+              "latency": 0.189580764
             },
             {
-              "latency": 0.174313964
+              "latency": 0.18279041
             },
             {
-              "latency": 0.174528647
+              "latency": 0.195449628
             },
             {
-              "latency": 0.184811804
+              "latency": 0.189558663
             },
             {
-              "latency": 0.174623483
+              "latency": 0.189122374
             },
             {
-              "latency": 0.183527603
+              "latency": 0.184844807
             },
             {
-              "latency": 0.19020418
+              "latency": 0.181579248
             },
             {
-              "latency": 0.185426598
+              "latency": 0.188462207
             },
             {
-              "latency": 0.174468863
+              "latency": 0.192760418
             },
             {
-              "latency": 0.177857082
+              "latency": 0.18606756
             }
           ],
           "implementation": "https",
@@ -2757,304 +2757,304 @@
         {
           "result": [
             {
-              "latency": 0.366394821
+              "latency": 0.361175268
             },
             {
-              "latency": 0.387611951
+              "latency": 0.30275689
             },
             {
-              "latency": 0.371353374
+              "latency": 0.308378693
             },
             {
-              "latency": 0.294033392
+              "latency": 0.367169458
             },
             {
-              "latency": 0.301716059
+              "latency": 0.311008599
             },
             {
-              "latency": 0.369744569
+              "latency": 0.355918851
             },
             {
-              "latency": 0.386171062
+              "latency": 0.308726832
             },
             {
-              "latency": 0.372204325
+              "latency": 0.328630544
             },
             {
-              "latency": 0.350970831
+              "latency": 0.370112243
             },
             {
-              "latency": 0.311631975
+              "latency": 0.326939344
             },
             {
-              "latency": 0.353771466
+              "latency": 0.318540244
             },
             {
-              "latency": 0.371337463
+              "latency": 0.300511465
             },
             {
-              "latency": 0.357957946
+              "latency": 0.310771298
             },
             {
-              "latency": 0.314417353
+              "latency": 0.314146345
             },
             {
-              "latency": 0.370954311
+              "latency": 0.304800098
             },
             {
-              "latency": 0.310411189
+              "latency": 0.307291346
             },
             {
-              "latency": 0.309872594
+              "latency": 0.31031901
             },
             {
-              "latency": 0.325667096
+              "latency": 0.304484812
             },
             {
-              "latency": 0.288466449
+              "latency": 0.354304786
             },
             {
-              "latency": 0.313891734
+              "latency": 0.311014654
             },
             {
-              "latency": 0.38272721
+              "latency": 0.380720874
             },
             {
-              "latency": 0.307870739
+              "latency": 0.368915304
             },
             {
-              "latency": 0.295299037
+              "latency": 0.31312659
             },
             {
-              "latency": 0.299654024
+              "latency": 0.360102333
             },
             {
-              "latency": 0.305034117
+              "latency": 0.312724539
             },
             {
-              "latency": 0.354312448
+              "latency": 0.325452886
             },
             {
-              "latency": 0.296650462
+              "latency": 0.316612881
             },
             {
-              "latency": 0.361718704
+              "latency": 0.307712598
             },
             {
-              "latency": 0.298192773
+              "latency": 0.308352151
             },
             {
-              "latency": 0.347864952
+              "latency": 0.307286397
             },
             {
-              "latency": 0.29915013
+              "latency": 0.322531939
             },
             {
-              "latency": 0.371259142
+              "latency": 0.314525351
             },
             {
-              "latency": 0.296001248
+              "latency": 0.30996224
             },
             {
-              "latency": 0.372786895
+              "latency": 0.373016242
             },
             {
-              "latency": 0.369373001
+              "latency": 0.315682768
             },
             {
-              "latency": 0.31287797
+              "latency": 0.376301532
             },
             {
-              "latency": 0.357887953
+              "latency": 0.302718924
             },
             {
-              "latency": 0.352372483
+              "latency": 0.367739517
             },
             {
-              "latency": 0.31610252
+              "latency": 0.357284019
             },
             {
-              "latency": 0.389906057
+              "latency": 0.305407461
             },
             {
-              "latency": 0.30990613
+              "latency": 0.296566085
             },
             {
-              "latency": 0.367263008
+              "latency": 0.29871731
             },
             {
-              "latency": 0.296693365
+              "latency": 0.303875109
             },
             {
-              "latency": 0.31353067
+              "latency": 0.316953361
             },
             {
-              "latency": 0.306975499
+              "latency": 0.308843925
             },
             {
-              "latency": 0.308686186
+              "latency": 0.384137947
             },
             {
-              "latency": 0.32557665
+              "latency": 0.325296112
             },
             {
-              "latency": 0.352479282
+              "latency": 0.305455686
             },
             {
-              "latency": 0.324864086
+              "latency": 0.308921425
             },
             {
-              "latency": 0.311296729
+              "latency": 0.360697001
             },
             {
-              "latency": 0.326673819
+              "latency": 0.305522539
             },
             {
-              "latency": 0.298738822
+              "latency": 0.385620665
             },
             {
-              "latency": 0.390830769
+              "latency": 0.296085128
             },
             {
-              "latency": 0.293117198
+              "latency": 0.39240176
             },
             {
-              "latency": 0.306158501
+              "latency": 0.362554436
             },
             {
-              "latency": 0.363512554
+              "latency": 0.370016779
             },
             {
-              "latency": 0.319954949
+              "latency": 0.298452941
             },
             {
-              "latency": 0.372492333
+              "latency": 0.307355417
             },
             {
-              "latency": 0.377911158
+              "latency": 0.321745003
             },
             {
-              "latency": 0.290501889
+              "latency": 0.315082818
             },
             {
-              "latency": 0.369737302
+              "latency": 0.301602783
             },
             {
-              "latency": 0.375520044
+              "latency": 0.37632363
             },
             {
-              "latency": 0.290928224
+              "latency": 0.38017455
             },
             {
-              "latency": 0.352961112
+              "latency": 0.312710169
             },
             {
-              "latency": 0.356098675
+              "latency": 0.385396091
             },
             {
-              "latency": 0.346121833
+              "latency": 0.30292301
             },
             {
-              "latency": 0.38776137
+              "latency": 0.319213105
             },
             {
-              "latency": 0.314931541
+              "latency": 0.312815685
             },
             {
-              "latency": 0.292885748
+              "latency": 0.320632716
             },
             {
-              "latency": 0.313642995
+              "latency": 0.320164322
             },
             {
-              "latency": 0.370930805
+              "latency": 0.307515072
             },
             {
-              "latency": 0.313930352
+              "latency": 0.311269813
             },
             {
-              "latency": 0.291804515
+              "latency": 0.316374179
             },
             {
-              "latency": 0.296185296
+              "latency": 0.374962081
             },
             {
-              "latency": 0.369140251
+              "latency": 0.310939086
             },
             {
-              "latency": 0.302614756
+              "latency": 0.296580305
             },
             {
-              "latency": 0.370268988
+              "latency": 0.308087703
             },
             {
-              "latency": 0.293781354
+              "latency": 0.318682255
             },
             {
-              "latency": 0.295039845
+              "latency": 0.303351387
             },
             {
-              "latency": 0.36033576
+              "latency": 0.375706666
             },
             {
-              "latency": 0.3267874
+              "latency": 0.351676581
             },
             {
-              "latency": 0.313476002
+              "latency": 0.307963658
             },
             {
-              "latency": 0.307320159
+              "latency": 0.387126661
             },
             {
-              "latency": 0.356219345
+              "latency": 0.304663055
             },
             {
-              "latency": 0.322246976
+              "latency": 0.316688567
             },
             {
-              "latency": 0.324314051
+              "latency": 0.376212246
             },
             {
-              "latency": 0.352601698
+              "latency": 0.30517305
             },
             {
-              "latency": 0.315187729
+              "latency": 0.378628976
             },
             {
-              "latency": 0.321798848
+              "latency": 0.320191005
             },
             {
-              "latency": 0.386192457
+              "latency": 0.311069042
             },
             {
-              "latency": 0.31505067
+              "latency": 0.295520318
             },
             {
-              "latency": 0.326851086
+              "latency": 0.305927208
             },
             {
-              "latency": 0.306641439
+              "latency": 0.316546666
             },
             {
-              "latency": 0.30674061
+              "latency": 0.30786616
             },
             {
-              "latency": 0.307683205
+              "latency": 0.297869031
             },
             {
-              "latency": 0.311184282
+              "latency": 0.314197386
             },
             {
-              "latency": 0.300250573
+              "latency": 0.381471379
             },
             {
-              "latency": 0.314549545
+              "latency": 0.315354254
             },
             {
-              "latency": 0.371355188
+              "latency": 0.323793011
             },
             {
-              "latency": 0.304987685
+              "latency": 0.315832317
             }
           ],
           "implementation": "go-libp2p",
@@ -3064,304 +3064,304 @@
         {
           "result": [
             {
-              "latency": 0.185584444
+              "latency": 0.187441926
             },
             {
-              "latency": 0.192142345
+              "latency": 0.187519826
             },
             {
-              "latency": 0.189678046
+              "latency": 0.194523127
             },
             {
-              "latency": 0.197901708
+              "latency": 0.188636796
             },
             {
-              "latency": 0.199985342
+              "latency": 0.187295547
             },
             {
-              "latency": 0.179878464
+              "latency": 0.187616337
             },
             {
-              "latency": 0.19307856
+              "latency": 0.18616792
             },
             {
-              "latency": 0.195359151
+              "latency": 0.195532521
             },
             {
-              "latency": 0.187585013
+              "latency": 0.189303543
             },
             {
-              "latency": 0.174772927
+              "latency": 0.188699086
             },
             {
-              "latency": 0.189701242
+              "latency": 0.19619727
             },
             {
-              "latency": 0.178236844
+              "latency": 0.193585372
             },
             {
-              "latency": 0.17921054
+              "latency": 0.191223504
             },
             {
-              "latency": 0.187631618
+              "latency": 0.192024019
             },
             {
-              "latency": 0.177599791
+              "latency": 0.186947658
             },
             {
-              "latency": 0.189515256
+              "latency": 0.179771654
             },
             {
-              "latency": 0.195703238
+              "latency": 0.191989536
             },
             {
-              "latency": 0.187568978
+              "latency": 0.191372521
             },
             {
-              "latency": 0.180255114
+              "latency": 0.186488854
             },
             {
-              "latency": 0.187177927
+              "latency": 0.195771459
             },
             {
-              "latency": 0.178595852
+              "latency": 0.193486765
             },
             {
-              "latency": 0.19156949
+              "latency": 0.186664918
             },
             {
-              "latency": 0.185651002
+              "latency": 0.189571419
             },
             {
-              "latency": 0.182396131
+              "latency": 0.187541772
             },
             {
-              "latency": 0.196983411
+              "latency": 0.179203986
             },
             {
-              "latency": 0.200381545
+              "latency": 0.180173435
             },
             {
-              "latency": 0.179328509
+              "latency": 0.18615946
             },
             {
-              "latency": 0.190696691
+              "latency": 0.18667274
             },
             {
-              "latency": 0.188884414
+              "latency": 0.19287719
             },
             {
-              "latency": 0.191276901
+              "latency": 0.193519864
             },
             {
-              "latency": 0.176600054
+              "latency": 0.193939548
             },
             {
-              "latency": 0.188847762
+              "latency": 0.187744769
             },
             {
-              "latency": 0.19478753
+              "latency": 0.197202707
             },
             {
-              "latency": 0.187376794
+              "latency": 0.195331149
             },
             {
-              "latency": 0.180855219
+              "latency": 0.181942645
             },
             {
-              "latency": 0.187749503
+              "latency": 0.186778251
             },
             {
-              "latency": 0.198115788
+              "latency": 0.191285484
             },
             {
-              "latency": 0.188147815
+              "latency": 0.194842366
             },
             {
-              "latency": 0.189488753
+              "latency": 0.194688086
             },
             {
-              "latency": 0.196918632
+              "latency": 0.187802968
             },
             {
-              "latency": 0.18613667
+              "latency": 0.188976577
             },
             {
-              "latency": 0.190244438
+              "latency": 0.192033011
             },
             {
-              "latency": 0.1828935
+              "latency": 0.186824432
             },
             {
-              "latency": 0.188165356
+              "latency": 0.19139243
             },
             {
-              "latency": 0.196403784
+              "latency": 0.188556894
             },
             {
-              "latency": 0.186362548
+              "latency": 0.186626756
             },
             {
-              "latency": 0.181013184
+              "latency": 0.187351655
             },
             {
-              "latency": 0.187848279
+              "latency": 0.181379875
             },
             {
-              "latency": 0.190330705
+              "latency": 0.18775405
             },
             {
-              "latency": 0.192655437
+              "latency": 0.187001403
             },
             {
-              "latency": 0.185466752
+              "latency": 0.188667014
             },
             {
-              "latency": 0.187453746
+              "latency": 0.189902037
             },
             {
-              "latency": 0.189241644
+              "latency": 0.181211041
             },
             {
-              "latency": 0.184458095
+              "latency": 0.185219427
             },
             {
-              "latency": 0.198074235
+              "latency": 0.190117437
             },
             {
-              "latency": 0.188886632
+              "latency": 0.178794197
             },
             {
-              "latency": 0.189062871
+              "latency": 0.193689757
             },
             {
-              "latency": 0.185959382
+              "latency": 0.186274477
             },
             {
-              "latency": 0.182665072
+              "latency": 0.195265522
             },
             {
-              "latency": 0.18789722
+              "latency": 0.198959727
             },
             {
-              "latency": 0.185226101
+              "latency": 0.19064636
             },
             {
-              "latency": 0.179206418
+              "latency": 0.196609054
             },
             {
-              "latency": 0.181524025
+              "latency": 0.197537579
             },
             {
-              "latency": 0.189119169
+              "latency": 0.193061468
             },
             {
-              "latency": 0.17533884
+              "latency": 0.175183251
             },
             {
-              "latency": 0.191655528
+              "latency": 0.180245272
             },
             {
-              "latency": 0.196366637
+              "latency": 0.195846626
             },
             {
-              "latency": 0.179639704
+              "latency": 0.175054923
             },
             {
-              "latency": 0.189809911
+              "latency": 0.183034878
             },
             {
-              "latency": 0.191541158
+              "latency": 0.186330551
             },
             {
-              "latency": 0.189797501
+              "latency": 0.187038336
             },
             {
-              "latency": 0.19711685
+              "latency": 0.187643005
             },
             {
-              "latency": 0.190112146
+              "latency": 0.187739424
             },
             {
-              "latency": 0.1861244
+              "latency": 0.183758499
             },
             {
-              "latency": 0.181383469
+              "latency": 0.179761235
             },
             {
-              "latency": 0.187058013
+              "latency": 0.189645963
             },
             {
-              "latency": 0.185899314
+              "latency": 0.183288398
             },
             {
-              "latency": 0.182064501
+              "latency": 0.185467371
             },
             {
-              "latency": 0.188710241
+              "latency": 0.195381213
             },
             {
-              "latency": 0.198499104
+              "latency": 0.189426895
             },
             {
-              "latency": 0.191525811
+              "latency": 0.185906265
             },
             {
-              "latency": 0.178973971
+              "latency": 0.186748227
             },
             {
-              "latency": 0.179846234
+              "latency": 0.188339919
             },
             {
-              "latency": 0.191875235
+              "latency": 0.188589445
             },
             {
-              "latency": 0.187605443
+              "latency": 0.188076936
             },
             {
-              "latency": 0.179340171
+              "latency": 0.187328752
             },
             {
-              "latency": 0.181584293
+              "latency": 0.187582266
             },
             {
-              "latency": 0.191546402
+              "latency": 0.189095235
             },
             {
-              "latency": 0.188227191
+              "latency": 0.193144269
             },
             {
-              "latency": 0.199884317
+              "latency": 0.183220856
             },
             {
-              "latency": 0.187518905
+              "latency": 0.185579554
             },
             {
-              "latency": 0.183989015
+              "latency": 0.196126716
             },
             {
-              "latency": 0.196282806
+              "latency": 0.18693908
             },
             {
-              "latency": 0.180160436
+              "latency": 0.179407387
             },
             {
-              "latency": 0.176645402
+              "latency": 0.184532938
             },
             {
-              "latency": 0.191052372
+              "latency": 0.192201946
             },
             {
-              "latency": 0.189009291
+              "latency": 0.194854126
             },
             {
-              "latency": 0.185422907
+              "latency": 0.19805576
             },
             {
-              "latency": 0.194180649
+              "latency": 0.192467695
             },
             {
-              "latency": 0.198620205
+              "latency": 0.187013304
             }
           ],
           "implementation": "go-libp2p",
@@ -3371,304 +3371,304 @@
         {
           "result": [
             {
-              "latency": 0.388716908
+              "latency": 0.309072689
             },
             {
-              "latency": 0.311976322
+              "latency": 0.318168175
             },
             {
-              "latency": 0.295012859
+              "latency": 0.304624288
             },
             {
-              "latency": 0.311264287
+              "latency": 0.307521111
             },
             {
-              "latency": 0.293171422
+              "latency": 0.305563561
             },
             {
-              "latency": 0.297732365
+              "latency": 0.322874446
             },
             {
-              "latency": 0.309995881
+              "latency": 0.31090352
             },
             {
-              "latency": 0.371882056
+              "latency": 0.310687574
             },
             {
-              "latency": 0.299159243
+              "latency": 0.370563082
             },
             {
-              "latency": 0.350350559
+              "latency": 0.322631255
             },
             {
-              "latency": 0.356106672
+              "latency": 0.317373569
             },
             {
-              "latency": 0.376118898
+              "latency": 0.287180588
             },
             {
-              "latency": 0.357399379
+              "latency": 0.318415455
             },
             {
-              "latency": 0.288875967
+              "latency": 0.379779538
             },
             {
-              "latency": 0.30245001
+              "latency": 0.376509042
             },
             {
-              "latency": 0.299996053
+              "latency": 0.319863867
             },
             {
-              "latency": 0.367568741
+              "latency": 0.316111866
             },
             {
-              "latency": 0.315870204
+              "latency": 0.404091316
             },
             {
-              "latency": 0.289100654
+              "latency": 0.308407764
             },
             {
-              "latency": 0.305489038
+              "latency": 0.31095061
             },
             {
-              "latency": 0.374918807
+              "latency": 0.307131318
             },
             {
-              "latency": 0.349261432
+              "latency": 0.359516033
             },
             {
-              "latency": 0.301565056
+              "latency": 0.296082618
             },
             {
-              "latency": 0.314495446
+              "latency": 0.316308482
             },
             {
-              "latency": 0.29481242
+              "latency": 0.36403645
             },
             {
-              "latency": 0.307587028
+              "latency": 0.311093597
             },
             {
-              "latency": 0.297434774
+              "latency": 0.367762055
             },
             {
-              "latency": 0.296040536
+              "latency": 0.394056294
             },
             {
-              "latency": 0.327968555
+              "latency": 0.376632485
             },
             {
-              "latency": 0.353838056
+              "latency": 0.312395596
             },
             {
-              "latency": 0.32851158
+              "latency": 0.385554358
             },
             {
-              "latency": 0.310443715
+              "latency": 0.314945643
             },
             {
-              "latency": 0.350260886
+              "latency": 0.371723816
             },
             {
-              "latency": 0.305339707
+              "latency": 0.3197937
             },
             {
-              "latency": 0.328458771
+              "latency": 0.319095304
             },
             {
-              "latency": 0.294923963
+              "latency": 0.30718548
             },
             {
-              "latency": 0.290231797
+              "latency": 0.310700662
             },
             {
-              "latency": 0.349975997
+              "latency": 0.388759514
             },
             {
-              "latency": 0.377875856
+              "latency": 0.318451931
             },
             {
-              "latency": 0.36834961
+              "latency": 0.292938895
             },
             {
-              "latency": 0.389064343
+              "latency": 0.305128687
             },
             {
-              "latency": 0.296606706
+              "latency": 0.289186272
             },
             {
-              "latency": 0.392728472
+              "latency": 0.323047358
             },
             {
-              "latency": 0.310881592
+              "latency": 0.324731199
             },
             {
-              "latency": 0.304912382
+              "latency": 0.312795852
             },
             {
-              "latency": 0.369597951
+              "latency": 0.302302707
             },
             {
-              "latency": 0.310416262
+              "latency": 0.368018246
             },
             {
-              "latency": 0.310442246
+              "latency": 0.317737999
             },
             {
-              "latency": 0.375221097
+              "latency": 0.319690914
             },
             {
-              "latency": 0.312601993
+              "latency": 0.323475302
             },
             {
-              "latency": 0.372186989
+              "latency": 0.318348864
             },
             {
-              "latency": 0.294630556
+              "latency": 0.299457498
             },
             {
-              "latency": 0.306746346
+              "latency": 0.306095393
             },
             {
-              "latency": 0.302724497
+              "latency": 0.37206899
             },
             {
-              "latency": 0.313355188
+              "latency": 0.311674166
             },
             {
-              "latency": 0.304000202
+              "latency": 0.289112292
             },
             {
-              "latency": 0.298867857
+              "latency": 0.313807919
             },
             {
-              "latency": 0.37259542
+              "latency": 0.313827453
             },
             {
-              "latency": 0.37454866
+              "latency": 0.329102501
             },
             {
-              "latency": 0.388887694
+              "latency": 0.312134606
             },
             {
-              "latency": 0.308863152
+              "latency": 0.303494547
             },
             {
-              "latency": 0.30808999
+              "latency": 0.309971535
             },
             {
-              "latency": 0.2955768
+              "latency": 0.378485704
             },
             {
-              "latency": 0.376037316
+              "latency": 0.321655824
             },
             {
-              "latency": 0.295336835
+              "latency": 0.30797697
             },
             {
-              "latency": 0.296472281
+              "latency": 0.390553848
             },
             {
-              "latency": 0.290229607
+              "latency": 0.376435431
             },
             {
-              "latency": 0.36847906
+              "latency": 0.304978538
             },
             {
-              "latency": 0.368997408
+              "latency": 0.301892458
             },
             {
-              "latency": 0.324761174
+              "latency": 0.384375216
             },
             {
-              "latency": 0.316987721
+              "latency": 0.365216576
             },
             {
-              "latency": 0.349679792
+              "latency": 0.37683604
             },
             {
-              "latency": 0.313916803
+              "latency": 0.369576997
             },
             {
-              "latency": 0.322774479
+              "latency": 0.312533651
             },
             {
-              "latency": 0.359698016
+              "latency": 0.308957754
             },
             {
-              "latency": 0.368259648
+              "latency": 0.372783063
             },
             {
-              "latency": 0.326613476
+              "latency": 0.37415111
             },
             {
-              "latency": 0.377099258
+              "latency": 0.385521639
             },
             {
-              "latency": 0.388869541
+              "latency": 0.369218748
             },
             {
-              "latency": 0.304925091
+              "latency": 0.37531192
             },
             {
-              "latency": 0.297113944
+              "latency": 0.304338805
             },
             {
-              "latency": 0.3078765
+              "latency": 0.32215669
             },
             {
-              "latency": 0.300388033
+              "latency": 0.312822132
             },
             {
-              "latency": 0.312779895
+              "latency": 0.30671321
             },
             {
-              "latency": 0.311863505
+              "latency": 0.362460625
             },
             {
-              "latency": 0.360930243
+              "latency": 0.31416601
             },
             {
-              "latency": 0.290593456
+              "latency": 0.300409678
             },
             {
-              "latency": 0.359176138
+              "latency": 0.296452198
             },
             {
-              "latency": 0.356287791
+              "latency": 0.32282151
             },
             {
-              "latency": 0.311062323
+              "latency": 0.379581942
             },
             {
-              "latency": 0.325016693
+              "latency": 0.366892289
             },
             {
-              "latency": 0.309451052
+              "latency": 0.382105521
             },
             {
-              "latency": 0.359115789
+              "latency": 0.379978514
             },
             {
-              "latency": 0.309696908
+              "latency": 0.379192505
             },
             {
-              "latency": 0.29698105
+              "latency": 0.392271604
             },
             {
-              "latency": 0.292259289
+              "latency": 0.319351348
             },
             {
-              "latency": 0.310364166
+              "latency": 0.317076947
             },
             {
-              "latency": 0.310784003
+              "latency": 0.313510644
             },
             {
-              "latency": 0.322962386
+              "latency": 0.37590546
             },
             {
-              "latency": 0.297861501
+              "latency": 0.378761533
             }
           ],
           "implementation": "go-libp2p",
@@ -3678,304 +3678,304 @@
         {
           "result": [
             {
-              "latency": 0.181393239
+              "latency": 0.1867361
             },
             {
-              "latency": 0.189830269
+              "latency": 0.190153712
             },
             {
-              "latency": 0.183977346
+              "latency": 0.182258067
             },
             {
-              "latency": 0.189322975
+              "latency": 0.193481088
             },
             {
-              "latency": 0.189869514
+              "latency": 0.182297895
             },
             {
-              "latency": 0.179148911
+              "latency": 0.186475253
             },
             {
-              "latency": 0.198522697
+              "latency": 0.185550444
             },
             {
-              "latency": 0.189069483
+              "latency": 0.185361432
             },
             {
-              "latency": 0.198527793
+              "latency": 0.189504418
             },
             {
-              "latency": 0.191336846
+              "latency": 0.194361042
             },
             {
-              "latency": 0.17915749
+              "latency": 0.187504795
             },
             {
-              "latency": 0.187952884
+              "latency": 0.185536181
             },
             {
-              "latency": 0.199137224
+              "latency": 0.190820973
             },
             {
-              "latency": 0.177936666
+              "latency": 0.187160913
             },
             {
-              "latency": 0.199587772
+              "latency": 0.186384962
             },
             {
-              "latency": 0.197871651
+              "latency": 0.191407403
             },
             {
-              "latency": 0.189928476
+              "latency": 0.200277032
             },
             {
-              "latency": 0.196500152
+              "latency": 0.192498428
             },
             {
-              "latency": 0.19813696
+              "latency": 0.19337702
             },
             {
-              "latency": 0.191696636
+              "latency": 0.193518513
             },
             {
-              "latency": 0.187823789
+              "latency": 0.186369648
             },
             {
-              "latency": 0.178328125
+              "latency": 0.187738661
             },
             {
-              "latency": 0.190770825
+              "latency": 0.195823516
             },
             {
-              "latency": 0.18754548
+              "latency": 0.19114493
             },
             {
-              "latency": 0.197791096
+              "latency": 0.192637577
             },
             {
-              "latency": 0.185674801
+              "latency": 0.182547405
             },
             {
-              "latency": 0.191758718
+              "latency": 0.195843713
             },
             {
-              "latency": 0.17720567
+              "latency": 0.181915911
             },
             {
-              "latency": 0.190020489
+              "latency": 0.186468204
             },
             {
-              "latency": 0.196409726
+              "latency": 0.195439877
             },
             {
-              "latency": 0.198271767
+              "latency": 0.193666488
             },
             {
-              "latency": 0.187203767
+              "latency": 0.182720092
             },
             {
-              "latency": 0.197826351
+              "latency": 0.195536301
             },
             {
-              "latency": 0.183136827
+              "latency": 0.185027363
             },
             {
-              "latency": 0.196589399
+              "latency": 0.18624842
             },
             {
-              "latency": 0.182491592
+              "latency": 0.198401959
             },
             {
-              "latency": 0.186049497
+              "latency": 0.196669168
             },
             {
-              "latency": 0.191086681
+              "latency": 0.194487057
             },
             {
-              "latency": 0.192650493
+              "latency": 0.194322495
             },
             {
-              "latency": 0.1859269
+              "latency": 0.182821091
             },
             {
-              "latency": 0.18766659
+              "latency": 0.185630383
             },
             {
-              "latency": 0.187875455
+              "latency": 0.200197485
             },
             {
-              "latency": 0.196902371
+              "latency": 0.191200188
             },
             {
-              "latency": 0.187843038
+              "latency": 0.17998716
             },
             {
-              "latency": 0.187180974
+              "latency": 0.195832796
             },
             {
-              "latency": 0.185285009
+              "latency": 0.19844318
             },
             {
-              "latency": 0.182499945
+              "latency": 0.185293982
             },
             {
-              "latency": 0.189617069
+              "latency": 0.197682954
             },
             {
-              "latency": 0.1872908
+              "latency": 0.190124741
             },
             {
-              "latency": 0.189850787
+              "latency": 0.19560742
             },
             {
-              "latency": 0.188241906
+              "latency": 0.188218398
             },
             {
-              "latency": 0.177578867
+              "latency": 0.18838037
             },
             {
-              "latency": 0.178164156
+              "latency": 0.185657297
             },
             {
-              "latency": 0.183563975
+              "latency": 0.198957868
             },
             {
-              "latency": 0.194595009
+              "latency": 0.19163254
             },
             {
-              "latency": 0.178380172
+              "latency": 0.191866536
             },
             {
-              "latency": 0.185636645
+              "latency": 0.197497888
             },
             {
-              "latency": 0.174739834
+              "latency": 0.186902633
             },
             {
-              "latency": 0.19025583
+              "latency": 0.182904442
             },
             {
-              "latency": 0.187543949
+              "latency": 0.186932653
             },
             {
-              "latency": 0.186114887
+              "latency": 0.192144865
             },
             {
-              "latency": 0.198653927
+              "latency": 0.181066201
             },
             {
-              "latency": 0.187428402
+              "latency": 0.189496607
             },
             {
-              "latency": 0.184592162
+              "latency": 0.187153405
             },
             {
-              "latency": 0.188216222
+              "latency": 0.178815064
             },
             {
-              "latency": 0.197296705
+              "latency": 0.192378832
             },
             {
-              "latency": 0.196493722
+              "latency": 0.188256957
             },
             {
-              "latency": 0.197287778
+              "latency": 0.186715938
             },
             {
-              "latency": 0.197974929
+              "latency": 0.179875519
             },
             {
-              "latency": 0.187271904
+              "latency": 0.189579122
             },
             {
-              "latency": 0.180170115
+              "latency": 0.193858299
             },
             {
-              "latency": 0.187954876
+              "latency": 0.185741056
             },
             {
-              "latency": 0.179265927
+              "latency": 0.178837601
             },
             {
-              "latency": 0.189219086
+              "latency": 0.196788114
             },
             {
-              "latency": 0.186811252
+              "latency": 0.189336894
             },
             {
-              "latency": 0.197309339
+              "latency": 0.197320509
             },
             {
-              "latency": 0.199580149
+              "latency": 0.174864471
             },
             {
-              "latency": 0.195982433
+              "latency": 0.194226924
             },
             {
-              "latency": 0.183780449
+              "latency": 0.183450965
             },
             {
-              "latency": 0.197635025
+              "latency": 0.190592953
             },
             {
-              "latency": 0.192759805
+              "latency": 0.181039599
             },
             {
-              "latency": 0.17871328
+              "latency": 0.199946949
             },
             {
-              "latency": 0.191052675
+              "latency": 0.191023624
             },
             {
-              "latency": 0.185404005
+              "latency": 0.186301499
             },
             {
-              "latency": 0.196131085
+              "latency": 0.188890727
             },
             {
-              "latency": 0.183897184
+              "latency": 0.191870335
             },
             {
-              "latency": 0.187285455
+              "latency": 0.195288797
             },
             {
-              "latency": 0.196932511
+              "latency": 0.185763467
             },
             {
-              "latency": 0.188573655
+              "latency": 0.17946677
             },
             {
-              "latency": 0.189245182
+              "latency": 0.181670015
             },
             {
-              "latency": 0.182320831
+              "latency": 0.188398112
             },
             {
-              "latency": 0.19637268
+              "latency": 0.192125456
             },
             {
-              "latency": 0.191310468
+              "latency": 0.196169976
             },
             {
-              "latency": 0.189524269
+              "latency": 0.183919601
             },
             {
-              "latency": 0.18579568
+              "latency": 0.189079999
             },
             {
-              "latency": 0.183862134
+              "latency": 0.192747121
             },
             {
-              "latency": 0.189238185
+              "latency": 0.192453605
             },
             {
-              "latency": 0.188838808
+              "latency": 0.186734274
             },
             {
-              "latency": 0.179388781
+              "latency": 0.194210217
             },
             {
-              "latency": 0.182789895
+              "latency": 0.179194811
             }
           ],
           "implementation": "go-libp2p",
@@ -3985,304 +3985,304 @@
         {
           "result": [
             {
-              "latency": 0.378178718
+              "latency": 0.357594952
             },
             {
-              "latency": 0.370659182
+              "latency": 0.291781738
             },
             {
-              "latency": 0.323738446
+              "latency": 0.321685464
             },
             {
-              "latency": 0.366890812
+              "latency": 0.317243951
             },
             {
-              "latency": 0.346200467
+              "latency": 0.361208899
             },
             {
-              "latency": 0.308560472
+              "latency": 0.306440258
             },
             {
-              "latency": 0.377446794
+              "latency": 0.32007977
             },
             {
-              "latency": 0.297177828
+              "latency": 0.324097897
             },
             {
-              "latency": 0.370914206
+              "latency": 0.303882428
             },
             {
-              "latency": 0.308725696
+              "latency": 0.367345149
             },
             {
-              "latency": 0.295878306
+              "latency": 0.318353043
             },
             {
-              "latency": 0.369465101
+              "latency": 0.372087784
             },
             {
-              "latency": 0.311574154
+              "latency": 0.300387264
             },
             {
-              "latency": 0.301004485
+              "latency": 0.350097173
             },
             {
-              "latency": 0.320717341
+              "latency": 0.309794582
             },
             {
-              "latency": 0.327181179
+              "latency": 0.310683393
             },
             {
-              "latency": 0.352069284
+              "latency": 0.307342644
             },
             {
-              "latency": 0.327338383
+              "latency": 0.319632116
             },
             {
-              "latency": 0.310728786
+              "latency": 0.305418588
             },
             {
-              "latency": 0.30969451
+              "latency": 0.368631633
             },
             {
-              "latency": 0.30858605
+              "latency": 0.322799153
             },
             {
-              "latency": 0.308360131
+              "latency": 0.306653151
             },
             {
-              "latency": 0.315029856
+              "latency": 0.321725966
             },
             {
-              "latency": 0.305441243
+              "latency": 0.322081597
             },
             {
-              "latency": 0.313830026
+              "latency": 0.302419388
             },
             {
-              "latency": 0.295654583
+              "latency": 0.302098864
             },
             {
-              "latency": 0.309588659
+              "latency": 0.386883962
             },
             {
-              "latency": 0.292401025
+              "latency": 0.303306016
             },
             {
-              "latency": 0.371777713
+              "latency": 0.310818506
             },
             {
-              "latency": 0.35681032
+              "latency": 0.377746872
             },
             {
-              "latency": 0.311597806
+              "latency": 0.311379396
             },
             {
-              "latency": 0.356817015
+              "latency": 0.314993353
             },
             {
-              "latency": 0.3064066
+              "latency": 0.387252403
             },
             {
-              "latency": 0.356874027
+              "latency": 0.301338534
             },
             {
-              "latency": 0.318877616
+              "latency": 0.305435236
             },
             {
-              "latency": 0.322982082
+              "latency": 0.326784157
             },
             {
-              "latency": 0.288934309
+              "latency": 0.371309738
             },
             {
-              "latency": 0.298925899
+              "latency": 0.297016941
             },
             {
-              "latency": 0.312552909
+              "latency": 0.306432795
             },
             {
-              "latency": 0.303791909
+              "latency": 0.304999845
             },
             {
-              "latency": 0.309577781
+              "latency": 0.306436335
             },
             {
-              "latency": 0.295524329
+              "latency": 0.284873063
             },
             {
-              "latency": 0.320623719
+              "latency": 0.366089053
             },
             {
-              "latency": 0.349669491
+              "latency": 0.302260364
             },
             {
-              "latency": 0.304957521
+              "latency": 0.348582388
             },
             {
-              "latency": 0.312802395
+              "latency": 0.291819145
             },
             {
-              "latency": 0.297844224
+              "latency": 0.371600076
             },
             {
-              "latency": 0.309951671
+              "latency": 0.323627274
             },
             {
-              "latency": 0.326493442
+              "latency": 0.307718964
             },
             {
-              "latency": 0.310397531
+              "latency": 0.297197636
             },
             {
-              "latency": 0.309389275
+              "latency": 0.362124734
             },
             {
-              "latency": 0.291272692
+              "latency": 0.319022554
             },
             {
-              "latency": 0.358939859
+              "latency": 0.357229598
             },
             {
-              "latency": 0.388702847
+              "latency": 0.388282253
             },
             {
-              "latency": 0.292769768
+              "latency": 0.318673521
             },
             {
-              "latency": 0.349653259
+              "latency": 0.32713238
             },
             {
-              "latency": 0.295751101
+              "latency": 0.315780772
             },
             {
-              "latency": 0.294437954
+              "latency": 0.365680066
             },
             {
-              "latency": 0.312282126
+              "latency": 0.370515193
             },
             {
-              "latency": 0.308782203
+              "latency": 0.35332436
             },
             {
-              "latency": 0.291272075
+              "latency": 0.306907926
             },
             {
-              "latency": 0.297855357
+              "latency": 0.32319414
             },
             {
-              "latency": 0.362497812
+              "latency": 0.36079156
             },
             {
-              "latency": 0.306155602
+              "latency": 0.365805526
             },
             {
-              "latency": 0.351089443
+              "latency": 0.319552784
             },
             {
-              "latency": 0.297343871
+              "latency": 0.383328978
             },
             {
-              "latency": 0.303563522
+              "latency": 0.316867233
             },
             {
-              "latency": 0.314314394
+              "latency": 0.365319624
             },
             {
-              "latency": 0.30587725
+              "latency": 0.307977111
             },
             {
-              "latency": 0.312257428
+              "latency": 0.377433849
             },
             {
-              "latency": 0.308610413
+              "latency": 0.315091042
             },
             {
-              "latency": 0.357053872
+              "latency": 0.309205889
             },
             {
-              "latency": 0.323195438
+              "latency": 0.305468272
             },
             {
-              "latency": 0.386967237
+              "latency": 0.355506605
             },
             {
-              "latency": 0.311958721
+              "latency": 0.371627248
             },
             {
-              "latency": 0.383438881
+              "latency": 0.320874942
             },
             {
-              "latency": 0.323977389
+              "latency": 0.31739913
             },
             {
-              "latency": 0.320664323
+              "latency": 0.308500274
             },
             {
-              "latency": 0.303601524
+              "latency": 0.370943253
             },
             {
-              "latency": 0.32187886
+              "latency": 0.316919536
             },
             {
-              "latency": 0.352823467
+              "latency": 0.324417982
             },
             {
-              "latency": 0.305808624
+              "latency": 0.320444528
             },
             {
-              "latency": 0.368617471
+              "latency": 0.318700443
             },
             {
-              "latency": 0.375240767
+              "latency": 0.371720315
             },
             {
-              "latency": 0.295814951
+              "latency": 0.307048465
             },
             {
-              "latency": 0.353050794
+              "latency": 0.311665669
             },
             {
-              "latency": 0.324573155
+              "latency": 0.307450982
             },
             {
-              "latency": 0.30744308
+              "latency": 0.306206241
             },
             {
-              "latency": 0.39151899
+              "latency": 0.358668605
             },
             {
-              "latency": 0.313051482
+              "latency": 0.353735759
             },
             {
-              "latency": 0.349272926
+              "latency": 0.300398957
             },
             {
-              "latency": 0.294990752
+              "latency": 0.309843183
             },
             {
-              "latency": 0.309929823
+              "latency": 0.312107538
             },
             {
-              "latency": 0.325647379
+              "latency": 0.317694276
             },
             {
-              "latency": 0.303592782
+              "latency": 0.310318429
             },
             {
-              "latency": 0.310759415
+              "latency": 0.371181488
             },
             {
-              "latency": 0.321116937
+              "latency": 0.312660156
             },
             {
-              "latency": 0.31185131
+              "latency": 0.317124679
             },
             {
-              "latency": 0.29480032
+              "latency": 0.314004683
             },
             {
-              "latency": 0.368900279
+              "latency": 0.371184118
             }
           ],
           "implementation": "go-libp2p",
@@ -4292,304 +4292,304 @@
         {
           "result": [
             {
-              "latency": 0.182098133
+              "latency": 0.184784819
             },
             {
-              "latency": 0.180417261
+              "latency": 0.188181003
             },
             {
-              "latency": 0.188042582
+              "latency": 0.188074649
             },
             {
-              "latency": 0.186121251
+              "latency": 0.193739718
             },
             {
-              "latency": 0.182925206
+              "latency": 0.192608196
             },
             {
-              "latency": 0.17901374
+              "latency": 0.184191057
             },
             {
-              "latency": 0.177233034
+              "latency": 0.193444848
             },
             {
-              "latency": 0.187726335
+              "latency": 0.188803624
             },
             {
-              "latency": 0.190378265
+              "latency": 0.197717965
             },
             {
-              "latency": 0.176353779
+              "latency": 0.186332626
             },
             {
-              "latency": 0.188797498
+              "latency": 0.193857622
             },
             {
-              "latency": 0.176623031
+              "latency": 0.189474125
             },
             {
-              "latency": 0.196521097
+              "latency": 0.184924786
             },
             {
-              "latency": 0.177769546
+              "latency": 0.189075056
             },
             {
-              "latency": 0.186002854
+              "latency": 0.195276115
             },
             {
-              "latency": 0.189711211
+              "latency": 0.189382887
             },
             {
-              "latency": 0.177857604
+              "latency": 0.184836815
             },
             {
-              "latency": 0.189064002
+              "latency": 0.190504217
             },
             {
-              "latency": 0.185780625
+              "latency": 0.182271961
             },
             {
-              "latency": 0.194649083
+              "latency": 0.193364684
             },
             {
-              "latency": 0.17694103
+              "latency": 0.186283028
             },
             {
-              "latency": 0.179678011
+              "latency": 0.187001549
             },
             {
-              "latency": 0.186195775
+              "latency": 0.193400721
             },
             {
-              "latency": 0.182881707
+              "latency": 0.190175584
             },
             {
-              "latency": 0.175421438
+              "latency": 0.189883666
             },
             {
-              "latency": 0.187038598
+              "latency": 0.193233214
             },
             {
-              "latency": 0.186746847
+              "latency": 0.17445127
             },
             {
-              "latency": 0.19606362
+              "latency": 0.193349832
             },
             {
-              "latency": 0.190820407
+              "latency": 0.193776559
             },
             {
-              "latency": 0.194684352
+              "latency": 0.187484886
             },
             {
-              "latency": 0.188052584
+              "latency": 0.189092619
             },
             {
-              "latency": 0.176987959
+              "latency": 0.195496051
             },
             {
-              "latency": 0.179397447
+              "latency": 0.190295353
             },
             {
-              "latency": 0.188219327
+              "latency": 0.195191725
             },
             {
-              "latency": 0.187590497
+              "latency": 0.189271977
             },
             {
-              "latency": 0.178682972
+              "latency": 0.197552994
             },
             {
-              "latency": 0.190507982
+              "latency": 0.175447684
             },
             {
-              "latency": 0.181254683
+              "latency": 0.192702092
             },
             {
-              "latency": 0.18826517
+              "latency": 0.194345183
             },
             {
-              "latency": 0.191243787
+              "latency": 0.187562806
             },
             {
-              "latency": 0.182333662
+              "latency": 0.184493141
             },
             {
-              "latency": 0.190257174
+              "latency": 0.192578828
             },
             {
-              "latency": 0.181014159
+              "latency": 0.190393759
             },
             {
-              "latency": 0.179635653
+              "latency": 0.18595881
             },
             {
-              "latency": 0.189781743
+              "latency": 0.187733854
             },
             {
-              "latency": 0.197522157
+              "latency": 0.195715713
             },
             {
-              "latency": 0.183464132
+              "latency": 0.177167162
             },
             {
-              "latency": 0.177357477
+              "latency": 0.185887741
             },
             {
-              "latency": 0.196538688
+              "latency": 0.191911289
             },
             {
-              "latency": 0.178246283
+              "latency": 0.187433992
             },
             {
-              "latency": 0.186049883
+              "latency": 0.187112579
             },
             {
-              "latency": 0.188905131
+              "latency": 0.185305075
             },
             {
-              "latency": 0.198079076
+              "latency": 0.195277148
             },
             {
-              "latency": 0.177309423
+              "latency": 0.181028571
             },
             {
-              "latency": 0.191155166
+              "latency": 0.185835632
             },
             {
-              "latency": 0.188917264
+              "latency": 0.185120904
             },
             {
-              "latency": 0.185955515
+              "latency": 0.188649626
             },
             {
-              "latency": 0.196631202
+              "latency": 0.182626849
             },
             {
-              "latency": 0.181085531
+              "latency": 0.189461416
             },
             {
-              "latency": 0.179415741
+              "latency": 0.193938837
             },
             {
-              "latency": 0.176846994
+              "latency": 0.18580676
             },
             {
-              "latency": 0.197549951
+              "latency": 0.194586257
             },
             {
-              "latency": 0.191459134
+              "latency": 0.189347734
             },
             {
-              "latency": 0.184140579
+              "latency": 0.196793367
             },
             {
-              "latency": 0.194355847
+              "latency": 0.186930185
             },
             {
-              "latency": 0.187672673
+              "latency": 0.196209787
             },
             {
-              "latency": 0.19434618
+              "latency": 0.190248446
             },
             {
-              "latency": 0.196547424
+              "latency": 0.185263321
             },
             {
-              "latency": 0.18068377
+              "latency": 0.189314094
             },
             {
-              "latency": 0.18812528
+              "latency": 0.195023408
             },
             {
-              "latency": 0.196238152
+              "latency": 0.196141163
             },
             {
-              "latency": 0.187527132
+              "latency": 0.19395669
             },
             {
-              "latency": 0.195665654
+              "latency": 0.189196091
             },
             {
-              "latency": 0.189370696
+              "latency": 0.194072201
             },
             {
-              "latency": 0.192483144
+              "latency": 0.191245396
             },
             {
-              "latency": 0.19561782
+              "latency": 0.183056738
             },
             {
-              "latency": 0.185894242
+              "latency": 0.191182965
             },
             {
-              "latency": 0.196853094
+              "latency": 0.187593245
             },
             {
-              "latency": 0.189516329
+              "latency": 0.189379136
             },
             {
-              "latency": 0.186023118
+              "latency": 0.191940849
             },
             {
-              "latency": 0.184977528
+              "latency": 0.186880156
             },
             {
-              "latency": 0.180428078
+              "latency": 0.199915922
             },
             {
-              "latency": 0.178871525
+              "latency": 0.183027872
             },
             {
-              "latency": 0.186792847
+              "latency": 0.192547251
             },
             {
-              "latency": 0.188202222
+              "latency": 0.185216271
             },
             {
-              "latency": 0.198026244
+              "latency": 0.185432805
             },
             {
-              "latency": 0.194003714
+              "latency": 0.190760251
             },
             {
-              "latency": 0.189448153
+              "latency": 0.190800449
             },
             {
-              "latency": 0.175430565
+              "latency": 0.186134974
             },
             {
-              "latency": 0.187791761
+              "latency": 0.18548809
             },
             {
-              "latency": 0.188470415
+              "latency": 0.188371132
             },
             {
-              "latency": 0.197923743
+              "latency": 0.187530822
             },
             {
-              "latency": 0.188973595
+              "latency": 0.195767263
             },
             {
-              "latency": 0.18107083
+              "latency": 0.18404208
             },
             {
-              "latency": 0.197050085
+              "latency": 0.193704777
             },
             {
-              "latency": 0.175520411
+              "latency": 0.185406641
             },
             {
-              "latency": 0.189845175
+              "latency": 0.184979712
             },
             {
-              "latency": 0.191142769
+              "latency": 0.195741564
             },
             {
-              "latency": 0.179284237
+              "latency": 0.186051107
             },
             {
-              "latency": 0.179066351
+              "latency": 0.19227316
             }
           ],
           "implementation": "go-libp2p",
@@ -4606,173 +4606,173 @@
   "pings": {
     "unit": "s",
     "results": [
-      0.0574,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0574,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0574,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0574,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573,
-      0.0573
+      0.0615,
+      0.0613,
+      0.0613,
+      0.0616,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0616,
+      0.0613,
+      0.0616,
+      0.061399999999999996,
+      0.061399999999999996,
+      0.0613,
+      0.0613,
+      0.061799999999999994,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.061399999999999996,
+      0.0613,
+      0.061399999999999996,
+      0.061700000000000005,
+      0.0615,
+      0.0613,
+      0.061399999999999996,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.061700000000000005,
+      0.0616,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0616,
+      0.0613,
+      0.061399999999999996,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.061399999999999996,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.061399999999999996,
+      0.0613,
+      0.0613,
+      0.061399999999999996,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613,
+      0.0613
     ]
   },
   "iperf": {
     "unit": "bit/s",
     "results": [
-      2220000000,
+      2029999999.9999998,
       4780000000,
       4780000000,
-      4080000000,
-      3580000000,
-      2670000000,
-      2750000000,
-      2820000000,
-      2880000000,
-      2940000000,
-      2980000000,
-      2850000000,
-      2170000000,
-      2240000000,
-      2290000000,
-      2350000000,
-      2390000000,
-      2430000000,
-      2450000000,
-      2500000000,
-      2500000000,
-      2540000000,
-      2530000000,
-      2570000000,
-      2550000000,
-      2580000000,
-      2570000000,
-      2580000000,
-      2580000000,
-      2570000000,
-      2590000000,
-      2450000000,
-      1870000000,
-      1960000000,
-      2060000000,
-      2130000000,
-      2210000000,
-      2250000000,
-      2330000000,
-      2360000000,
-      2420000000,
-      2430000000,
-      2480000000,
-      2500000000,
-      2520000000,
-      2060000000,
-      1840000000,
-      1900000000,
-      1950000000,
-      1990000000,
-      2020000000,
-      2060000000,
-      2080000000,
-      2109999999.9999998,
-      2109999999.9999998,
-      2140000000.0000002,
-      2130000000,
-      2150000000,
-      2140000000.0000002,
-      2160000000,
-      2490000000,
-      2470000000
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4740000000,
+      4720000000
     ]
   }
 }

--- a/perf/terraform/modules/long_lived/main.tf
+++ b/perf/terraform/modules/long_lived/main.tf
@@ -108,4 +108,13 @@ resource "aws_launch_template" "perf" {
     security_groups = [aws_security_group.restricted_inbound.id]
     delete_on_termination = true
   }
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size           = 100 # New root volume size in GiB
+      volume_type           = "gp2"
+      delete_on_termination = true
+    }
+  }
 }

--- a/perf/terraform/modules/short_lived/main.tf
+++ b/perf/terraform/modules/short_lived/main.tf
@@ -19,7 +19,7 @@ resource "aws_instance" "perf" {
 
   launch_template {
     name = "perf-node"
-    version = "2"
+    version = "3"
   }
 
   key_name = aws_key_pair.perf.key_name


### PR DESCRIPTION
Multiple perf runs have failed due to "no space left on device". See e.g. https://github.com/libp2p/test-plans/actions/runs/5727165977/job/15527780097.

The perf terraform launch template previously did not specify a root volume size. Thus terraform used the default:

```
df -h

Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        4.0M     0  4.0M   0% /dev
tmpfs            63G     0   63G   0% /dev/shm
tmpfs            25G  540K   25G   1% /run
/dev/nvme0n1p1  8.0G  1.9G  6.1G  24% /
tmpfs            63G     0   63G   0% /tmp
tmpfs            13G     0   13G   0% /run/user/1000
```

With this commit the root volume is increased to 100GB:

```
df -h

Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        4.0M     0  4.0M   0% /dev
tmpfs            63G     0   63G   0% /dev/shm
tmpfs            25G  564K   25G   1% /run
/dev/nvme0n1p1  100G  2.6G   98G   3% /
tmpfs            63G  8.0K   63G   1% /tmp
tmpfs            13G     0   13G   0% /run/user/0
tmpfs            13G     0   13G   0% /run/user/1000
```

//CC @galargh in case you have some time to take a quick look.

//CC @thomaseizinger given that we faced this issue on https://github.com/libp2p/test-plans/pull/247.

//CC @maschad since you have seen this issue on your personal AWS account.