### PR TITLE
fix(perf): use `$Latest` launch template

### DIFF
--- a/perf/runner/benchmark-results.json
+++ b/perf/runner/benchmark-results.json
@@ -7,34 +7,34 @@
         {
           "result": [
             {
-              "latency": 1.071285577
+              "latency": 1.028831684
             },
             {
-              "latency": 1.069395315
+              "latency": 1.086669124
             },
             {
-              "latency": 1.042424524
+              "latency": 1.071025996
             },
             {
-              "latency": 1.056611303
+              "latency": 1.095323838
             },
             {
-              "latency": 1.071165158
+              "latency": 1.006762935
             },
             {
-              "latency": 1.04385611
+              "latency": 1.079348034
             },
             {
-              "latency": 1.063371162
+              "latency": 1.082299325
             },
             {
-              "latency": 1.083406849
+              "latency": 1.099030779
             },
             {
-              "latency": 1.099260456
+              "latency": 1.03714172
             },
             {
-              "latency": 1.015545856
+              "latency": 1.076451765
             }
           ],
           "implementation": "quic-go",
@@ -44,34 +44,34 @@
         {
           "result": [
             {
-              "latency": 43.849901028
+              "latency": 46.860277012
             },
             {
-              "latency": 43.842900998
+              "latency": 45.330739118
             },
             {
-              "latency": 45.197651355
+              "latency": 42.748425905
             },
             {
-              "latency": 44.21477204
+              "latency": 44.999543702
             },
             {
-              "latency": 43.655197483
+              "latency": 42.881921821
             },
             {
-              "latency": 44.672155938
+              "latency": 41.976728568
             },
             {
-              "latency": 41.880360527
+              "latency": 44.157906383
             },
             {
-              "latency": 44.525619358
+              "latency": 40.555873137
             },
             {
-              "latency": 43.213599543
+              "latency": 43.765111026
             },
             {
-              "latency": 43.738450351
+              "latency": 42.951670202
             }
           ],
           "implementation": "rust-libp2p",
@@ -81,34 +81,34 @@
         {
           "result": [
             {
-              "latency": 17.930301157
+              "latency": 9.615035272
             },
             {
-              "latency": 19.303762261
+              "latency": 15.064550206
             },
             {
-              "latency": 18.273005145
+              "latency": 14.167703407
             },
             {
-              "latency": 22.866542705
+              "latency": 14.754582365
             },
             {
-              "latency": 10.707955945
+              "latency": 10.193240516
             },
             {
-              "latency": 15.697471398
+              "latency": 8.095532758
             },
             {
-              "latency": 8.201255957
+              "latency": 14.869921246
             },
             {
-              "latency": 17.398968493
+              "latency": 13.721053551
             },
             {
-              "latency": 20.649270846
+              "latency": 12.947267378
             },
             {
-              "latency": 17.879851484
+              "latency": 11.794897402
             }
           ],
           "implementation": "rust-libp2p",
@@ -118,34 +118,34 @@
         {
           "result": [
             {
-              "latency": 42.780782348
+              "latency": 43.989525793
             },
             {
-              "latency": 43.860069886
+              "latency": 42.437325152
             },
             {
-              "latency": 44.970232156
+              "latency": 46.815517546
             },
             {
-              "latency": 43.779607607
+              "latency": 43.735041003
             },
             {
-              "latency": 43.942253083
+              "latency": 42.495245622
             },
             {
-              "latency": 44.602692612
+              "latency": 46.961400957
             },
             {
-              "latency": 46.349489671
+              "latency": 43.319491715
             },
             {
-              "latency": 46.668700571
+              "latency": 42.217155204
             },
             {
-              "latency": 42.399196518
+              "latency": 43.875890258
             },
             {
-              "latency": 44.801937367
+              "latency": 46.175659495
             }
           ],
           "implementation": "rust-libp2p",
@@ -155,34 +155,34 @@
         {
           "result": [
             {
-              "latency": 1.465039631
+              "latency": 1.445680764
             },
             {
-              "latency": 1.469524763
+              "latency": 1.445675769
             },
             {
-              "latency": 1.445585724
+              "latency": 1.463474532
             },
             {
-              "latency": 1.431238773
+              "latency": 1.445989296
             },
             {
-              "latency": 1.527760603
+              "latency": 1.426202987
             },
             {
-              "latency": 1.414356687
+              "latency": 1.471524751
             },
             {
-              "latency": 1.496875298
+              "latency": 1.411513009
             },
             {
-              "latency": 1.532772236
+              "latency": 1.4865466299999999
             },
             {
-              "latency": 1.492001593
+              "latency": 1.443801347
             },
             {
-              "latency": 1.4326656199999999
+              "latency": 1.466631882
             }
           ],
           "implementation": "rust-libp2p",
@@ -192,34 +192,34 @@
         {
           "result": [
             {
-              "latency": 1.085260831
+              "latency": 1.211935299
             },
             {
-              "latency": 1.040458165
+              "latency": 1.15778602
             },
             {
-              "latency": 1.057703353
+              "latency": 0.947399403
             },
             {
-              "latency": 1.526690323
+              "latency": 1.029041556
             },
             {
-              "latency": 1.158624489
+              "latency": 1.001075903
             },
             {
-              "latency": 0.987676366
+              "latency": 1.004185919
             },
             {
-              "latency": 1.07832605
+              "latency": 1.054228795
             },
             {
-              "latency": 1.123405368
+              "latency": 1.598689762
             },
             {
-              "latency": 1.176931877
+              "latency": 1.082119209
             },
             {
-              "latency": 0.972582383
+              "latency": 0.987950852
             }
           ],
           "implementation": "https",
@@ -229,34 +229,34 @@
         {
           "result": [
             {
-              "latency": 2.00041718
+              "latency": 2.14799032
             },
             {
-              "latency": 1.926055813
+              "latency": 2.088131784
             },
             {
-              "latency": 1.938247083
+              "latency": 1.8337325610000001
             },
             {
-              "latency": 1.9089656480000001
+              "latency": 2.175413402
             },
             {
-              "latency": 1.987682889
+              "latency": 2.250306989
             },
             {
-              "latency": 2.077785405
+              "latency": 1.8167588239999999
             },
             {
-              "latency": 1.876459788
+              "latency": 3.3344338110000002
             },
             {
-              "latency": 1.898380258
+              "latency": 2.202830303
             },
             {
-              "latency": 2.107207021
+              "latency": 2.033111406
             },
             {
-              "latency": 1.864232171
+              "latency": 1.976838388
             }
           ],
           "implementation": "go-libp2p",
@@ -266,34 +266,34 @@
         {
           "result": [
             {
-              "latency": 1.493318184
+              "latency": 1.4872633180000001
             },
             {
-              "latency": 1.526047135
+              "latency": 1.515854617
             },
             {
-              "latency": 1.384726298
+              "latency": 1.371569109
             },
             {
-              "latency": 1.468875621
+              "latency": 1.360426132
             },
             {
-              "latency": 1.475157714
+              "latency": 1.448610458
             },
             {
-              "latency": 1.453121249
+              "latency": 1.437290829
             },
             {
-              "latency": 1.45227682
+              "latency": 1.435319934
             },
             {
-              "latency": 1.461752988
+              "latency": 1.447892586
             },
             {
-              "latency": 1.518416706
+              "latency": 1.515551092
             },
             {
-              "latency": 1.445255755
+              "latency": 1.485473747
             }
           ],
           "implementation": "go-libp2p",
@@ -303,34 +303,34 @@
         {
           "result": [
             {
-              "latency": 1.822296742
+              "latency": 1.946624414
             },
             {
-              "latency": 1.8696535600000002
+              "latency": 1.871213598
             },
             {
-              "latency": 1.910893207
+              "latency": 1.930647818
             },
             {
-              "latency": 2.058775486
+              "latency": 2.036804969
             },
             {
-              "latency": 1.7983950640000002
+              "latency": 1.822786415
             },
             {
-              "latency": 1.899713628
+              "latency": 2.070897382
             },
             {
-              "latency": 2.211065942
+              "latency": 2.252804278
             },
             {
-              "latency": 1.84486204
+              "latency": 1.9856770830000001
             },
             {
-              "latency": 1.964718382
+              "latency": 2.110161443
             },
             {
-              "latency": 2.039322815
+              "latency": 1.871776415
             }
           ],
           "implementation": "go-libp2p",
@@ -340,34 +340,34 @@
         {
           "result": [
             {
-              "latency": 1.510232859
+              "latency": 1.467866827
             },
             {
-              "latency": 1.5096963780000001
+              "latency": 1.499022531
             },
             {
-              "latency": 1.451701074
+              "latency": 1.449318823
             },
             {
-              "latency": 1.507893198
+              "latency": 1.487555051
             },
             {
-              "latency": 1.427003445
+              "latency": 1.442905997
             },
             {
-              "latency": 1.4247460539999999
+              "latency": 1.410488052
             },
             {
-              "latency": 1.4869463010000001
+              "latency": 1.525585168
             },
             {
-              "latency": 1.502917124
+              "latency": 1.444252613
             },
             {
-              "latency": 1.506837921
+              "latency": 1.505780895
             },
             {
-              "latency": 1.523948048
+              "latency": 1.414071243
             }
           ],
           "implementation": "go-libp2p",
@@ -377,34 +377,34 @@
         {
           "result": [
             {
-              "latency": 1.887423789
+              "latency": 1.7113871299999999
             },
             {
-              "latency": 1.828131129
+              "latency": 1.973979666
             },
             {
-              "latency": 1.847789302
+              "latency": 1.869741822
             },
             {
-              "latency": 1.807732865
+              "latency": 2.193706121
             },
             {
-              "latency": 1.868927057
+              "latency": 1.917633871
             },
             {
-              "latency": 1.9384547589999999
+              "latency": 1.930348143
             },
             {
-              "latency": 1.973003737
+              "latency": 1.867303723
             },
             {
-              "latency": 2.104874296
+              "latency": 2.039253214
             },
             {
-              "latency": 2.077658277
+              "latency": 1.926235283
             },
             {
-              "latency": 2.049212007
+              "latency": 1.864707529
             }
           ],
           "implementation": "go-libp2p",
@@ -414,34 +414,34 @@
         {
           "result": [
             {
-              "latency": 1.4489625959999999
+              "latency": 1.443154588
             },
             {
-              "latency": 1.438072231
+              "latency": 1.470407504
             },
             {
-              "latency": 1.47192888
+              "latency": 1.407338099
             },
             {
-              "latency": 1.36653179
+              "latency": 1.443158769
             },
             {
-              "latency": 1.447688209
+              "latency": 1.470717768
             },
             {
-              "latency": 1.43794569
+              "latency": 1.490384623
             },
             {
-              "latency": 1.422484858
+              "latency": 1.489250703
             },
             {
-              "latency": 1.507912567
+              "latency": 1.482503307
             },
             {
-              "latency": 1.422477268
+              "latency": 1.493298214
             },
             {
-              "latency": 1.450366273
+              "latency": 1.43030538
             }
           ],
           "implementation": "go-libp2p",
@@ -461,34 +461,34 @@
         {
           "result": [
             {
-              "latency": 1.149199048
+              "latency": 1.109308432
             },
             {
-              "latency": 1.157563774
+              "latency": 1.054018318
             },
             {
-              "latency": 1.114077801
+              "latency": 1.147751252
             },
             {
-              "latency": 1.15452198
+              "latency": 1.037174594
             },
             {
-              "latency": 1.084618645
+              "latency": 1.118115819
             },
             {
-              "latency": 1.11946623
+              "latency": 1.100911853
             },
             {
-              "latency": 1.146397234
+              "latency": 1.098210334
             },
             {
-              "latency": 1.115965759
+              "latency": 1.130081284
             },
             {
-              "latency": 1.156336724
+              "latency": 1.093357034
             },
             {
-              "latency": 1.080715488
+              "latency": 1.025402529
             }
           ],
           "implementation": "quic-go",
@@ -498,34 +498,34 @@
         {
           "result": [
             {
-              "latency": 46.006305198
+              "latency": 46.304567801
             },
             {
-              "latency": 45.59101943
+              "latency": 44.810690425
             },
             {
-              "latency": 46.909697672
+              "latency": 41.725360365
             },
             {
-              "latency": 46.92568299
+              "latency": 44.734912262
             },
             {
-              "latency": 45.152127336
+              "latency": 42.043148009
             },
             {
-              "latency": 42.538929055
+              "latency": 47.207299765
             },
             {
-              "latency": 46.080626541
+              "latency": 45.743792887
             },
             {
-              "latency": 44.26846442
+              "latency": 41.716502211
             },
             {
-              "latency": 47.018440163
+              "latency": 43.308838582999996
             },
             {
-              "latency": 44.122497155
+              "latency": 45.019887105
             }
           ],
           "implementation": "rust-libp2p",
@@ -535,34 +535,34 @@
         {
           "result": [
             {
-              "latency": 33.164872835
+              "latency": 13.461747453
             },
             {
-              "latency": 20.23798894
+              "latency": 7.4078973359999996
             },
             {
-              "latency": 16.607925497
+              "latency": 8.692457869
             },
             {
-              "latency": 15.523835048
+              "latency": 15.178098381
             },
             {
-              "latency": 8.203831203
+              "latency": 19.923681776
             },
             {
-              "latency": 13.395711191
+              "latency": 14.621029034
             },
             {
-              "latency": 13.951129538
+              "latency": 16.217042778
             },
             {
-              "latency": 8.558814731
+              "latency": 24.793247866
             },
             {
-              "latency": 12.492643916
+              "latency": 11.943579449
             },
             {
-              "latency": 14.671470039
+              "latency": 16.019983053
             }
           ],
           "implementation": "rust-libp2p",
@@ -572,34 +572,34 @@
         {
           "result": [
             {
-              "latency": 45.626450328
+              "latency": 44.688566175
             },
             {
-              "latency": 43.272589128999996
+              "latency": 46.282443574
             },
             {
-              "latency": 45.447037749
+              "latency": 44.185855607
             },
             {
-              "latency": 45.975694488
+              "latency": 45.004593614
             },
             {
-              "latency": 45.426381055
+              "latency": 47.998729775
             },
             {
-              "latency": 46.921007984
+              "latency": 41.554185445
             },
             {
-              "latency": 45.374440872
+              "latency": 41.987058412
             },
             {
-              "latency": 45.866453431
+              "latency": 43.923258514
             },
             {
-              "latency": 42.280475852
+              "latency": 46.270399731
             },
             {
-              "latency": 43.604913492
+              "latency": 43.829340867
             }
           ],
           "implementation": "rust-libp2p",
@@ -609,34 +609,34 @@
         {
           "result": [
             {
-              "latency": 1.5269195469999999
+              "latency": 1.529759138
             },
             {
-              "latency": 1.401511865
+              "latency": 1.460648167
             },
             {
-              "latency": 1.351604413
+              "latency": 1.459205893
             },
             {
-              "latency": 1.495406051
+              "latency": 1.470609963
             },
             {
-              "latency": 1.444137512
+              "latency": 1.479408576
             },
             {
-              "latency": 1.433565694
+              "latency": 1.452668627
             },
             {
-              "latency": 1.469279238
+              "latency": 1.5346404869999999
             },
             {
-              "latency": 1.441981719
+              "latency": 1.5237283590000001
             },
             {
-              "latency": 1.475345647
+              "latency": 1.378006045
             },
             {
-              "latency": 1.4954403410000001
+              "latency": 1.5270299330000001
             }
           ],
           "implementation": "rust-libp2p",
@@ -646,34 +646,34 @@
         {
           "result": [
             {
-              "latency": 1.018266091
+              "latency": 1.06985192
             },
             {
-              "latency": 1.16434628
+              "latency": 1.078975178
             },
             {
-              "latency": 1.078597881
+              "latency": 1.090954122
             },
             {
-              "latency": 1.068773445
+              "latency": 1.078056918
             },
             {
-              "latency": 1.18122069
+              "latency": 1.032631315
             },
             {
-              "latency": 1.666752361
+              "latency": 0.987232718
             },
             {
-              "latency": 1.079439141
+              "latency": 1.061332927
             },
             {
-              "latency": 1.079188576
+              "latency": 1.218349379
             },
             {
-              "latency": 1.18315602
+              "latency": 1.044808215
             },
             {
-              "latency": 1.211309013
+              "latency": 1.094213245
             }
           ],
           "implementation": "https",
@@ -683,34 +683,34 @@
         {
           "result": [
             {
-              "latency": 2.215776735
+              "latency": 1.94770385
             },
             {
-              "latency": 1.950393949
+              "latency": 1.853613671
             },
             {
-              "latency": 1.752649385
+              "latency": 1.959894228
             },
             {
-              "latency": 1.914636944
+              "latency": 1.779944554
             },
             {
-              "latency": 2.140913856
+              "latency": 1.897294269
             },
             {
-              "latency": 1.8511913629999999
+              "latency": 2.305439342
             },
             {
-              "latency": 1.786344674
+              "latency": 1.8942532810000001
             },
             {
-              "latency": 2.116697589
+              "latency": 1.921182328
             },
             {
-              "latency": 1.97959514
+              "latency": 2.25273432
             },
             {
-              "latency": 2.786357404
+              "latency": 2.127689995
             }
           ],
           "implementation": "go-libp2p",
@@ -720,34 +720,34 @@
         {
           "result": [
             {
-              "latency": 1.486444174
+              "latency": 1.5416403010000002
             },
             {
-              "latency": 1.4239469200000001
+              "latency": 1.467889457
             },
             {
-              "latency": 1.447086572
+              "latency": 1.446612813
             },
             {
-              "latency": 1.513992215
+              "latency": 1.3398296219999999
             },
             {
-              "latency": 5.081743365
+              "latency": 1.495534615
             },
             {
-              "latency": 1.486929825
+              "latency": 1.447575503
             },
             {
-              "latency": 1.530266978
+              "latency": 1.456547657
             },
             {
-              "latency": 1.437148686
+              "latency": 1.459856937
             },
             {
-              "latency": 1.442237815
+              "latency": 1.449846874
             },
             {
-              "latency": 1.463068032
+              "latency": 1.463668413
             }
           ],
           "implementation": "go-libp2p",
@@ -757,34 +757,34 @@
         {
           "result": [
             {
-              "latency": 1.984648098
+              "latency": 2.066471317
             },
             {
-              "latency": 1.915011154
+              "latency": 1.826449427
             },
             {
-              "latency": 2.174927185
+              "latency": 1.955103203
             },
             {
-              "latency": 2.127334374
+              "latency": 1.770377723
             },
             {
-              "latency": 1.829379466
+              "latency": 1.9531610160000001
             },
             {
-              "latency": 1.976193457
+              "latency": 1.924892393
             },
             {
-              "latency": 1.816409833
+              "latency": 1.897355756
             },
             {
-              "latency": 2.213465902
+              "latency": 1.8721706120000001
             },
             {
-              "latency": 1.9789948659999999
+              "latency": 1.9907122940000002
             },
             {
-              "latency": 2.056144496
+              "latency": 2.074084887
             }
           ],
           "implementation": "go-libp2p",
@@ -794,34 +794,34 @@
         {
           "result": [
             {
-              "latency": 1.471732982
+              "latency": 1.4413598460000001
             },
             {
-              "latency": 1.386400597
+              "latency": 1.448569754
             },
             {
-              "latency": 1.4744533610000001
+              "latency": 1.458297064
             },
             {
-              "latency": 1.475587438
+              "latency": 1.429398183
             },
             {
-              "latency": 1.476875106
+              "latency": 1.416642429
             },
             {
-              "latency": 1.498334311
+              "latency": 1.451650191
             },
             {
-              "latency": 1.423239728
+              "latency": 1.3687256300000001
             },
             {
-              "latency": 1.465852953
+              "latency": 1.487059134
             },
             {
-              "latency": 1.499112768
+              "latency": 1.5102343299999998
             },
             {
-              "latency": 1.534331492
+              "latency": 1.440230047
             }
           ],
           "implementation": "go-libp2p",
@@ -831,34 +831,34 @@
         {
           "result": [
             {
-              "latency": 1.87368222
+              "latency": 1.837694982
             },
             {
-              "latency": 1.976366793
+              "latency": 1.95983684
             },
             {
-              "latency": 1.7837310610000001
+              "latency": 1.973159041
             },
             {
-              "latency": 2.137891339
+              "latency": 1.9481318220000001
             },
             {
-              "latency": 2.190050614
+              "latency": 1.8442657279999999
             },
             {
-              "latency": 1.8649698479999999
+              "latency": 2.266168538
             },
             {
-              "latency": 2.125164286
+              "latency": 1.802858213
             },
             {
-              "latency": 2.094308199
+              "latency": 1.885832916
             },
             {
-              "latency": 1.915074339
+              "latency": 2.17910766
             },
             {
-              "latency": 2.131227978
+              "latency": 1.853186806
             }
           ],
           "implementation": "go-libp2p",
@@ -868,34 +868,34 @@
         {
           "result": [
             {
-              "latency": 1.4503606470000001
+              "latency": 1.414330714
             },
             {
-              "latency": 1.466142601
+              "latency": 1.50316357
             },
             {
-              "latency": 1.483229164
+              "latency": 1.507053516
             },
             {
-              "latency": 1.4580926920000001
+              "latency": 1.518935104
             },
             {
-              "latency": 1.5389658659999998
+              "latency": 1.465909666
             },
             {
-              "latency": 1.519644902
+              "latency": 1.459079584
             },
             {
-              "latency": 1.477906865
+              "latency": 1.485010239
             },
             {
-              "latency": 1.4759470559999999
+              "latency": 1.356988938
             },
             {
-              "latency": 1.444991447
+              "latency": 1.4706868690000001
             },
             {
-              "latency": 1.408619595
+              "latency": 1.429391507
             }
           ],
           "implementation": "go-libp2p",
@@ -915,304 +915,304 @@
         {
           "result": [
             {
-              "latency": 0.125762936
+              "latency": 0.121812216
             },
             {
-              "latency": 0.125532012
+              "latency": 0.122165168
             },
             {
-              "latency": 0.130680355
+              "latency": 0.129256117
             },
             {
-              "latency": 0.125002467
+              "latency": 0.130976324
             },
             {
-              "latency": 0.129832706
+              "latency": 0.12373669
             },
             {
-              "latency": 0.126789261
+              "latency": 0.12277203
             },
             {
-              "latency": 0.126112536
+              "latency": 0.121540007
             },
             {
-              "latency": 0.12648094
+              "latency": 0.126459505
             },
             {
-              "latency": 0.129648537
+              "latency": 0.125045577
             },
             {
-              "latency": 0.122423247
+              "latency": 0.1242434
             },
             {
-              "latency": 0.125126655
+              "latency": 0.125203912
             },
             {
-              "latency": 0.128063248
+              "latency": 0.120402531
             },
             {
-              "latency": 0.128997095
+              "latency": 0.12766902
             },
             {
-              "latency": 0.124706607
+              "latency": 0.123599923
             },
             {
-              "latency": 0.125246785
+              "latency": 0.131815466
             },
             {
-              "latency": 0.127441164
+              "latency": 0.119195313
             },
             {
-              "latency": 0.126592187
+              "latency": 0.127419994
             },
             {
-              "latency": 0.124894141
+              "latency": 0.130671224
             },
             {
-              "latency": 0.125709114
+              "latency": 0.130759172
             },
             {
-              "latency": 0.12913498
+              "latency": 0.124879858
             },
             {
-              "latency": 0.130439712
+              "latency": 0.122289818
             },
             {
-              "latency": 0.129369247
+              "latency": 0.121966346
             },
             {
-              "latency": 0.126821524
+              "latency": 0.117793726
             },
             {
-              "latency": 0.124599749
+              "latency": 0.124330435
             },
             {
-              "latency": 0.127713992
+              "latency": 0.12603103
             },
             {
-              "latency": 0.121446872
+              "latency": 0.123550293
             },
             {
-              "latency": 0.128051265
+              "latency": 0.123160017
             },
             {
-              "latency": 0.126931838
+              "latency": 0.123686527
             },
             {
-              "latency": 0.123857001
+              "latency": 0.128570203
             },
             {
-              "latency": 0.125986067
+              "latency": 0.126438475
             },
             {
-              "latency": 0.12480403
+              "latency": 0.12702998
             },
             {
-              "latency": 0.122271363
+              "latency": 0.123565444
             },
             {
-              "latency": 0.12591565
+              "latency": 0.124183462
             },
             {
-              "latency": 0.128481507
+              "latency": 0.118530613
             },
             {
-              "latency": 0.125585317
+              "latency": 0.126379835
             },
             {
-              "latency": 0.128365935
+              "latency": 0.130409956
             },
             {
-              "latency": 0.129465262
+              "latency": 0.122432923
             },
             {
-              "latency": 0.126937259
+              "latency": 0.128748901
             },
             {
-              "latency": 0.127662778
+              "latency": 0.123154312
             },
             {
-              "latency": 0.130185132
+              "latency": 0.124575533
             },
             {
-              "latency": 0.12860616
+              "latency": 0.116122387
             },
             {
-              "latency": 0.130559279
+              "latency": 0.128019242
             },
             {
-              "latency": 0.120208756
+              "latency": 0.124316484
             },
             {
-              "latency": 0.130442452
+              "latency": 0.12922136
             },
             {
-              "latency": 0.126745972
+              "latency": 0.123677468
             },
             {
-              "latency": 0.120316019
+              "latency": 0.132696518
             },
             {
-              "latency": 0.127710272
+              "latency": 0.128185898
             },
             {
-              "latency": 0.12985534
+              "latency": 0.124142989
             },
             {
-              "latency": 0.126844139
+              "latency": 0.123605278
             },
             {
-              "latency": 0.123207861
+              "latency": 0.127313401
             },
             {
-              "latency": 0.129726701
+              "latency": 0.118691816
             },
             {
-              "latency": 0.126182044
+              "latency": 0.124502248
             },
             {
-              "latency": 0.129656797
+              "latency": 0.125154089
             },
             {
-              "latency": 0.122401266
+              "latency": 0.124900111
             },
             {
-              "latency": 0.128554508
+              "latency": 0.129261267
             },
             {
-              "latency": 0.129179946
+              "latency": 0.124985781
             },
             {
-              "latency": 0.126667809
+              "latency": 0.125198974
             },
             {
-              "latency": 0.130729093
+              "latency": 0.126372191
             },
             {
-              "latency": 0.128035322
+              "latency": 0.12816465
             },
             {
-              "latency": 0.12727555
+              "latency": 0.124340911
             },
             {
-              "latency": 0.123530668
+              "latency": 0.121889119
             },
             {
-              "latency": 0.123798811
+              "latency": 0.120924069
             },
             {
-              "latency": 0.127614154
+              "latency": 0.126416598
             },
             {
-              "latency": 0.129787272
+              "latency": 0.123334834
             },
             {
-              "latency": 0.129313602
+              "latency": 0.130319836
             },
             {
-              "latency": 0.116634619
+              "latency": 0.12501785
             },
             {
-              "latency": 0.129093054
+              "latency": 0.124682274
             },
             {
-              "latency": 0.12668097
+              "latency": 0.125519886
             },
             {
-              "latency": 0.130769547
+              "latency": 0.131039611
             },
             {
-              "latency": 0.11989181
+              "latency": 0.123335233
             },
             {
-              "latency": 0.12361692
+              "latency": 0.128616666
             },
             {
-              "latency": 0.123713242
+              "latency": 0.131132887
             },
             {
-              "latency": 0.121143274
+              "latency": 0.124246989
             },
             {
-              "latency": 0.122933957
+              "latency": 0.130009172
             },
             {
-              "latency": 0.123485686
+              "latency": 0.12835994
             },
             {
-              "latency": 0.130484268
+              "latency": 0.125172666
             },
             {
-              "latency": 0.126988858
+              "latency": 0.12765526
             },
             {
-              "latency": 0.131100738
+              "latency": 0.124106946
             },
             {
-              "latency": 0.122147542
+              "latency": 0.129408378
             },
             {
-              "latency": 0.129422668
+              "latency": 0.124177353
             },
             {
-              "latency": 0.12742579
+              "latency": 0.122043524
             },
             {
-              "latency": 0.124992949
+              "latency": 0.123079856
             },
             {
-              "latency": 0.127668144
+              "latency": 0.12919236
             },
             {
-              "latency": 0.122618205
+              "latency": 0.124914543
             },
             {
-              "latency": 0.129735755
+              "latency": 0.125970369
             },
             {
-              "latency": 0.119158566
+              "latency": 0.122639148
             },
             {
-              "latency": 0.128970332
+              "latency": 0.120406082
             },
             {
-              "latency": 0.122207535
+              "latency": 0.124899118
             },
             {
-              "latency": 0.131265173
+              "latency": 0.120994013
             },
             {
-              "latency": 0.122236005
+              "latency": 0.127757762
             },
             {
-              "latency": 0.123582575
+              "latency": 0.122493976
             },
             {
-              "latency": 0.126172587
+              "latency": 0.123099601
             },
             {
-              "latency": 0.120163279
+              "latency": 0.125641448
             },
             {
-              "latency": 0.122660541
+              "latency": 0.118797402
             },
             {
-              "latency": 0.120163301
+              "latency": 0.129293164
             },
             {
-              "latency": 0.122411836
+              "latency": 0.126112107
             },
             {
-              "latency": 0.124202701
+              "latency": 0.123104324
             },
             {
-              "latency": 0.124915141
+              "latency": 0.128918945
             },
             {
-              "latency": 0.129693881
+              "latency": 0.124961593
             },
             {
-              "latency": 0.127959635
+              "latency": 0.11772313
             }
           ],
           "implementation": "quic-go",
@@ -1222,304 +1222,304 @@
         {
           "result": [
             {
-              "latency": 0.194368692
+              "latency": 0.1941267
             },
             {
-              "latency": 0.189691375
+              "latency": 0.19307774
             },
             {
-              "latency": 0.192411456
+              "latency": 0.181736122
             },
             {
-              "latency": 0.183154474
+              "latency": 0.194886941
             },
             {
-              "latency": 0.189793379
+              "latency": 0.178028364
             },
             {
-              "latency": 0.193699012
+              "latency": 0.179926856
             },
             {
-              "latency": 0.18104075
+              "latency": 0.189802289
             },
             {
-              "latency": 0.191544617
+              "latency": 0.179438239
             },
             {
-              "latency": 0.186680903
+              "latency": 0.191637625
             },
             {
-              "latency": 0.184681401
+              "latency": 0.176200869
             },
             {
-              "latency": 0.178201234
+              "latency": 0.176609059
             },
             {
-              "latency": 0.194998587
+              "latency": 0.175244008
             },
             {
-              "latency": 0.179636468
+              "latency": 0.19178628
             },
             {
-              "latency": 0.189925731
+              "latency": 0.19381411
             },
             {
-              "latency": 0.186969406
+              "latency": 0.182227247
             },
             {
-              "latency": 0.180127125
+              "latency": 0.173479231
             },
             {
-              "latency": 0.183475765
+              "latency": 0.19207593
             },
             {
-              "latency": 0.192985348
+              "latency": 0.191947956
             },
             {
-              "latency": 0.189097566
+              "latency": 0.182663945
             },
             {
-              "latency": 0.193951777
+              "latency": 0.187370314
             },
             {
-              "latency": 0.181436901
+              "latency": 0.174376296
             },
             {
-              "latency": 0.178586606
+              "latency": 0.182528392
             },
             {
-              "latency": 0.179856966
+              "latency": 0.180649939
             },
             {
-              "latency": 0.180201979
+              "latency": 0.183950797
             },
             {
-              "latency": 0.191594229
+              "latency": 0.193775389
             },
             {
-              "latency": 0.196091922
+              "latency": 0.183284942
             },
             {
-              "latency": 0.194219892
+              "latency": 0.179957313
             },
             {
-              "latency": 0.192522551
+              "latency": 0.192043664
             },
             {
-              "latency": 0.187786397
+              "latency": 0.184202277
             },
             {
-              "latency": 0.192274582
+              "latency": 0.187842688
             },
             {
-              "latency": 0.178288945
+              "latency": 0.191863784
             },
             {
-              "latency": 0.192671711
+              "latency": 0.194359041
             },
             {
-              "latency": 0.189423477
+              "latency": 0.189889968
             },
             {
-              "latency": 0.181164996
+              "latency": 0.18619675
             },
             {
-              "latency": 0.186369674
+              "latency": 0.189072333
             },
             {
-              "latency": 0.190700246
+              "latency": 0.181648896
             },
             {
-              "latency": 0.187744401
+              "latency": 0.195709785
             },
             {
-              "latency": 0.182324192
+              "latency": 0.183649577
             },
             {
-              "latency": 0.189598931
+              "latency": 0.182872872
             },
             {
-              "latency": 0.196607228
+              "latency": 0.180496761
             },
             {
-              "latency": 0.187071643
+              "latency": 0.196217556
             },
             {
-              "latency": 0.191964036
+              "latency": 0.185308698
             },
             {
-              "latency": 0.193843733
+              "latency": 0.192454666
             },
             {
-              "latency": 0.181391708
+              "latency": 0.17803931
             },
             {
-              "latency": 0.188757624
+              "latency": 0.171271946
             },
             {
-              "latency": 0.183353697
+              "latency": 0.194299993
             },
             {
-              "latency": 0.186387892
+              "latency": 0.194498849
             },
             {
-              "latency": 0.183802869
+              "latency": 0.187026178
             },
             {
-              "latency": 0.186582892
+              "latency": 0.184302316
             },
             {
-              "latency": 0.195209015
+              "latency": 0.176725004
             },
             {
-              "latency": 0.180370885
+              "latency": 0.184656032
             },
             {
-              "latency": 0.188749239
+              "latency": 0.189106243
             },
             {
-              "latency": 0.188363144
+              "latency": 0.176190317
             },
             {
-              "latency": 0.186546855
+              "latency": 0.184753441
             },
             {
-              "latency": 0.180555902
+              "latency": 0.194745866
             },
             {
-              "latency": 0.18824631
+              "latency": 0.184133281
             },
             {
-              "latency": 0.19458154
+              "latency": 0.184247017
             },
             {
-              "latency": 0.190109293
+              "latency": 0.186155128
             },
             {
-              "latency": 0.194537186
+              "latency": 0.187598435
             },
             {
-              "latency": 0.186403431
+              "latency": 0.193235171
             },
             {
-              "latency": 0.17951082
+              "latency": 0.17945188
             },
             {
-              "latency": 0.191254675
+              "latency": 0.188175096
             },
             {
-              "latency": 0.193843565
+              "latency": 0.195647575
             },
             {
-              "latency": 0.183220511
+              "latency": 0.190330185
             },
             {
-              "latency": 0.176310991
+              "latency": 0.187374773
             },
             {
-              "latency": 0.193939589
+              "latency": 0.181001847
             },
             {
-              "latency": 0.192416016
+              "latency": 0.187489068
             },
             {
-              "latency": 0.187443431
+              "latency": 0.179700091
             },
             {
-              "latency": 0.186505826
+              "latency": 0.189100363
             },
             {
-              "latency": 0.187148986
+              "latency": 0.18692074
             },
             {
-              "latency": 0.184515852
+              "latency": 0.183773129
             },
             {
-              "latency": 0.191141286
+              "latency": 0.187028682
             },
             {
-              "latency": 0.185594935
+              "latency": 0.182586957
             },
             {
-              "latency": 0.19103688
+              "latency": 0.18326823
             },
             {
-              "latency": 0.194180515
+              "latency": 0.182601467
             },
             {
-              "latency": 0.189610721
+              "latency": 0.181536493
             },
             {
-              "latency": 0.189543587
+              "latency": 0.184744258
             },
             {
-              "latency": 0.184003378
+              "latency": 0.178102722
             },
             {
-              "latency": 0.192176496
+              "latency": 0.195772322
             },
             {
-              "latency": 0.181398182
+              "latency": 0.19641536
             },
             {
-              "latency": 0.192565254
+              "latency": 0.188165119
             },
             {
-              "latency": 0.185139335
+              "latency": 0.178775929
             },
             {
-              "latency": 0.1914053
+              "latency": 0.194289284
             },
             {
-              "latency": 0.194573086
+              "latency": 0.185580308
             },
             {
-              "latency": 0.17961313
+              "latency": 0.18278545
             },
             {
-              "latency": 0.175065798
+              "latency": 0.194629909
             },
             {
-              "latency": 0.192552441
+              "latency": 0.187642131
             },
             {
-              "latency": 0.183442162
+              "latency": 0.170969631
             },
             {
-              "latency": 0.189579775
+              "latency": 0.179868448
             },
             {
-              "latency": 0.184564674
+              "latency": 0.18735446
             },
             {
-              "latency": 0.191932335
+              "latency": 0.185370272
             },
             {
-              "latency": 0.190904123
+              "latency": 0.176980705
             },
             {
-              "latency": 0.185644925
+              "latency": 0.190988621
             },
             {
-              "latency": 0.186823936
+              "latency": 0.177682585
             },
             {
-              "latency": 0.194164782
+              "latency": 0.19327623
             },
             {
-              "latency": 0.190613626
+              "latency": 0.191539338
             },
             {
-              "latency": 0.189539427
+              "latency": 0.183850659
             },
             {
-              "latency": 0.194340185
+              "latency": 0.188200265
             },
             {
-              "latency": 0.187782284
+              "latency": 0.192912215
             },
             {
-              "latency": 0.192670484
+              "latency": 0.186805603
             }
           ],
           "implementation": "rust-libp2p",
@@ -1529,304 +1529,304 @@
         {
           "result": [
             {
-              "latency": 0.123276392
+              "latency": 0.131838016
             },
             {
-              "latency": 0.120475341
+              "latency": 0.129344865
             },
             {
-              "latency": 0.130001909
+              "latency": 0.128681771
             },
             {
-              "latency": 0.129379616
+              "latency": 0.129683359
             },
             {
-              "latency": 0.12861122
+              "latency": 0.1224404
             },
             {
-              "latency": 0.116627012
+              "latency": 0.130635765
             },
             {
-              "latency": 0.124845813
+              "latency": 0.132134479
             },
             {
-              "latency": 0.127151755
+              "latency": 0.126963732
             },
             {
-              "latency": 0.12683793
+              "latency": 0.128810359
             },
             {
-              "latency": 0.122322219
+              "latency": 0.122813956
             },
             {
-              "latency": 0.123653201
+              "latency": 0.124346032
             },
             {
-              "latency": 0.130983224
+              "latency": 0.12390356
             },
             {
-              "latency": 0.128379513
+              "latency": 0.122420529
             },
             {
-              "latency": 0.124183694
+              "latency": 0.116504626
             },
             {
-              "latency": 0.12334287
+              "latency": 0.124161336
             },
             {
-              "latency": 0.129752007
+              "latency": 0.122097986
             },
             {
-              "latency": 0.126590695
+              "latency": 0.128595663
             },
             {
-              "latency": 0.123619453
+              "latency": 0.118907431
             },
             {
-              "latency": 0.124521745
+              "latency": 0.120371368
             },
             {
-              "latency": 0.122188226
+              "latency": 0.11952006
             },
             {
-              "latency": 0.127358426
+              "latency": 0.128398295
             },
             {
-              "latency": 0.12592717
+              "latency": 0.131167076
             },
             {
-              "latency": 0.119957896
+              "latency": 0.128501077
             },
             {
-              "latency": 0.129618406
+              "latency": 0.132281479
             },
             {
-              "latency": 0.118990386
+              "latency": 0.118543079
             },
             {
-              "latency": 0.126991864
+              "latency": 0.130136164
             },
             {
-              "latency": 0.120591392
+              "latency": 0.132370998
             },
             {
-              "latency": 0.12757593
+              "latency": 0.120060804
             },
             {
-              "latency": 0.130995569
+              "latency": 0.119275143
             },
             {
-              "latency": 0.123755555
+              "latency": 0.129446097
             },
             {
-              "latency": 0.126461191
+              "latency": 0.123520192
             },
             {
-              "latency": 0.129524831
+              "latency": 0.116819112
             },
             {
-              "latency": 0.121201289
+              "latency": 0.12815828
             },
             {
-              "latency": 0.1213488
+              "latency": 0.132722973
             },
             {
-              "latency": 0.126740105
+              "latency": 0.128993497
             },
             {
-              "latency": 0.122462219
+              "latency": 0.122132444
             },
             {
-              "latency": 0.129813433
+              "latency": 0.125849922
             },
             {
-              "latency": 0.12453865
+              "latency": 0.118184174
             },
             {
-              "latency": 0.128731273
+              "latency": 0.120281936
             },
             {
-              "latency": 0.131617495
+              "latency": 0.122916361
             },
             {
-              "latency": 0.121413546
+              "latency": 0.124672626
             },
             {
-              "latency": 0.128579371
+              "latency": 0.118965077
             },
             {
-              "latency": 0.129644786
+              "latency": 0.11559907
             },
             {
-              "latency": 0.127734079
+              "latency": 0.122171935
             },
             {
-              "latency": 0.117014776
+              "latency": 0.126332262
             },
             {
-              "latency": 0.127334311
+              "latency": 0.131185532
             },
             {
-              "latency": 0.120994042
+              "latency": 0.126092824
             },
             {
-              "latency": 0.129226169
+              "latency": 0.126702273
             },
             {
-              "latency": 0.126374601
+              "latency": 0.121998469
             },
             {
-              "latency": 0.122385816
+              "latency": 0.120226992
             },
             {
-              "latency": 0.125369074
+              "latency": 0.129590204
             },
             {
-              "latency": 0.12945342
+              "latency": 0.121267154
             },
             {
-              "latency": 0.130410394
+              "latency": 0.123831946
             },
             {
-              "latency": 0.124536901
+              "latency": 0.124839836
             },
             {
-              "latency": 0.130894383
+              "latency": 0.121335893
             },
             {
-              "latency": 0.126070284
+              "latency": 0.125059045
             },
             {
-              "latency": 0.123707233
+              "latency": 0.125703042
             },
             {
-              "latency": 0.125989785
+              "latency": 0.126219614
             },
             {
-              "latency": 0.129533527
+              "latency": 0.118121372
             },
             {
-              "latency": 0.125445686
+              "latency": 0.122809262
             },
             {
-              "latency": 0.11679691
+              "latency": 0.124409859
             },
             {
-              "latency": 0.129002178
+              "latency": 0.116837455
             },
             {
-              "latency": 0.124485696
+              "latency": 0.125361389
             },
             {
-              "latency": 0.123631551
+              "latency": 0.125511165
             },
             {
-              "latency": 0.123590584
+              "latency": 0.125510955
             },
             {
-              "latency": 0.120186334
+              "latency": 0.120069609
             },
             {
-              "latency": 0.130309507
+              "latency": 0.123883511
             },
             {
-              "latency": 0.127390056
+              "latency": 0.129830584
             },
             {
-              "latency": 0.12227457
+              "latency": 0.123415136
             },
             {
-              "latency": 0.121441414
+              "latency": 0.118832745
             },
             {
-              "latency": 0.123933561
+              "latency": 0.130503913
             },
             {
-              "latency": 0.12613447
+              "latency": 0.131154233
             },
             {
-              "latency": 0.129767597
+              "latency": 0.128931207
             },
             {
-              "latency": 0.128926516
+              "latency": 0.124313952
             },
             {
-              "latency": 0.126456323
+              "latency": 0.130101878
             },
             {
-              "latency": 0.115585511
+              "latency": 0.118810539
             },
             {
-              "latency": 0.131583219
+              "latency": 0.126598634
             },
             {
-              "latency": 0.126838957
+              "latency": 0.126456877
             },
             {
-              "latency": 0.126360132
+              "latency": 0.118979219
             },
             {
-              "latency": 0.126476447
+              "latency": 0.127800778
             },
             {
-              "latency": 0.120305065
+              "latency": 0.126219392
             },
             {
-              "latency": 0.131292257
+              "latency": 0.117193661
             },
             {
-              "latency": 0.128034558
+              "latency": 0.124464789
             },
             {
-              "latency": 0.127022279
+              "latency": 0.122917544
             },
             {
-              "latency": 0.126894805
+              "latency": 0.121123335
             },
             {
-              "latency": 0.130081538
+              "latency": 0.12972595
             },
             {
-              "latency": 0.118000286
+              "latency": 0.127279471
             },
             {
-              "latency": 0.127866032
+              "latency": 0.128211126
             },
             {
-              "latency": 0.122115477
+              "latency": 0.122850753
             },
             {
-              "latency": 0.128478789
+              "latency": 0.116695657
             },
             {
-              "latency": 0.132344615
+              "latency": 0.125641148
             },
             {
-              "latency": 0.125978719
+              "latency": 0.119194638
             },
             {
-              "latency": 0.126002943
+              "latency": 0.130794384
             },
             {
-              "latency": 0.126476129
+              "latency": 0.119391546
             },
             {
-              "latency": 0.128620826
+              "latency": 0.125724188
             },
             {
-              "latency": 0.129547225
+              "latency": 0.125096067
             },
             {
-              "latency": 0.128374094
+              "latency": 0.122629764
             },
             {
-              "latency": 0.127214501
+              "latency": 0.128886939
             },
             {
-              "latency": 0.123055021
+              "latency": 0.120965165
             },
             {
-              "latency": 0.129480901
+              "latency": 0.129594485
             }
           ],
           "implementation": "rust-libp2p",
@@ -1836,304 +1836,304 @@
         {
           "result": [
             {
-              "latency": 0.189179014
+              "latency": 0.182420211
             },
             {
-              "latency": 0.186346635
+              "latency": 0.193418607
             },
             {
-              "latency": 0.187458629
+              "latency": 0.182947211
             },
             {
-              "latency": 0.186704148
+              "latency": 0.182684007
             },
             {
-              "latency": 0.190423159
+              "latency": 0.172743591
             },
             {
-              "latency": 0.191635793
+              "latency": 0.1907026
             },
             {
-              "latency": 0.186393059
+              "latency": 0.183052206
             },
             {
-              "latency": 0.185044612
+              "latency": 0.191949535
             },
             {
-              "latency": 0.18150695
+              "latency": 0.184983195
             },
             {
-              "latency": 0.188685187
+              "latency": 0.185224679
             },
             {
-              "latency": 0.191944019
+              "latency": 0.178710283
             },
             {
-              "latency": 0.181788395
+              "latency": 0.192017146
             },
             {
-              "latency": 0.19406981
+              "latency": 0.18199387
             },
             {
-              "latency": 0.183321971
+              "latency": 0.179622685
             },
             {
-              "latency": 0.183121551
+              "latency": 0.180885476
             },
             {
-              "latency": 0.19046398
+              "latency": 0.19425825
             },
             {
-              "latency": 0.184391436
+              "latency": 0.175774927
             },
             {
-              "latency": 0.185649737
+              "latency": 0.184842664
             },
             {
-              "latency": 0.181835076
+              "latency": 0.176652062
             },
             {
-              "latency": 0.194197535
+              "latency": 0.179678112
             },
             {
-              "latency": 0.189615181
+              "latency": 0.184730737
             },
             {
-              "latency": 0.18176952
+              "latency": 0.185409482
             },
             {
-              "latency": 0.18991616
+              "latency": 0.18387493
             },
             {
-              "latency": 0.19000046
+              "latency": 0.193652652
             },
             {
-              "latency": 0.194041141
+              "latency": 0.176423266
             },
             {
-              "latency": 0.182471207
+              "latency": 0.185349953
             },
             {
-              "latency": 0.18668001
+              "latency": 0.189644517
             },
             {
-              "latency": 0.181737708
+              "latency": 0.182211398
             },
             {
-              "latency": 0.171228488
+              "latency": 0.182087611
             },
             {
-              "latency": 0.183275731
+              "latency": 0.174702872
             },
             {
-              "latency": 0.194024912
+              "latency": 0.194413991
             },
             {
-              "latency": 0.183181159
+              "latency": 0.179688299
             },
             {
-              "latency": 0.190331232
+              "latency": 0.187454725
             },
             {
-              "latency": 0.185401014
+              "latency": 0.184757154
             },
             {
-              "latency": 0.187804362
+              "latency": 0.193810955
             },
             {
-              "latency": 0.18304435
+              "latency": 0.194098222
             },
             {
-              "latency": 0.179683402
+              "latency": 0.187047043
             },
             {
-              "latency": 0.192879867
+              "latency": 0.183517997
             },
             {
-              "latency": 0.193431078
+              "latency": 0.18557684
             },
             {
-              "latency": 0.191187918
+              "latency": 0.18350173
             },
             {
-              "latency": 0.181496006
+              "latency": 0.192875151
             },
             {
-              "latency": 0.184528288
+              "latency": 0.188879993
             },
             {
-              "latency": 0.191416677
+              "latency": 0.186899409
             },
             {
-              "latency": 0.189034274
+              "latency": 0.18321976
             },
             {
-              "latency": 0.184923565
+              "latency": 0.175268644
             },
             {
-              "latency": 0.192400792
+              "latency": 0.184735733
             },
             {
-              "latency": 0.191932404
+              "latency": 0.19571033
             },
             {
-              "latency": 0.188265461
+              "latency": 0.188252996
             },
             {
-              "latency": 0.191339945
+              "latency": 0.186212675
             },
             {
-              "latency": 0.185692404
+              "latency": 0.18561714
             },
             {
-              "latency": 0.182550527
+              "latency": 0.18080782
             },
             {
-              "latency": 0.1711929
+              "latency": 0.18896674
             },
             {
-              "latency": 0.189663679
+              "latency": 0.174761919
             },
             {
-              "latency": 0.186539819
+              "latency": 0.189525415
             },
             {
-              "latency": 0.186568841
+              "latency": 0.175178525
             },
             {
-              "latency": 0.189258068
+              "latency": 0.18120828
             },
             {
-              "latency": 0.185281066
+              "latency": 0.193508968
             },
             {
-              "latency": 0.192096482
+              "latency": 0.183636965
             },
             {
-              "latency": 0.192633475
+              "latency": 0.189202394
             },
             {
-              "latency": 0.185156903
+              "latency": 0.181865784
             },
             {
-              "latency": 0.195944712
+              "latency": 0.184798572
             },
             {
-              "latency": 0.186097869
+              "latency": 0.194234233
             },
             {
-              "latency": 0.196481881
+              "latency": 0.185876989
             },
             {
-              "latency": 0.185460374
+              "latency": 0.191812862
             },
             {
-              "latency": 0.195286529
+              "latency": 0.185267154
             },
             {
-              "latency": 0.194138365
+              "latency": 0.186601769
             },
             {
-              "latency": 0.183172296
+              "latency": 0.182240773
             },
             {
-              "latency": 0.19030241
+              "latency": 0.185135383
             },
             {
-              "latency": 0.174690789
+              "latency": 0.174034675
             },
             {
-              "latency": 0.186198331
+              "latency": 0.193819399
             },
             {
-              "latency": 0.190711052
+              "latency": 0.18990808
             },
             {
-              "latency": 0.188637751
+              "latency": 0.184585626
             },
             {
-              "latency": 0.186032353
+              "latency": 0.189290188
             },
             {
-              "latency": 0.187738757
+              "latency": 0.182595918
             },
             {
-              "latency": 0.187848413
+              "latency": 0.187725558
             },
             {
-              "latency": 0.179948131
+              "latency": 0.176315104
             },
             {
-              "latency": 0.191664828
+              "latency": 0.191803138
             },
             {
-              "latency": 0.196891139
+              "latency": 0.18874598
             },
             {
-              "latency": 0.189586728
+              "latency": 0.195275806
             },
             {
-              "latency": 0.178231102
+              "latency": 0.176463238
             },
             {
-              "latency": 0.180020154
+              "latency": 0.174506775
             },
             {
-              "latency": 0.187977917
+              "latency": 0.186448817
             },
             {
-              "latency": 0.18105511
+              "latency": 0.17703164
             },
             {
-              "latency": 0.192553155
+              "latency": 0.191576629
             },
             {
-              "latency": 0.187516972
+              "latency": 0.181736779
             },
             {
-              "latency": 0.192787903
+              "latency": 0.187628173
             },
             {
-              "latency": 0.182182042
+              "latency": 0.195762356
             },
             {
-              "latency": 0.193602734
+              "latency": 0.184214154
             },
             {
-              "latency": 0.175529324
+              "latency": 0.185468935
             },
             {
-              "latency": 0.176361646
+              "latency": 0.185018911
             },
             {
-              "latency": 0.183293024
+              "latency": 0.180876235
             },
             {
-              "latency": 0.174766487
+              "latency": 0.192999467
             },
             {
-              "latency": 0.187906582
+              "latency": 0.192304702
             },
             {
-              "latency": 0.186062804
+              "latency": 0.186400412
             },
             {
-              "latency": 0.184865748
+              "latency": 0.179292792
             },
             {
-              "latency": 0.17803894
+              "latency": 0.185605686
             },
             {
-              "latency": 0.186880066
+              "latency": 0.18636479
             },
             {
-              "latency": 0.181575613
+              "latency": 0.189951975
             },
             {
-              "latency": 0.183426629
+              "latency": 0.17977227
             },
             {
-              "latency": 0.179988641
+              "latency": 0.191194221
             }
           ],
           "implementation": "rust-libp2p",
@@ -2143,304 +2143,304 @@
         {
           "result": [
             {
-              "latency": 0.125275028
+              "latency": 0.130023425
             },
             {
-              "latency": 0.128610092
+              "latency": 0.129630624
             },
             {
-              "latency": 0.127767896
+              "latency": 0.127692966
             },
             {
-              "latency": 0.119150259
+              "latency": 0.131710764
             },
             {
-              "latency": 0.129707389
+              "latency": 0.129602585
             },
             {
-              "latency": 0.126236746
+              "latency": 0.121110439
             },
             {
-              "latency": 0.129556083
+              "latency": 0.131690465
             },
             {
-              "latency": 0.129954142
+              "latency": 0.12409171
             },
             {
-              "latency": 0.128610501
+              "latency": 0.13264508
             },
             {
-              "latency": 0.123633907
+              "latency": 0.12526033
             },
             {
-              "latency": 0.122607639
+              "latency": 0.11817004
             },
             {
-              "latency": 0.122904711
+              "latency": 0.123926248
             },
             {
-              "latency": 0.120406318
+              "latency": 0.117971962
             },
             {
-              "latency": 0.126972133
+              "latency": 0.118114533
             },
             {
-              "latency": 0.125638089
+              "latency": 0.129454067
             },
             {
-              "latency": 0.122936983
+              "latency": 0.118508149
             },
             {
-              "latency": 0.126958994
+              "latency": 0.124498423
             },
             {
-              "latency": 0.129229477
+              "latency": 0.115631805
             },
             {
-              "latency": 0.128917869
+              "latency": 0.12438509
             },
             {
-              "latency": 0.130111267
+              "latency": 0.13059137
             },
             {
-              "latency": 0.128079818
+              "latency": 0.127606377
             },
             {
-              "latency": 0.130073164
+              "latency": 0.129783448
             },
             {
-              "latency": 0.119589406
+              "latency": 0.129589746
             },
             {
-              "latency": 0.127874729
+              "latency": 0.117852871
             },
             {
-              "latency": 0.121316621
+              "latency": 0.126490281
             },
             {
-              "latency": 0.13108835
+              "latency": 0.124121739
             },
             {
-              "latency": 0.131576367
+              "latency": 0.13099893
             },
             {
-              "latency": 0.129212126
+              "latency": 0.1219605
             },
             {
-              "latency": 0.126707831
+              "latency": 0.127588455
             },
             {
-              "latency": 0.120374625
+              "latency": 0.13106399
             },
             {
-              "latency": 0.117397549
+              "latency": 0.130997716
             },
             {
-              "latency": 0.131366279
+              "latency": 0.127768462
             },
             {
-              "latency": 0.128216324
+              "latency": 0.127344591
             },
             {
-              "latency": 0.127677644
+              "latency": 0.128024176
             },
             {
-              "latency": 0.12390403
+              "latency": 0.129155181
             },
             {
-              "latency": 0.120458983
+              "latency": 0.130433094
             },
             {
-              "latency": 0.132903025
+              "latency": 0.128753937
             },
             {
-              "latency": 0.125948439
+              "latency": 0.124669915
             },
             {
-              "latency": 0.128720886
+              "latency": 0.124201781
             },
             {
-              "latency": 0.124130668
+              "latency": 0.124347264
             },
             {
-              "latency": 0.120326974
+              "latency": 0.120980964
             },
             {
-              "latency": 0.12731677
+              "latency": 0.118088891
             },
             {
-              "latency": 0.127286387
+              "latency": 0.122510831
             },
             {
-              "latency": 0.124155115
+              "latency": 0.115509927
             },
             {
-              "latency": 0.131223057
+              "latency": 0.131068035
             },
             {
-              "latency": 0.129846572
+              "latency": 0.122153306
             },
             {
-              "latency": 0.128608705
+              "latency": 0.12400728
             },
             {
-              "latency": 0.12854944
+              "latency": 0.124608478
             },
             {
-              "latency": 0.126078115
+              "latency": 0.122674733
             },
             {
-              "latency": 0.128550889
+              "latency": 0.125075393
             },
             {
-              "latency": 0.131828498
+              "latency": 0.123615462
             },
             {
-              "latency": 0.124863586
+              "latency": 0.128663998
             },
             {
-              "latency": 0.123962945
+              "latency": 0.130684812
             },
             {
-              "latency": 0.127910346
+              "latency": 0.122150696
             },
             {
-              "latency": 0.122275632
+              "latency": 0.126229675
             },
             {
-              "latency": 0.125074754
+              "latency": 0.119318706
             },
             {
-              "latency": 0.128078063
+              "latency": 0.126740614
             },
             {
-              "latency": 0.122388484
+              "latency": 0.13240901
             },
             {
-              "latency": 0.12726112
+              "latency": 0.130905124
             },
             {
-              "latency": 0.121659235
+              "latency": 0.130750524
             },
             {
-              "latency": 0.128019582
+              "latency": 0.131401983
             },
             {
-              "latency": 0.128676694
+              "latency": 0.122688815
             },
             {
-              "latency": 0.126196227
+              "latency": 0.125487558
             },
             {
-              "latency": 0.123339628
+              "latency": 0.122717314
             },
             {
-              "latency": 0.129252279
+              "latency": 0.1247382
             },
             {
-              "latency": 0.126272745
+              "latency": 0.128582953
             },
             {
-              "latency": 0.126274096
+              "latency": 0.124953087
             },
             {
-              "latency": 0.128744713
+              "latency": 0.123993277
             },
             {
-              "latency": 0.123731
+              "latency": 0.116992262
             },
             {
-              "latency": 0.128264633
+              "latency": 0.130736791
             },
             {
-              "latency": 0.122572575
+              "latency": 0.119036267
             },
             {
-              "latency": 0.12752454
+              "latency": 0.121340747
             },
             {
-              "latency": 0.129481963
+              "latency": 0.125307585
             },
             {
-              "latency": 0.128034632
+              "latency": 0.122090288
             },
             {
-              "latency": 0.123716736
+              "latency": 0.123185661
             },
             {
-              "latency": 0.128572592
+              "latency": 0.123141352
             },
             {
-              "latency": 0.128029892
+              "latency": 0.127265799
             },
             {
-              "latency": 0.131069824
+              "latency": 0.123273945
             },
             {
-              "latency": 0.125063496
+              "latency": 0.130685112
             },
             {
-              "latency": 0.132692692
+              "latency": 0.118693239
             },
             {
-              "latency": 0.123567987
+              "latency": 0.119799913
             },
             {
-              "latency": 0.128061669
+              "latency": 0.126229587
             },
             {
-              "latency": 0.128295648
+              "latency": 0.130463723
             },
             {
-              "latency": 0.127830816
+              "latency": 0.126617475
             },
             {
-              "latency": 0.130509406
+              "latency": 0.119409297
             },
             {
-              "latency": 0.126723756
+              "latency": 0.126527103
             },
             {
-              "latency": 0.118282894
+              "latency": 0.132429605
             },
             {
-              "latency": 0.13006055
+              "latency": 0.120680307
             },
             {
-              "latency": 0.123958645
+              "latency": 0.128586321
             },
             {
-              "latency": 0.129924661
+              "latency": 0.131395532
             },
             {
-              "latency": 0.126205173
+              "latency": 0.123344627
             },
             {
-              "latency": 0.129743403
+              "latency": 0.123535843
             },
             {
-              "latency": 0.125261128
+              "latency": 0.128087204
             },
             {
-              "latency": 0.123806895
+              "latency": 0.123507999
             },
             {
-              "latency": 0.131155726
+              "latency": 0.126420524
             },
             {
-              "latency": 0.125406105
+              "latency": 0.123409383
             },
             {
-              "latency": 0.124214683
+              "latency": 0.130525448
             },
             {
-              "latency": 0.129591095
+              "latency": 0.129712086
             },
             {
-              "latency": 0.122420879
+              "latency": 0.122853241
             },
             {
-              "latency": 0.126166731
+              "latency": 0.126339842
             }
           ],
           "implementation": "rust-libp2p",
@@ -2450,304 +2450,304 @@
         {
           "result": [
             {
-              "latency": 0.192217083
+              "latency": 0.182188662
             },
             {
-              "latency": 0.188112098
+              "latency": 0.175941929
             },
             {
-              "latency": 0.184690269
+              "latency": 0.183376346
             },
             {
-              "latency": 0.170675526
+              "latency": 0.175698802
             },
             {
-              "latency": 0.187434557
+              "latency": 0.188549965
             },
             {
-              "latency": 0.18587156
+              "latency": 0.19060037
             },
             {
-              "latency": 0.18107949
+              "latency": 0.185171816
             },
             {
-              "latency": 0.192015944
+              "latency": 0.173212131
             },
             {
-              "latency": 0.18633219
+              "latency": 0.190062162
             },
             {
-              "latency": 0.194150176
+              "latency": 0.175505666
             },
             {
-              "latency": 0.189018544
+              "latency": 0.180899159
             },
             {
-              "latency": 0.186161411
+              "latency": 0.184381819
             },
             {
-              "latency": 0.190369555
+              "latency": 0.181847828
             },
             {
-              "latency": 0.17929416
+              "latency": 0.187949568
             },
             {
-              "latency": 0.186739068
+              "latency": 0.18186248
             },
             {
-              "latency": 0.184651014
+              "latency": 0.183303606
             },
             {
-              "latency": 0.183799811
+              "latency": 0.174862549
             },
             {
-              "latency": 0.189356855
+              "latency": 0.181118152
             },
             {
-              "latency": 0.19352993
+              "latency": 0.183914788
             },
             {
-              "latency": 0.184778849
+              "latency": 0.178158908
             },
             {
-              "latency": 0.19223893
+              "latency": 0.183066667
             },
             {
-              "latency": 0.189195866
+              "latency": 0.175014702
             },
             {
-              "latency": 0.184757286
+              "latency": 0.184654466
             },
             {
-              "latency": 0.191856286
+              "latency": 0.186914371
             },
             {
-              "latency": 0.182276109
+              "latency": 0.181869341
             },
             {
-              "latency": 0.192178893
+              "latency": 0.180213795
             },
             {
-              "latency": 0.194787832
+              "latency": 0.191900767
             },
             {
-              "latency": 0.193568496
+              "latency": 0.182962762
             },
             {
-              "latency": 0.184829939
+              "latency": 0.179281404
             },
             {
-              "latency": 0.18352955
+              "latency": 0.180927241
             },
             {
-              "latency": 0.186601817
+              "latency": 0.182391073
             },
             {
-              "latency": 0.188776197
+              "latency": 0.189878247
             },
             {
-              "latency": 0.18319026
+              "latency": 0.178276764
             },
             {
-              "latency": 0.190396565
+              "latency": 0.170420497
             },
             {
-              "latency": 0.180793266
+              "latency": 0.183710684
             },
             {
-              "latency": 0.189609173
+              "latency": 0.178480803
             },
             {
-              "latency": 0.18737005
+              "latency": 0.188770028
             },
             {
-              "latency": 0.191660098
+              "latency": 0.173850106
             },
             {
-              "latency": 0.180611805
+              "latency": 0.182092467
             },
             {
-              "latency": 0.189401186
+              "latency": 0.183777363
             },
             {
-              "latency": 0.193172233
+              "latency": 0.195848769
             },
             {
-              "latency": 0.181449265
+              "latency": 0.179103259
             },
             {
-              "latency": 0.192369124
+              "latency": 0.176819385
             },
             {
-              "latency": 0.190733356
+              "latency": 0.188458735
             },
             {
-              "latency": 0.189280974
+              "latency": 0.172762992
             },
             {
-              "latency": 0.182930565
+              "latency": 0.183516491
             },
             {
-              "latency": 0.193022756
+              "latency": 0.186102828
             },
             {
-              "latency": 0.186147802
+              "latency": 0.18945859
             },
             {
-              "latency": 0.187602504
+              "latency": 0.190674054
             },
             {
-              "latency": 0.186031488
+              "latency": 0.183234077
             },
             {
-              "latency": 0.186570516
+              "latency": 0.186169012
             },
             {
-              "latency": 0.192286486
+              "latency": 0.182367904
             },
             {
-              "latency": 0.181390233
+              "latency": 0.184483464
             },
             {
-              "latency": 0.177657325
+              "latency": 0.180705325
             },
             {
-              "latency": 0.192050131
+              "latency": 0.191584852
             },
             {
-              "latency": 0.1916059
+              "latency": 0.185044593
             },
             {
-              "latency": 0.184643452
+              "latency": 0.185673346
             },
             {
-              "latency": 0.185367246
+              "latency": 0.175625936
             },
             {
-              "latency": 0.184145772
+              "latency": 0.189736284
             },
             {
-              "latency": 0.190495395
+              "latency": 0.186979345
             },
             {
-              "latency": 0.191298168
+              "latency": 0.194053778
             },
             {
-              "latency": 0.189013052
+              "latency": 0.180845616
             },
             {
-              "latency": 0.191208059
+              "latency": 0.185695609
             },
             {
-              "latency": 0.184269597
+              "latency": 0.175515346
             },
             {
-              "latency": 0.183106917
+              "latency": 0.187091717
             },
             {
-              "latency": 0.187749555
+              "latency": 0.172400459
             },
             {
-              "latency": 0.184991296
+              "latency": 0.186562857
             },
             {
-              "latency": 0.193826954
+              "latency": 0.191054299
             },
             {
-              "latency": 0.178223782
+              "latency": 0.184247753
             },
             {
-              "latency": 0.190726535
+              "latency": 0.190812741
             },
             {
-              "latency": 0.179372425
+              "latency": 0.185561368
             },
             {
-              "latency": 0.172664516
+              "latency": 0.181875604
             },
             {
-              "latency": 0.184251488
+              "latency": 0.174936381
             },
             {
-              "latency": 0.190163511
+              "latency": 0.178272108
             },
             {
-              "latency": 0.195192407
+              "latency": 0.179083309
             },
             {
-              "latency": 0.192936307
+              "latency": 0.190291243
             },
             {
-              "latency": 0.183610187
+              "latency": 0.190077051
             },
             {
-              "latency": 0.178241551
+              "latency": 0.184209602
             },
             {
-              "latency": 0.192386722
+              "latency": 0.190896026
             },
             {
-              "latency": 0.193685116
+              "latency": 0.182914324
             },
             {
-              "latency": 0.184594255
+              "latency": 0.186861464
             },
             {
-              "latency": 0.172252605
+              "latency": 0.184629451
             },
             {
-              "latency": 0.186092129
+              "latency": 0.187145178
             },
             {
-              "latency": 0.178878851
+              "latency": 0.170617306
             },
             {
-              "latency": 0.187011399
+              "latency": 0.194371634
             },
             {
-              "latency": 0.184491136
+              "latency": 0.188509371
             },
             {
-              "latency": 0.176620408
+              "latency": 0.191691508
             },
             {
-              "latency": 0.183093737
+              "latency": 0.189215559
             },
             {
-              "latency": 0.192989067
+              "latency": 0.190942937
             },
             {
-              "latency": 0.188982369
+              "latency": 0.18028766
             },
             {
-              "latency": 0.18714761
+              "latency": 0.186049459
             },
             {
-              "latency": 0.191018486
+              "latency": 0.188726683
             },
             {
-              "latency": 0.186367345
+              "latency": 0.180207483
             },
             {
-              "latency": 0.195896297
+              "latency": 0.185711698
             },
             {
-              "latency": 0.177907831
+              "latency": 0.191128837
             },
             {
-              "latency": 0.193055878
+              "latency": 0.188282009
             },
             {
-              "latency": 0.18566966
+              "latency": 0.186915989
             },
             {
-              "latency": 0.186067086
+              "latency": 0.185485628
             },
             {
-              "latency": 0.191816208
+              "latency": 0.173941686
             },
             {
-              "latency": 0.184365671
+              "latency": 0.186369095
             }
           ],
           "implementation": "https",
@@ -2757,304 +2757,304 @@
         {
           "result": [
             {
-              "latency": 0.376317157
+              "latency": 0.289577521
             },
             {
-              "latency": 0.306057682
+              "latency": 0.384452868
             },
             {
-              "latency": 0.371006317
+              "latency": 0.30751613
             },
             {
-              "latency": 0.322710859
+              "latency": 0.290502599
             },
             {
-              "latency": 0.382943603
+              "latency": 0.290737828
             },
             {
-              "latency": 0.371200558
+              "latency": 0.36602199
             },
             {
-              "latency": 0.31244236
+              "latency": 0.313876179
             },
             {
-              "latency": 0.305396238
+              "latency": 0.318738273
             },
             {
-              "latency": 0.31479173
+              "latency": 0.321072125
             },
             {
-              "latency": 0.391939558
+              "latency": 0.303809189
             },
             {
-              "latency": 0.313222323
+              "latency": 0.352710726
             },
             {
-              "latency": 0.302328505
+              "latency": 0.374128308
             },
             {
-              "latency": 0.309499095
+              "latency": 0.319659654
             },
             {
-              "latency": 0.322475989
+              "latency": 0.306006417
             },
             {
-              "latency": 0.380464776
+              "latency": 0.295462409
             },
             {
-              "latency": 0.322381975
+              "latency": 0.371456461
             },
             {
-              "latency": 0.367018623
+              "latency": 0.304988209
             },
             {
-              "latency": 0.365384292
+              "latency": 0.317200927
             },
             {
-              "latency": 0.312495026
+              "latency": 0.308922747
             },
             {
-              "latency": 0.316982439
+              "latency": 0.368628062
             },
             {
-              "latency": 0.382773901
+              "latency": 0.307318049
             },
             {
-              "latency": 0.310454677
+              "latency": 0.319235816
             },
             {
-              "latency": 0.307204646
+              "latency": 0.373496217
             },
             {
-              "latency": 0.322141504
+              "latency": 0.316234275
             },
             {
-              "latency": 0.385754359
+              "latency": 0.365697355
             },
             {
-              "latency": 0.392232399
+              "latency": 0.303919367
             },
             {
-              "latency": 0.317533688
+              "latency": 0.376961001
             },
             {
-              "latency": 0.370203763
+              "latency": 0.382052531
             },
             {
-              "latency": 0.304397095
+              "latency": 0.302465418
             },
             {
-              "latency": 0.368483721
+              "latency": 0.385127326
             },
             {
-              "latency": 0.323683721
+              "latency": 0.297171282
             },
             {
-              "latency": 0.306611966
+              "latency": 0.306801807
             },
             {
-              "latency": 0.324728695
+              "latency": 0.306105904
             },
             {
-              "latency": 0.304455114
+              "latency": 0.379784894
             },
             {
-              "latency": 0.362719075
+              "latency": 0.393279411
             },
             {
-              "latency": 0.310731453
+              "latency": 0.373152379
             },
             {
-              "latency": 0.374273606
+              "latency": 0.305927101
             },
             {
-              "latency": 0.321010151
+              "latency": 0.310558874
             },
             {
-              "latency": 0.300020537
+              "latency": 0.31496368
             },
             {
-              "latency": 0.303348512
+              "latency": 0.365292159
             },
             {
-              "latency": 0.320662076
+              "latency": 0.285743588
             },
             {
-              "latency": 0.375507086
+              "latency": 0.319315671
             },
             {
-              "latency": 0.376148002
+              "latency": 0.30240055
             },
             {
-              "latency": 0.367309344
+              "latency": 0.295049617
             },
             {
-              "latency": 0.31412059
+              "latency": 0.313397577
             },
             {
-              "latency": 0.295873942
+              "latency": 0.368321984
             },
             {
-              "latency": 0.310184489
+              "latency": 0.293468869
             },
             {
-              "latency": 0.30114126
+              "latency": 0.371563868
             },
             {
-              "latency": 0.305295443
+              "latency": 0.299354835
             },
             {
-              "latency": 0.315479252
+              "latency": 0.295214189
             },
             {
-              "latency": 0.392413074
+              "latency": 0.312968884
             },
             {
-              "latency": 0.316496871
+              "latency": 0.304038581
             },
             {
-              "latency": 0.382461403
+              "latency": 0.323723195
             },
             {
-              "latency": 0.365227582
+              "latency": 0.314332754
             },
             {
-              "latency": 0.355268542
+              "latency": 0.381484044
             },
             {
-              "latency": 0.383690159
+              "latency": 0.313167098
             },
             {
-              "latency": 0.309240762
+              "latency": 0.316335619
             },
             {
-              "latency": 0.306509242
+              "latency": 0.326037877
             },
             {
-              "latency": 0.38330132
+              "latency": 0.303201454
             },
             {
-              "latency": 0.309438074
+              "latency": 0.370303577
             },
             {
-              "latency": 0.378588582
+              "latency": 0.386071755
             },
             {
-              "latency": 0.366827452
+              "latency": 0.303670647
             },
             {
-              "latency": 0.315929131
+              "latency": 0.321033003
             },
             {
-              "latency": 0.297017123
+              "latency": 0.311005635
             },
             {
-              "latency": 0.368913557
+              "latency": 0.382446689
             },
             {
-              "latency": 0.316837176
+              "latency": 0.369878315
             },
             {
-              "latency": 0.353323857
+              "latency": 0.314845678
             },
             {
-              "latency": 0.301625424
+              "latency": 0.310575883
             },
             {
-              "latency": 0.387999799
+              "latency": 0.304119496
             },
             {
-              "latency": 0.306238546
+              "latency": 0.318896805
             },
             {
-              "latency": 0.293840581
+              "latency": 0.369566758
             },
             {
-              "latency": 0.322324953
+              "latency": 0.369833566
             },
             {
-              "latency": 0.298316945
+              "latency": 0.323679367
             },
             {
-              "latency": 0.306935389
+              "latency": 0.307203085
             },
             {
-              "latency": 0.317264648
+              "latency": 0.303532745
             },
             {
-              "latency": 0.312872275
+              "latency": 0.356169641
             },
             {
-              "latency": 0.372826689
+              "latency": 0.305989521
             },
             {
-              "latency": 0.366174549
+              "latency": 0.308841965
             },
             {
-              "latency": 0.380254827
+              "latency": 0.313622592
             },
             {
-              "latency": 0.384410085
+              "latency": 0.363473131
             },
             {
-              "latency": 0.314303694
+              "latency": 0.308826991
             },
             {
-              "latency": 0.301084158
+              "latency": 0.372788505
             },
             {
-              "latency": 0.370230686
+              "latency": 0.367412257
             },
             {
-              "latency": 0.303849343
+              "latency": 0.296366174
             },
             {
-              "latency": 0.363079228
+              "latency": 0.325929577
             },
             {
-              "latency": 0.374156599
+              "latency": 0.383467667
             },
             {
-              "latency": 0.370801659
+              "latency": 0.318811548
             },
             {
-              "latency": 0.319587912
+              "latency": 0.310262664
             },
             {
-              "latency": 0.318035087
+              "latency": 0.389580166
             },
             {
-              "latency": 0.381502162
+              "latency": 0.371747563
             },
             {
-              "latency": 0.322719002
+              "latency": 0.309469224
             },
             {
-              "latency": 0.312373382
+              "latency": 0.30714232
             },
             {
-              "latency": 0.389811596
+              "latency": 0.378455078
             },
             {
-              "latency": 0.311728363
+              "latency": 0.311967197
             },
             {
-              "latency": 0.315704929
+              "latency": 0.381624383
             },
             {
-              "latency": 0.375620709
+              "latency": 0.307674442
             },
             {
-              "latency": 0.382014545
+              "latency": 0.361246875
             },
             {
-              "latency": 0.314126693
+              "latency": 0.313715734
             },
             {
-              "latency": 0.318440181
+              "latency": 0.307625495
             },
             {
-              "latency": 0.302484761
+              "latency": 0.320910832
             }
           ],
           "implementation": "go-libp2p",
@@ -3064,304 +3064,304 @@
         {
           "result": [
             {
-              "latency": 0.18459799
+              "latency": 0.182958473
             },
             {
-              "latency": 0.185395657
+              "latency": 0.189361133
             },
             {
-              "latency": 0.196001093
+              "latency": 0.195037219
             },
             {
-              "latency": 0.18803513
+              "latency": 0.188201081
             },
             {
-              "latency": 0.188890528
+              "latency": 0.18412952
             },
             {
-              "latency": 0.189242405
+              "latency": 0.198430651
             },
             {
-              "latency": 0.186821505
+              "latency": 0.180873473
             },
             {
-              "latency": 0.19786605
+              "latency": 0.187921587
             },
             {
-              "latency": 0.182365512
+              "latency": 0.181361154
             },
             {
-              "latency": 0.193277067
+              "latency": 0.197423188
             },
             {
-              "latency": 0.19593583
+              "latency": 0.195502414
             },
             {
-              "latency": 0.195189427
+              "latency": 0.183345948
             },
             {
-              "latency": 0.184202604
+              "latency": 0.191418268
             },
             {
-              "latency": 0.193460842
+              "latency": 0.191597335
             },
             {
-              "latency": 0.191349363
+              "latency": 0.200324347
             },
             {
-              "latency": 0.191023173
+              "latency": 0.193564213
             },
             {
-              "latency": 0.189019516
+              "latency": 0.193527703
             },
             {
-              "latency": 0.190223488
+              "latency": 0.188070158
             },
             {
-              "latency": 0.197302975
+              "latency": 0.176417303
             },
             {
-              "latency": 0.197742084
+              "latency": 0.190908902
             },
             {
-              "latency": 0.185972929
+              "latency": 0.200549509
             },
             {
-              "latency": 0.192939091
+              "latency": 0.184071063
             },
             {
-              "latency": 0.186962865
+              "latency": 0.19302923
             },
             {
-              "latency": 0.195953848
+              "latency": 0.183813684
             },
             {
-              "latency": 0.194447799
+              "latency": 0.186803316
             },
             {
-              "latency": 0.195343821
+              "latency": 0.177162756
             },
             {
-              "latency": 0.178995951
+              "latency": 0.178840142
             },
             {
-              "latency": 0.19379857
+              "latency": 0.194504819
             },
             {
-              "latency": 0.192325996
+              "latency": 0.175326511
             },
             {
-              "latency": 0.191343916
+              "latency": 0.183520642
             },
             {
-              "latency": 0.184999077
+              "latency": 0.193498312
             },
             {
-              "latency": 0.180677926
+              "latency": 0.186887087
             },
             {
-              "latency": 0.195227463
+              "latency": 0.196202187
             },
             {
-              "latency": 0.18811245
+              "latency": 0.185611478
             },
             {
-              "latency": 0.198817861
+              "latency": 0.189351912
             },
             {
-              "latency": 0.194008737
+              "latency": 0.188757238
             },
             {
-              "latency": 0.19505053
+              "latency": 0.177286559
             },
             {
-              "latency": 0.191672474
+              "latency": 0.196520224
             },
             {
-              "latency": 0.192448807
+              "latency": 0.189745858
             },
             {
-              "latency": 0.192557627
+              "latency": 0.185918145
             },
             {
-              "latency": 0.198582017
+              "latency": 0.194863941
             },
             {
-              "latency": 0.183451701
+              "latency": 0.183645893
             },
             {
-              "latency": 0.195071134
+              "latency": 0.192763469
             },
             {
-              "latency": 0.187093376
+              "latency": 0.183558825
             },
             {
-              "latency": 0.192748342
+              "latency": 0.189094701
             },
             {
-              "latency": 0.194477518
+              "latency": 0.185596471
             },
             {
-              "latency": 0.189969332
+              "latency": 0.187263973
             },
             {
-              "latency": 0.190898593
+              "latency": 0.191596401
             },
             {
-              "latency": 4.380195799
+              "latency": 0.190660495
             },
             {
-              "latency": 0.192346761
+              "latency": 0.199026774
             },
             {
-              "latency": 0.193775336
+              "latency": 0.18309638
             },
             {
-              "latency": 0.188028174
+              "latency": 0.187825658
             },
             {
-              "latency": 0.189799884
+              "latency": 0.18197498
             },
             {
-              "latency": 0.19453083
+              "latency": 0.18835285
             },
             {
-              "latency": 0.190743583
+              "latency": 0.185251133
             },
             {
-              "latency": 0.188161168
+              "latency": 0.175428141
             },
             {
-              "latency": 0.190660841
+              "latency": 0.18696565
             },
             {
-              "latency": 0.185695763
+              "latency": 0.191845543
             },
             {
-              "latency": 0.191936496
+              "latency": 0.191912189
             },
             {
-              "latency": 0.184785452
+              "latency": 0.185672716
             },
             {
-              "latency": 0.190590851
+              "latency": 0.195823025
             },
             {
-              "latency": 0.180526757
+              "latency": 0.185169273
             },
             {
-              "latency": 0.182705083
+              "latency": 0.196539549
             },
             {
-              "latency": 0.189903952
+              "latency": 0.185884659
             },
             {
-              "latency": 0.190079205
+              "latency": 0.188644702
             },
             {
-              "latency": 0.192051443
+              "latency": 0.192997643
             },
             {
-              "latency": 0.196812704
+              "latency": 0.19411548
             },
             {
-              "latency": 0.187464296
+              "latency": 0.196056722
             },
             {
-              "latency": 0.189166966
+              "latency": 0.185451183
             },
             {
-              "latency": 0.187600151
+              "latency": 0.196923769
             },
             {
-              "latency": 0.187550946
+              "latency": 0.192950542
             },
             {
-              "latency": 0.183998533
+              "latency": 0.194304798
             },
             {
-              "latency": 0.183971675
+              "latency": 0.197735232
             },
             {
-              "latency": 0.188934445
+              "latency": 0.189853186
             },
             {
-              "latency": 0.191226129
+              "latency": 0.184630798
             },
             {
-              "latency": 0.193838859
+              "latency": 0.183459399
             },
             {
-              "latency": 0.184236094
+              "latency": 0.19148805
             },
             {
-              "latency": 0.19477038
+              "latency": 0.200339502
             },
             {
-              "latency": 0.18724714
+              "latency": 0.178182872
             },
             {
-              "latency": 0.187968977
+              "latency": 0.183074151
             },
             {
-              "latency": 0.183836416
+              "latency": 0.186197812
             },
             {
-              "latency": 0.183600203
+              "latency": 0.191331743
             },
             {
-              "latency": 0.194291511
+              "latency": 0.186807777
             },
             {
-              "latency": 0.182355171
+              "latency": 0.190078538
             },
             {
-              "latency": 0.188816034
+              "latency": 0.189798638
             },
             {
-              "latency": 0.191630685
+              "latency": 0.19715514
             },
             {
-              "latency": 0.177400691
+              "latency": 0.186849154
             },
             {
-              "latency": 0.188934558
+              "latency": 0.189439379
             },
             {
-              "latency": 0.185439673
+              "latency": 0.183044673
             },
             {
-              "latency": 0.186015979
+              "latency": 0.187636978
             },
             {
-              "latency": 0.198036308
+              "latency": 0.192537972
             },
             {
-              "latency": 0.198119648
+              "latency": 0.183134445
             },
             {
-              "latency": 0.190713888
+              "latency": 0.188061502
             },
             {
-              "latency": 0.185456165
+              "latency": 0.191357454
             },
             {
-              "latency": 0.194871408
+              "latency": 0.187163273
             },
             {
-              "latency": 0.195810787
+              "latency": 0.186384604
             },
             {
-              "latency": 0.19079062
+              "latency": 0.191371101
             },
             {
-              "latency": 0.181880737
+              "latency": 0.191414601
             },
             {
-              "latency": 0.192683653
+              "latency": 0.191619582
             },
             {
-              "latency": 0.185732271
+              "latency": 0.191504948
             }
           ],
           "implementation": "go-libp2p",
@@ -3371,304 +3371,304 @@
         {
           "result": [
             {
-              "latency": 0.374807067
+              "latency": 0.368517716
             },
             {
-              "latency": 0.374259564
+              "latency": 0.318717987
             },
             {
-              "latency": 0.312939902
+              "latency": 0.32589302
             },
             {
-              "latency": 0.359249902
+              "latency": 0.308921096
             },
             {
-              "latency": 0.307032956
+              "latency": 0.325258224
             },
             {
-              "latency": 0.324519744
+              "latency": 0.302266962
             },
             {
-              "latency": 0.316593986
+              "latency": 0.311370516
             },
             {
-              "latency": 0.306647122
+              "latency": 0.328976503
             },
             {
-              "latency": 0.323329378
+              "latency": 0.322396874
             },
             {
-              "latency": 0.322298001
+              "latency": 0.304154463
             },
             {
-              "latency": 0.379261346
+              "latency": 0.32063917
             },
             {
-              "latency": 0.305279711
+              "latency": 0.299192381
             },
             {
-              "latency": 0.36685664
+              "latency": 0.308761179
             },
             {
-              "latency": 0.360760132
+              "latency": 0.309606491
             },
             {
-              "latency": 0.361958065
+              "latency": 0.298457271
             },
             {
-              "latency": 0.306196239
+              "latency": 0.351387627
             },
             {
-              "latency": 0.310889814
+              "latency": 0.29978078
             },
             {
-              "latency": 0.298184875
+              "latency": 0.317515355
             },
             {
-              "latency": 0.390102105
+              "latency": 0.350023838
             },
             {
-              "latency": 0.302551415
+              "latency": 0.367833216
             },
             {
-              "latency": 0.390765534
+              "latency": 0.359049792
             },
             {
-              "latency": 0.385131715
+              "latency": 0.385052976
             },
             {
-              "latency": 0.309707407
+              "latency": 0.299250786
             },
             {
-              "latency": 0.377401682
+              "latency": 0.314131963
             },
             {
-              "latency": 0.322871755
+              "latency": 0.383580021
             },
             {
-              "latency": 0.361493688
+              "latency": 0.372126725
             },
             {
-              "latency": 0.309233972
+              "latency": 0.352952364
             },
             {
-              "latency": 0.37082291
+              "latency": 0.321086347
             },
             {
-              "latency": 0.306732215
+              "latency": 0.314673125
             },
             {
-              "latency": 0.325476359
+              "latency": 0.301935145
             },
             {
-              "latency": 0.316628309
+              "latency": 0.303397145
             },
             {
-              "latency": 0.300713991
+              "latency": 0.321661166
             },
             {
-              "latency": 0.371440484
+              "latency": 0.301250174
             },
             {
-              "latency": 0.316708978
+              "latency": 0.371685361
             },
             {
-              "latency": 0.372238331
+              "latency": 0.385406347
             },
             {
-              "latency": 0.315972468
+              "latency": 0.382200858
             },
             {
-              "latency": 0.320223145
+              "latency": 0.307068829
             },
             {
-              "latency": 0.380184173
+              "latency": 0.311388225
             },
             {
-              "latency": 0.370825214
+              "latency": 0.309018064
             },
             {
-              "latency": 0.383781226
+              "latency": 0.36365507
             },
             {
-              "latency": 0.356976784
+              "latency": 0.31003429
             },
             {
-              "latency": 0.31347973
+              "latency": 0.315996377
             },
             {
-              "latency": 0.322337233
+              "latency": 0.320629686
             },
             {
-              "latency": 0.314891263
+              "latency": 0.372088642
             },
             {
-              "latency": 0.373959729
+              "latency": 0.368889154
             },
             {
-              "latency": 0.3046607
+              "latency": 0.298916425
             },
             {
-              "latency": 0.327652602
+              "latency": 0.316564686
             },
             {
-              "latency": 0.367226073
+              "latency": 0.379184281
             },
             {
-              "latency": 0.348002216
+              "latency": 0.36216359
             },
             {
-              "latency": 0.321017954
+              "latency": 0.373171052
             },
             {
-              "latency": 0.312083731
+              "latency": 0.304185891
             },
             {
-              "latency": 0.369931746
+              "latency": 0.361006911
             },
             {
-              "latency": 0.318498045
+              "latency": 0.369289781
             },
             {
-              "latency": 0.312247021
+              "latency": 0.369274648
             },
             {
-              "latency": 0.322443303
+              "latency": 0.301329772
             },
             {
-              "latency": 0.315057166
+              "latency": 0.323458234
             },
             {
-              "latency": 0.365983797
+              "latency": 0.311571403
             },
             {
-              "latency": 0.381319167
+              "latency": 0.311461612
             },
             {
-              "latency": 0.34457003
+              "latency": 0.302984831
             },
             {
-              "latency": 0.314634586
+              "latency": 0.367194488
             },
             {
-              "latency": 0.30172012
+              "latency": 0.311944592
             },
             {
-              "latency": 0.304371267
+              "latency": 0.325124945
             },
             {
-              "latency": 0.326793879
+              "latency": 0.380029592
             },
             {
-              "latency": 0.307221186
+              "latency": 0.386823145
             },
             {
-              "latency": 0.361344547
+              "latency": 0.372508642
             },
             {
-              "latency": 0.359921782
+              "latency": 0.30996837
             },
             {
-              "latency": 0.308853834
+              "latency": 0.363276279
             },
             {
-              "latency": 0.377802618
+              "latency": 0.365438887
             },
             {
-              "latency": 0.320152763
+              "latency": 0.371389979
             },
             {
-              "latency": 0.319787748
+              "latency": 0.357614032
             },
             {
-              "latency": 0.385121005
+              "latency": 0.347723268
             },
             {
-              "latency": 0.324511702
+              "latency": 0.308595739
             },
             {
-              "latency": 0.318074667
+              "latency": 0.311006579
             },
             {
-              "latency": 0.355704786
+              "latency": 0.299063226
             },
             {
-              "latency": 0.36599909
+              "latency": 0.370172986
             },
             {
-              "latency": 0.313563125
+              "latency": 0.324423791
             },
             {
-              "latency": 0.294834549
+              "latency": 0.384458421
             },
             {
-              "latency": 0.32017521
+              "latency": 0.313100909
             },
             {
-              "latency": 0.388315765
+              "latency": 0.307969298
             },
             {
-              "latency": 0.31771058
+              "latency": 0.369192997
             },
             {
-              "latency": 0.300520732
+              "latency": 0.316820496
             },
             {
-              "latency": 0.315472005
+              "latency": 0.299058219
             },
             {
-              "latency": 0.312797001
+              "latency": 0.308979152
             },
             {
-              "latency": 0.299452776
+              "latency": 0.351172373
             },
             {
-              "latency": 0.321465302
+              "latency": 0.320971342
             },
             {
-              "latency": 0.311021185
+              "latency": 0.306018079
             },
             {
-              "latency": 0.311042426
+              "latency": 0.305490471
             },
             {
-              "latency": 0.313078597
+              "latency": 0.326811612
             },
             {
-              "latency": 0.318201546
+              "latency": 0.348255858
             },
             {
-              "latency": 0.322313895
+              "latency": 0.379079876
             },
             {
-              "latency": 0.310776704
+              "latency": 0.321956638
             },
             {
-              "latency": 0.301867679
+              "latency": 0.287521143
             },
             {
-              "latency": 0.316292779
+              "latency": 0.308079329
             },
             {
-              "latency": 0.305750114
+              "latency": 0.317728013
             },
             {
-              "latency": 0.363610344
+              "latency": 0.367006792
             },
             {
-              "latency": 0.375510697
+              "latency": 0.31249577
             },
             {
-              "latency": 0.373411509
+              "latency": 0.36352541
             },
             {
-              "latency": 0.30680601
+              "latency": 0.358886553
             },
             {
-              "latency": 0.320114241
+              "latency": 0.313059549
             },
             {
-              "latency": 0.369615994
+              "latency": 0.384686398
             }
           ],
           "implementation": "go-libp2p",
@@ -3678,304 +3678,304 @@
         {
           "result": [
             {
-              "latency": 0.196620692
+              "latency": 0.188428849
             },
             {
-              "latency": 0.185999633
+              "latency": 0.186858563
             },
             {
-              "latency": 0.183760526
+              "latency": 0.17304416
             },
             {
-              "latency": 0.191757043
+              "latency": 0.19777017
             },
             {
-              "latency": 0.192498279
+              "latency": 0.189751826
             },
             {
-              "latency": 0.19122281
+              "latency": 0.183522177
             },
             {
-              "latency": 0.187209843
+              "latency": 0.195904562
             },
             {
-              "latency": 0.190032811
+              "latency": 0.181440796
             },
             {
-              "latency": 0.200740452
+              "latency": 0.195886
             },
             {
-              "latency": 0.185890531
+              "latency": 0.193259166
             },
             {
-              "latency": 0.187034573
+              "latency": 0.186179635
             },
             {
-              "latency": 0.178578857
+              "latency": 0.186652033
             },
             {
-              "latency": 0.192287145
+              "latency": 0.182784682
             },
             {
-              "latency": 0.190748458
+              "latency": 0.197834601
             },
             {
-              "latency": 0.185887005
+              "latency": 0.18770541
             },
             {
-              "latency": 0.185883821
+              "latency": 0.188713884
             },
             {
-              "latency": 0.188081622
+              "latency": 0.184780281
             },
             {
-              "latency": 0.188146091
+              "latency": 0.193445728
             },
             {
-              "latency": 0.196414865
+              "latency": 0.189776589
             },
             {
-              "latency": 0.186037242
+              "latency": 0.183222834
             },
             {
-              "latency": 0.186767458
+              "latency": 0.189978167
             },
             {
-              "latency": 0.191531008
+              "latency": 0.193813516
             },
             {
-              "latency": 0.182928327
+              "latency": 0.189500194
             },
             {
-              "latency": 0.195184985
+              "latency": 0.195868915
             },
             {
-              "latency": 0.200388548
+              "latency": 0.18209057
             },
             {
-              "latency": 0.191591117
+              "latency": 0.186985102
             },
             {
-              "latency": 0.193895551
+              "latency": 0.183619756
             },
             {
-              "latency": 0.187002339
+              "latency": 0.188050634
             },
             {
-              "latency": 0.189109685
+              "latency": 0.187817964
             },
             {
-              "latency": 0.20045243
+              "latency": 0.193379366
             },
             {
-              "latency": 0.187288408
+              "latency": 0.196129335
             },
             {
-              "latency": 0.18885219
+              "latency": 0.186507604
             },
             {
-              "latency": 0.198171782
+              "latency": 0.184927998
             },
             {
-              "latency": 0.193152243
+              "latency": 0.199747827
             },
             {
-              "latency": 0.192433855
+              "latency": 0.178936387
             },
             {
-              "latency": 0.176876225
+              "latency": 0.174572775
             },
             {
-              "latency": 0.192069667
+              "latency": 0.187702892
             },
             {
-              "latency": 0.197400712
+              "latency": 0.195039955
             },
             {
-              "latency": 0.195686907
+              "latency": 0.189845437
             },
             {
-              "latency": 0.188248126
+              "latency": 0.178080565
             },
             {
-              "latency": 0.195470745
+              "latency": 0.186633755
             },
             {
-              "latency": 0.189194294
+              "latency": 0.184880033
             },
             {
-              "latency": 0.189135962
+              "latency": 0.188016127
             },
             {
-              "latency": 0.198183611
+              "latency": 0.200108502
             },
             {
-              "latency": 0.184908574
+              "latency": 0.187760169
             },
             {
-              "latency": 0.187499113
+              "latency": 0.18963453
             },
             {
-              "latency": 0.18706434
+              "latency": 0.189624809
             },
             {
-              "latency": 0.195673484
+              "latency": 0.191400292
             },
             {
-              "latency": 0.190705484
+              "latency": 0.17760617
             },
             {
-              "latency": 0.18913505
+              "latency": 0.182518252
             },
             {
-              "latency": 0.194545787
+              "latency": 0.199599719
             },
             {
-              "latency": 0.194063675
+              "latency": 0.198196665
             },
             {
-              "latency": 0.185765357
+              "latency": 0.189726164
             },
             {
-              "latency": 0.19575294
+              "latency": 0.187554973
             },
             {
-              "latency": 0.190158784
+              "latency": 0.190326455
             },
             {
-              "latency": 0.192472982
+              "latency": 0.181765372
             },
             {
-              "latency": 0.186928858
+              "latency": 0.193258602
             },
             {
-              "latency": 0.192361228
+              "latency": 0.187774588
             },
             {
-              "latency": 0.19602117
+              "latency": 0.186940486
             },
             {
-              "latency": 0.200513982
+              "latency": 0.198767915
             },
             {
-              "latency": 0.180614561
+              "latency": 0.188548801
             },
             {
-              "latency": 0.188091232
+              "latency": 0.184534349
             },
             {
-              "latency": 0.18159724
+              "latency": 0.189802161
             },
             {
-              "latency": 0.186541406
+              "latency": 0.188157098
             },
             {
-              "latency": 0.1897679
+              "latency": 0.186544882
             },
             {
-              "latency": 0.198226696
+              "latency": 0.182077553
             },
             {
-              "latency": 0.192550144
+              "latency": 0.182955477
             },
             {
-              "latency": 0.185757076
+              "latency": 0.187910264
             },
             {
-              "latency": 0.183500851
+              "latency": 0.189486532
             },
             {
-              "latency": 0.185132907
+              "latency": 0.194569875
             },
             {
-              "latency": 0.194121619
+              "latency": 0.186011661
             },
             {
-              "latency": 0.188769913
+              "latency": 0.18556475
             },
             {
-              "latency": 0.188872481
+              "latency": 0.195526068
             },
             {
-              "latency": 0.188586828
+              "latency": 0.197660191
             },
             {
-              "latency": 0.196366904
+              "latency": 0.18005827
             },
             {
-              "latency": 0.185812387
+              "latency": 0.196106268
             },
             {
-              "latency": 0.190578305
+              "latency": 0.186785056
             },
             {
-              "latency": 0.20088663
+              "latency": 0.18951152
             },
             {
-              "latency": 0.189074246
+              "latency": 0.195867429
             },
             {
-              "latency": 0.186800658
+              "latency": 0.185794325
             },
             {
-              "latency": 0.190384793
+              "latency": 0.185817339
             },
             {
-              "latency": 0.191895166
+              "latency": 0.199321902
             },
             {
-              "latency": 0.18824756
+              "latency": 0.194652021
             },
             {
-              "latency": 0.187374645
+              "latency": 0.194905457
             },
             {
-              "latency": 0.186648579
+              "latency": 0.1784995
             },
             {
-              "latency": 0.18374025
+              "latency": 0.18188193
             },
             {
-              "latency": 0.193660625
+              "latency": 0.195240273
             },
             {
-              "latency": 0.188952514
+              "latency": 0.190289706
             },
             {
-              "latency": 0.198427537
+              "latency": 0.197942718
             },
             {
-              "latency": 0.190624352
+              "latency": 0.196215727
             },
             {
-              "latency": 0.190610929
+              "latency": 0.190414909
             },
             {
-              "latency": 0.196313032
+              "latency": 0.185995207
             },
             {
-              "latency": 0.197518607
+              "latency": 0.187609482
             },
             {
-              "latency": 0.19078892
+              "latency": 0.177282799
             },
             {
-              "latency": 0.193349048
+              "latency": 0.178595967
             },
             {
-              "latency": 0.187446995
+              "latency": 0.18615884
             },
             {
-              "latency": 0.195072376
+              "latency": 0.192241211
             },
             {
-              "latency": 0.198266569
+              "latency": 0.188350119
             },
             {
-              "latency": 0.176649628
+              "latency": 0.182063293
             },
             {
-              "latency": 0.187666865
+              "latency": 0.193673175
             }
           ],
           "implementation": "go-libp2p",
@@ -3985,304 +3985,304 @@
         {
           "result": [
             {
-              "latency": 0.375144926
+              "latency": 0.374512981
             },
             {
-              "latency": 0.365778564
+              "latency": 0.292296213
             },
             {
-              "latency": 0.392624919
+              "latency": 0.38849154
             },
             {
-              "latency": 0.312743939
+              "latency": 0.308047894
             },
             {
-              "latency": 0.36525608
+              "latency": 0.310817799
             },
             {
-              "latency": 0.311740815
+              "latency": 0.288587049
             },
             {
-              "latency": 0.319389212
+              "latency": 0.292249724
             },
             {
-              "latency": 0.36953231
+              "latency": 0.37920568
             },
             {
-              "latency": 0.3281115
+              "latency": 0.383359933
             },
             {
-              "latency": 0.311122979
+              "latency": 0.377362679
             },
             {
-              "latency": 0.38391715
+              "latency": 0.290936158
             },
             {
-              "latency": 0.314881956
+              "latency": 0.352072412
             },
             {
-              "latency": 0.315565435
+              "latency": 0.377338259
             },
             {
-              "latency": 0.375084466
+              "latency": 0.377092278
             },
             {
-              "latency": 0.305129394
+              "latency": 0.306536692
             },
             {
-              "latency": 0.299137835
+              "latency": 0.31923111
             },
             {
-              "latency": 0.320030178
+              "latency": 0.378413739
             },
             {
-              "latency": 0.308719376
+              "latency": 0.386071407
             },
             {
-              "latency": 0.372604871
+              "latency": 0.3827019
             },
             {
-              "latency": 0.295132457
+              "latency": 0.382724009
             },
             {
-              "latency": 0.305466681
+              "latency": 0.368082074
             },
             {
-              "latency": 0.380717838
+              "latency": 0.302116563
             },
             {
-              "latency": 0.293780755
+              "latency": 0.364674667
             },
             {
-              "latency": 0.321136067
+              "latency": 0.363884673
             },
             {
-              "latency": 0.324875546
+              "latency": 0.296975931
             },
             {
-              "latency": 0.317895578
+              "latency": 0.306353336
             },
             {
-              "latency": 0.320745576
+              "latency": 0.354784709
             },
             {
-              "latency": 0.306861105
+              "latency": 0.319876963
             },
             {
-              "latency": 0.374810412
+              "latency": 0.366705531
             },
             {
-              "latency": 0.316579673
+              "latency": 0.374040938
             },
             {
-              "latency": 0.310426278
+              "latency": 0.295687156
             },
             {
-              "latency": 0.308815659
+              "latency": 0.352701717
             },
             {
-              "latency": 0.311649087
+              "latency": 0.294666249
             },
             {
-              "latency": 0.378426948
+              "latency": 0.285808999
             },
             {
-              "latency": 0.392215717
+              "latency": 0.371735982
             },
             {
-              "latency": 0.365561236
+              "latency": 0.374304806
             },
             {
-              "latency": 0.361255594
+              "latency": 0.313200734
             },
             {
-              "latency": 0.322731313
+              "latency": 0.310590649
             },
             {
-              "latency": 0.316359774
+              "latency": 0.344858839
             },
             {
-              "latency": 0.313956376
+              "latency": 0.286520161
             },
             {
-              "latency": 0.308169296
+              "latency": 0.294456792
             },
             {
-              "latency": 0.316855409
+              "latency": 0.355134708
             },
             {
-              "latency": 0.31435849
+              "latency": 0.30812974
             },
             {
-              "latency": 0.378851435
+              "latency": 0.371427122
             },
             {
-              "latency": 0.315548884
+              "latency": 0.366389366
             },
             {
-              "latency": 0.358555657
+              "latency": 0.360498851
             },
             {
-              "latency": 0.382924976
+              "latency": 0.378724655
             },
             {
-              "latency": 0.315891622
+              "latency": 0.374409759
             },
             {
-              "latency": 0.378234852
+              "latency": 0.367599399
             },
             {
-              "latency": 0.361003556
+              "latency": 0.307336532
             },
             {
-              "latency": 0.387576649
+              "latency": 0.383457739
             },
             {
-              "latency": 0.382795871
+              "latency": 0.347933536
             },
             {
-              "latency": 0.373459938
+              "latency": 0.30778218
             },
             {
-              "latency": 0.378389278
+              "latency": 0.310653953
             },
             {
-              "latency": 0.383551989
+              "latency": 0.316051617
             },
             {
-              "latency": 0.307418163
+              "latency": 0.389489616
             },
             {
-              "latency": 0.383974463
+              "latency": 0.358060699
             },
             {
-              "latency": 0.308079098
+              "latency": 0.314737709
             },
             {
-              "latency": 0.36635653
+              "latency": 0.311694359
             },
             {
-              "latency": 0.377807789
+              "latency": 0.363779642
             },
             {
-              "latency": 0.378940313
+              "latency": 0.370014343
             },
             {
-              "latency": 0.304893981
+              "latency": 0.353503965
             },
             {
-              "latency": 0.324041352
+              "latency": 0.309759769
             },
             {
-              "latency": 0.35270859
+              "latency": 0.320593889
             },
             {
-              "latency": 0.29366276
+              "latency": 0.387294982
             },
             {
-              "latency": 0.382129049
+              "latency": 0.382181428
             },
             {
-              "latency": 0.38799702
+              "latency": 0.36948285
             },
             {
-              "latency": 0.384028647
+              "latency": 0.377059273
             },
             {
-              "latency": 0.370623515
+              "latency": 0.361921023
             },
             {
-              "latency": 0.380036665
+              "latency": 0.367419611
             },
             {
-              "latency": 0.311771191
+              "latency": 0.383040067
             },
             {
-              "latency": 0.369208556
+              "latency": 0.319594448
             },
             {
-              "latency": 0.304924313
+              "latency": 0.285380567
             },
             {
-              "latency": 0.385444229
+              "latency": 0.366245826
             },
             {
-              "latency": 0.305460765
+              "latency": 0.305307861
             },
             {
-              "latency": 0.374515765
+              "latency": 0.35207518
             },
             {
-              "latency": 0.317470977
+              "latency": 0.386951467
             },
             {
-              "latency": 0.374709628
+              "latency": 0.323495504
             },
             {
-              "latency": 0.354798833
+              "latency": 0.320296114
             },
             {
-              "latency": 0.365318581
+              "latency": 0.355072135
             },
             {
-              "latency": 0.377419131
+              "latency": 0.364918579
             },
             {
-              "latency": 0.311937899
+              "latency": 0.312238197
             },
             {
-              "latency": 0.315817419
+              "latency": 0.303328333
             },
             {
-              "latency": 0.311045539
+              "latency": 0.381194739
             },
             {
-              "latency": 0.359639441
+              "latency": 0.374157078
             },
             {
-              "latency": 0.36589914
+              "latency": 0.38071719
             },
             {
-              "latency": 0.291778956
+              "latency": 0.316337599
             },
             {
-              "latency": 0.288599933
+              "latency": 0.372786173
             },
             {
-              "latency": 0.324092583
+              "latency": 0.366795582
             },
             {
-              "latency": 0.319516178
+              "latency": 0.304980308
             },
             {
-              "latency": 0.307812499
+              "latency": 0.307439488
             },
             {
-              "latency": 0.304748825
+              "latency": 0.35642762
             },
             {
-              "latency": 0.321009849
+              "latency": 0.320060547
             },
             {
-              "latency": 0.311142664
+              "latency": 0.285259553
             },
             {
-              "latency": 0.290793839
+              "latency": 0.368343198
             },
             {
-              "latency": 0.319213995
+              "latency": 0.299649302
             },
             {
-              "latency": 0.37910792
+              "latency": 0.321616112
             },
             {
-              "latency": 0.390957792
+              "latency": 0.299982751
             },
             {
-              "latency": 0.316499917
+              "latency": 0.308789533
             },
             {
-              "latency": 0.309537188
+              "latency": 0.304927717
             }
           ],
           "implementation": "go-libp2p",
@@ -4292,304 +4292,304 @@
         {
           "result": [
             {
-              "latency": 0.197169269
+              "latency": 0.191525256
             },
             {
-              "latency": 0.198751322
+              "latency": 0.193610405
             },
             {
-              "latency": 0.198650845
+              "latency": 0.180508601
             },
             {
-              "latency": 0.19784868
+              "latency": 0.178554411
             },
             {
-              "latency": 0.18951009
+              "latency": 0.185245123
             },
             {
-              "latency": 0.195939065
+              "latency": 0.187930077
             },
             {
-              "latency": 0.187773599
+              "latency": 0.191376314
             },
             {
-              "latency": 0.191357964
+              "latency": 0.176943336
             },
             {
-              "latency": 0.188436378
+              "latency": 0.185216995
             },
             {
-              "latency": 0.196633812
+              "latency": 0.195660746
             },
             {
-              "latency": 0.191721848
+              "latency": 0.183561809
             },
             {
-              "latency": 0.194254886
+              "latency": 0.194975226
             },
             {
-              "latency": 0.188457443
+              "latency": 0.186701684
             },
             {
-              "latency": 0.192788241
+              "latency": 0.178602137
             },
             {
-              "latency": 0.195765146
+              "latency": 0.177156431
             },
             {
-              "latency": 0.197249529
+              "latency": 0.185601104
             },
             {
-              "latency": 0.196170867
+              "latency": 0.181914493
             },
             {
-              "latency": 0.200116519
+              "latency": 0.196261959
             },
             {
-              "latency": 0.186574715
+              "latency": 0.184362129
             },
             {
-              "latency": 0.195838835
+              "latency": 0.186508643
             },
             {
-              "latency": 0.19416503
+              "latency": 0.186638955
             },
             {
-              "latency": 0.190306897
+              "latency": 0.18887929
             },
             {
-              "latency": 0.18568374
+              "latency": 0.193868817
             },
             {
-              "latency": 0.198574642
+              "latency": 0.184122257
             },
             {
-              "latency": 0.199410656
+              "latency": 0.194205327
             },
             {
-              "latency": 0.192103993
+              "latency": 0.178552464
             },
             {
-              "latency": 0.185566253
+              "latency": 0.196183788
             },
             {
-              "latency": 0.187034148
+              "latency": 0.186314404
             },
             {
-              "latency": 0.188076892
+              "latency": 0.196025839
             },
             {
-              "latency": 0.190572074
+              "latency": 0.180045438
             },
             {
-              "latency": 0.18800255
+              "latency": 0.191262396
             },
             {
-              "latency": 0.193822392
+              "latency": 0.185115061
             },
             {
-              "latency": 0.187719455
+              "latency": 0.184082903
             },
             {
-              "latency": 0.186640985
+              "latency": 0.188259633
             },
             {
-              "latency": 0.190244259
+              "latency": 0.195085781
             },
             {
-              "latency": 0.189053242
+              "latency": 0.183409318
             },
             {
-              "latency": 0.191868562
+              "latency": 0.19646923
             },
             {
-              "latency": 0.18167821
+              "latency": 0.179044828
             },
             {
-              "latency": 0.19078117
+              "latency": 0.179904
             },
             {
-              "latency": 0.180227769
+              "latency": 0.194325576
             },
             {
-              "latency": 0.182051893
+              "latency": 0.189140003
             },
             {
-              "latency": 0.185279257
+              "latency": 0.184870345
             },
             {
-              "latency": 0.193969699
+              "latency": 0.186847879
             },
             {
-              "latency": 0.196103816
+              "latency": 0.186447399
             },
             {
-              "latency": 0.191829101
+              "latency": 0.181633101
             },
             {
-              "latency": 0.194351761
+              "latency": 0.19518719
             },
             {
-              "latency": 0.192721129
+              "latency": 0.195642493
             },
             {
-              "latency": 0.187010527
+              "latency": 0.191930507
             },
             {
-              "latency": 0.189895364
+              "latency": 0.196414763
             },
             {
-              "latency": 0.195719136
+              "latency": 0.194287479
             },
             {
-              "latency": 0.185413399
+              "latency": 0.191445086
             },
             {
-              "latency": 0.186960104
+              "latency": 0.178962975
             },
             {
-              "latency": 0.185546385
+              "latency": 0.194036749
             },
             {
-              "latency": 0.196370318
+              "latency": 0.191968922
             },
             {
-              "latency": 0.196279566
+              "latency": 0.194625722
             },
             {
-              "latency": 0.183035582
+              "latency": 0.194028109
             },
             {
-              "latency": 0.192582338
+              "latency": 0.188736452
             },
             {
-              "latency": 0.199423918
+              "latency": 0.190868747
             },
             {
-              "latency": 0.197515111
+              "latency": 0.188679429
             },
             {
-              "latency": 0.189327901
+              "latency": 0.183738401
             },
             {
-              "latency": 0.193889314
+              "latency": 0.198935515
             },
             {
-              "latency": 0.191183674
+              "latency": 0.189585223
             },
             {
-              "latency": 0.193086462
+              "latency": 0.180530858
             },
             {
-              "latency": 0.198898212
+              "latency": 0.183595121
             },
             {
-              "latency": 0.192799096
+              "latency": 0.189564229
             },
             {
-              "latency": 0.191050344
+              "latency": 0.183112821
             },
             {
-              "latency": 0.196552045
+              "latency": 0.178509756
             },
             {
-              "latency": 0.191643207
+              "latency": 0.183511344
             },
             {
-              "latency": 0.192119892
+              "latency": 0.186418643
             },
             {
-              "latency": 0.180426059
+              "latency": 0.184986569
             },
             {
-              "latency": 0.192615952
+              "latency": 0.18679463
             },
             {
-              "latency": 0.188478335
+              "latency": 0.179487446
             },
             {
-              "latency": 0.192272539
+              "latency": 0.193678778
             },
             {
-              "latency": 0.190172541
+              "latency": 0.17865506
             },
             {
-              "latency": 0.188555607
+              "latency": 0.185429742
             },
             {
-              "latency": 0.198969273
+              "latency": 0.179214579
             },
             {
-              "latency": 0.194132954
+              "latency": 0.178493491
             },
             {
-              "latency": 0.19240791
+              "latency": 0.183400595
             },
             {
-              "latency": 0.194100337
+              "latency": 0.186409569
             },
             {
-              "latency": 0.196370915
+              "latency": 0.192006719
             },
             {
-              "latency": 0.196373268
+              "latency": 0.180291837
             },
             {
-              "latency": 0.198667754
+              "latency": 0.181606254
             },
             {
-              "latency": 0.190597659
+              "latency": 0.19290224
             },
             {
-              "latency": 0.194847716
+              "latency": 0.184946482
             },
             {
-              "latency": 0.196733188
+              "latency": 0.18384604
             },
             {
-              "latency": 0.194730005
+              "latency": 0.186962243
             },
             {
-              "latency": 0.188612041
+              "latency": 0.186456494
             },
             {
-              "latency": 0.189992786
+              "latency": 0.189040764
             },
             {
-              "latency": 0.193479234
+              "latency": 0.183744163
             },
             {
-              "latency": 0.182603198
+              "latency": 0.179271233
             },
             {
-              "latency": 0.193309143
+              "latency": 0.179459429
             },
             {
-              "latency": 0.194503333
+              "latency": 0.189001883
             },
             {
-              "latency": 0.190437294
+              "latency": 0.187423934
             },
             {
-              "latency": 0.180342709
+              "latency": 0.197110376
             },
             {
-              "latency": 0.19663589
+              "latency": 0.191074594
             },
             {
-              "latency": 0.196405317
+              "latency": 0.188088286
             },
             {
-              "latency": 0.192049488
+              "latency": 0.196988818
             },
             {
-              "latency": 0.190754249
+              "latency": 0.180124387
             },
             {
-              "latency": 0.196142325
+              "latency": 0.18756265
             },
             {
-              "latency": 0.190650149
+              "latency": 0.183539854
             }
           ],
           "implementation": "go-libp2p",
@@ -4606,112 +4606,147 @@
   "pings": {
     "unit": "s",
     "results": [
-      0.0765,
-      0.07390000000000001,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.06409999999999999,
-      0.0638,
-      0.0649,
-      0.0691,
-      0.0691,
-      0.0691,
-      0.0691,
-      0.0691,
-      0.0691,
-      0.0691,
-      0.0691,
-      0.0691,
-      0.0634,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638,
-      0.0638
+      0.082,
+      0.0582,
+      0.0581,
+      0.0582,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0582,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0582,
+      0.0585,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0584,
+      0.0581,
+      0.0584,
+      0.0581,
+      0.0581,
+      0.063,
+      0.063,
+      0.063,
+      0.063,
+      0.063,
+      0.063,
+      0.063,
+      0.063,
+      0.063,
+      0.063,
+      0.063,
+      0.0573,
+      0.0581,
+      0.0582,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0582,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581,
+      0.0581
     ]
   },
   "iperf": {
     "unit": "bit/s",
     "results": [
-      2049999999.9999998,
+      2069999999.9999998,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
       4780000000,
       4780000000,
       4780000000,
@@ -4737,42 +4772,7 @@
       4780000000,
       4780000000,
       4740000000,
-      4650000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4510000000,
-      3880000000,
-      3950000000,
-      4070000000.0000005,
-      4139999999.9999995,
-      4200000000,
-      4290000000,
-      4330000000,
-      4380000000,
-      4440000000,
-      4460000000,
-      4500000000,
-      4520000000,
-      4540000000,
-      4570000000,
-      4620000000,
-      4600000000
+      4720000000
     ]
   }
 }

--- a/perf/runner/benchmark-results.json
+++ b/perf/runner/benchmark-results.json
@@ -7,34 +7,34 @@
         {
           "result": [
             {
-              "latency": 1.112042404
+              "latency": 1.071285577
             },
             {
-              "latency": 1.040904815
+              "latency": 1.069395315
             },
             {
-              "latency": 1.0686287
+              "latency": 1.042424524
             },
             {
-              "latency": 1.046221104
+              "latency": 1.056611303
             },
             {
-              "latency": 1.081287741
+              "latency": 1.071165158
             },
             {
-              "latency": 1.039672874
+              "latency": 1.04385611
             },
             {
-              "latency": 1.113648805
+              "latency": 1.063371162
             },
             {
-              "latency": 1.015741139
+              "latency": 1.083406849
             },
             {
-              "latency": 1.042960858
+              "latency": 1.099260456
             },
             {
-              "latency": 1.062364092
+              "latency": 1.015545856
             }
           ],
           "implementation": "quic-go",
@@ -44,34 +44,34 @@
         {
           "result": [
             {
-              "latency": 45.260004173
+              "latency": 43.849901028
             },
             {
-              "latency": 48.395110584
+              "latency": 43.842900998
             },
             {
-              "latency": 42.53477564
+              "latency": 45.197651355
             },
             {
-              "latency": 47.229432791
+              "latency": 44.21477204
             },
             {
-              "latency": 46.004655432
+              "latency": 43.655197483
             },
             {
-              "latency": 46.134159882
+              "latency": 44.672155938
             },
             {
-              "latency": 48.283460022
+              "latency": 41.880360527
             },
             {
-              "latency": 45.017688501
+              "latency": 44.525619358
             },
             {
-              "latency": 44.037586273
+              "latency": 43.213599543
             },
             {
-              "latency": 44.879217676
+              "latency": 43.738450351
             }
           ],
           "implementation": "rust-libp2p",
@@ -81,34 +81,34 @@
         {
           "result": [
             {
-              "latency": 11.092959903
+              "latency": 17.930301157
             },
             {
-              "latency": 10.358886645
+              "latency": 19.303762261
             },
             {
-              "latency": 9.407897071
+              "latency": 18.273005145
             },
             {
-              "latency": 12.42272799
+              "latency": 22.866542705
             },
             {
-              "latency": 6.378903829
+              "latency": 10.707955945
             },
             {
-              "latency": 8.435240077
+              "latency": 15.697471398
             },
             {
-              "latency": 8.182064314
+              "latency": 8.201255957
             },
             {
-              "latency": 7.358208135
+              "latency": 17.398968493
             },
             {
-              "latency": 8.235037151
+              "latency": 20.649270846
             },
             {
-              "latency": 8.091133249
+              "latency": 17.879851484
             }
           ],
           "implementation": "rust-libp2p",
@@ -118,34 +118,34 @@
         {
           "result": [
             {
-              "latency": 44.623240087
+              "latency": 42.780782348
             },
             {
-              "latency": 46.959591138
+              "latency": 43.860069886
             },
             {
-              "latency": 43.817789138
+              "latency": 44.970232156
             },
             {
-              "latency": 46.266781036
+              "latency": 43.779607607
             },
             {
-              "latency": 41.474235628
+              "latency": 43.942253083
             },
             {
-              "latency": 45.872058847
+              "latency": 44.602692612
             },
             {
-              "latency": 47.805469825
+              "latency": 46.349489671
             },
             {
-              "latency": 46.896982856
+              "latency": 46.668700571
             },
             {
-              "latency": 45.331136385
+              "latency": 42.399196518
             },
             {
-              "latency": 45.922625293
+              "latency": 44.801937367
             }
           ],
           "implementation": "rust-libp2p",
@@ -155,34 +155,34 @@
         {
           "result": [
             {
-              "latency": 1.436209786
+              "latency": 1.465039631
             },
             {
-              "latency": 1.490708842
+              "latency": 1.469524763
             },
             {
-              "latency": 1.450257599
+              "latency": 1.445585724
             },
             {
-              "latency": 1.508362704
+              "latency": 1.431238773
             },
             {
-              "latency": 1.441874859
+              "latency": 1.527760603
             },
             {
-              "latency": 1.507737002
+              "latency": 1.414356687
             },
             {
-              "latency": 1.516731305
+              "latency": 1.496875298
             },
             {
-              "latency": 1.432129312
+              "latency": 1.532772236
             },
             {
-              "latency": 1.463953129
+              "latency": 1.492001593
             },
             {
-              "latency": 1.486910093
+              "latency": 1.4326656199999999
             }
           ],
           "implementation": "rust-libp2p",
@@ -192,34 +192,34 @@
         {
           "result": [
             {
-              "latency": 1.000792633
+              "latency": 1.085260831
             },
             {
-              "latency": 1.067742801
+              "latency": 1.040458165
             },
             {
-              "latency": 1.074019847
+              "latency": 1.057703353
             },
             {
-              "latency": 1.070208927
+              "latency": 1.526690323
             },
             {
-              "latency": 1.030300038
+              "latency": 1.158624489
             },
             {
-              "latency": 1.063309417
+              "latency": 0.987676366
             },
             {
-              "latency": 1.131723965
+              "latency": 1.07832605
             },
             {
-              "latency": 1.026816626
+              "latency": 1.123405368
             },
             {
-              "latency": 1.072785453
+              "latency": 1.176931877
             },
             {
-              "latency": 1.040764109
+              "latency": 0.972582383
             }
           ],
           "implementation": "https",
@@ -229,34 +229,34 @@
         {
           "result": [
             {
-              "latency": 1.996814653
+              "latency": 2.00041718
             },
             {
-              "latency": 2.277546952
+              "latency": 1.926055813
             },
             {
-              "latency": 2.005660241
+              "latency": 1.938247083
             },
             {
-              "latency": 1.998867582
+              "latency": 1.9089656480000001
             },
             {
-              "latency": 2.07851598
+              "latency": 1.987682889
             },
             {
-              "latency": 2.168026242
+              "latency": 2.077785405
             },
             {
-              "latency": 1.917925734
+              "latency": 1.876459788
             },
             {
-              "latency": 2.066869461
+              "latency": 1.898380258
             },
             {
-              "latency": 2.084749114
+              "latency": 2.107207021
             },
             {
-              "latency": 1.9320118819999998
+              "latency": 1.864232171
             }
           ],
           "implementation": "go-libp2p",
@@ -266,34 +266,34 @@
         {
           "result": [
             {
-              "latency": 1.484297921
+              "latency": 1.493318184
             },
             {
-              "latency": 1.379805408
+              "latency": 1.526047135
             },
             {
-              "latency": 1.397722855
+              "latency": 1.384726298
             },
             {
-              "latency": 1.452930908
+              "latency": 1.468875621
             },
             {
-              "latency": 1.474663539
+              "latency": 1.475157714
             },
             {
-              "latency": 1.5304581160000001
+              "latency": 1.453121249
             },
             {
-              "latency": 1.518420351
+              "latency": 1.45227682
             },
             {
-              "latency": 1.452696631
+              "latency": 1.461752988
             },
             {
-              "latency": 1.459257176
+              "latency": 1.518416706
             },
             {
-              "latency": 1.448748649
+              "latency": 1.445255755
             }
           ],
           "implementation": "go-libp2p",
@@ -303,34 +303,34 @@
         {
           "result": [
             {
-              "latency": 1.73399728
+              "latency": 1.822296742
             },
             {
-              "latency": 1.953186395
+              "latency": 1.8696535600000002
             },
             {
-              "latency": 2.089665255
+              "latency": 1.910893207
             },
             {
-              "latency": 1.910508345
+              "latency": 2.058775486
             },
             {
-              "latency": 1.838861197
+              "latency": 1.7983950640000002
             },
             {
-              "latency": 2.10595773
+              "latency": 1.899713628
             },
             {
-              "latency": 1.9942206420000002
+              "latency": 2.211065942
             },
             {
-              "latency": 1.927580396
+              "latency": 1.84486204
             },
             {
-              "latency": 1.8339864110000001
+              "latency": 1.964718382
             },
             {
-              "latency": 2.032794671
+              "latency": 2.039322815
             }
           ],
           "implementation": "go-libp2p",
@@ -340,34 +340,34 @@
         {
           "result": [
             {
-              "latency": 1.479239691
+              "latency": 1.510232859
             },
             {
-              "latency": 1.495454027
+              "latency": 1.5096963780000001
             },
             {
-              "latency": 1.543158678
+              "latency": 1.451701074
             },
             {
-              "latency": 1.387968645
+              "latency": 1.507893198
             },
             {
-              "latency": 1.398235748
+              "latency": 1.427003445
             },
             {
-              "latency": 1.4706398
+              "latency": 1.4247460539999999
             },
             {
-              "latency": 1.460899138
+              "latency": 1.4869463010000001
             },
             {
-              "latency": 1.506342492
+              "latency": 1.502917124
             },
             {
-              "latency": 1.443469619
+              "latency": 1.506837921
             },
             {
-              "latency": 1.436209574
+              "latency": 1.523948048
             }
           ],
           "implementation": "go-libp2p",
@@ -377,34 +377,34 @@
         {
           "result": [
             {
-              "latency": 2.312588858
+              "latency": 1.887423789
             },
             {
-              "latency": 1.8135068890000001
+              "latency": 1.828131129
             },
             {
-              "latency": 2.010186869
+              "latency": 1.847789302
             },
             {
-              "latency": 2.069603199
+              "latency": 1.807732865
             },
             {
-              "latency": 2.2007226
+              "latency": 1.868927057
             },
             {
-              "latency": 1.851196675
+              "latency": 1.9384547589999999
             },
             {
-              "latency": 1.873183739
+              "latency": 1.973003737
             },
             {
-              "latency": 2.005022895
+              "latency": 2.104874296
             },
             {
-              "latency": 2.169229945
+              "latency": 2.077658277
             },
             {
-              "latency": 1.9769121649999999
+              "latency": 2.049212007
             }
           ],
           "implementation": "go-libp2p",
@@ -414,34 +414,34 @@
         {
           "result": [
             {
-              "latency": 1.453551709
+              "latency": 1.4489625959999999
             },
             {
-              "latency": 1.438258721
+              "latency": 1.438072231
             },
             {
-              "latency": 1.427642681
+              "latency": 1.47192888
             },
             {
-              "latency": 1.470681919
+              "latency": 1.36653179
             },
             {
-              "latency": 1.445951805
+              "latency": 1.447688209
             },
             {
-              "latency": 1.425751155
+              "latency": 1.43794569
             },
             {
-              "latency": 1.447851201
+              "latency": 1.422484858
             },
             {
-              "latency": 1.469297955
+              "latency": 1.507912567
             },
             {
-              "latency": 1.407125846
+              "latency": 1.422477268
             },
             {
-              "latency": 1.4423235939999999
+              "latency": 1.450366273
             }
           ],
           "implementation": "go-libp2p",
@@ -461,34 +461,34 @@
         {
           "result": [
             {
-              "latency": 1.110850124
+              "latency": 1.149199048
             },
             {
-              "latency": 1.093080731
+              "latency": 1.157563774
             },
             {
-              "latency": 1.076443205
+              "latency": 1.114077801
             },
             {
-              "latency": 1.160912817
+              "latency": 1.15452198
             },
             {
-              "latency": 1.179046732
+              "latency": 1.084618645
             },
             {
-              "latency": 1.142859698
+              "latency": 1.11946623
             },
             {
-              "latency": 1.147417751
+              "latency": 1.146397234
             },
             {
-              "latency": 1.174676316
+              "latency": 1.115965759
             },
             {
-              "latency": 1.127742135
+              "latency": 1.156336724
             },
             {
-              "latency": 1.080442361
+              "latency": 1.080715488
             }
           ],
           "implementation": "quic-go",
@@ -498,34 +498,34 @@
         {
           "result": [
             {
-              "latency": 44.364867506
+              "latency": 46.006305198
             },
             {
-              "latency": 43.693930473
+              "latency": 45.59101943
             },
             {
-              "latency": 48.210922296
+              "latency": 46.909697672
             },
             {
-              "latency": 45.937198162
+              "latency": 46.92568299
             },
             {
-              "latency": 45.051868171
+              "latency": 45.152127336
             },
             {
-              "latency": 46.447137472
+              "latency": 42.538929055
             },
             {
-              "latency": 43.37108255
+              "latency": 46.080626541
             },
             {
-              "latency": 48.145707393
+              "latency": 44.26846442
             },
             {
-              "latency": 45.796887394
+              "latency": 47.018440163
             },
             {
-              "latency": 43.830320226
+              "latency": 44.122497155
             }
           ],
           "implementation": "rust-libp2p",
@@ -535,34 +535,34 @@
         {
           "result": [
             {
-              "latency": 14.320809405
+              "latency": 33.164872835
             },
             {
-              "latency": 7.549444058
+              "latency": 20.23798894
             },
             {
-              "latency": 13.946676377
+              "latency": 16.607925497
             },
             {
-              "latency": 6.044759483
+              "latency": 15.523835048
             },
             {
-              "latency": 12.942239565
+              "latency": 8.203831203
             },
             {
-              "latency": 22.411561057
+              "latency": 13.395711191
             },
             {
-              "latency": 12.029670458
+              "latency": 13.951129538
             },
             {
-              "latency": 7.40864408
+              "latency": 8.558814731
             },
             {
-              "latency": 10.056136359
+              "latency": 12.492643916
             },
             {
-              "latency": 10.791029753
+              "latency": 14.671470039
             }
           ],
           "implementation": "rust-libp2p",
@@ -572,34 +572,34 @@
         {
           "result": [
             {
-              "latency": 46.452801501
+              "latency": 45.626450328
             },
             {
-              "latency": 44.537785066
+              "latency": 43.272589128999996
             },
             {
-              "latency": 46.706174282
+              "latency": 45.447037749
             },
             {
-              "latency": 46.787322998
+              "latency": 45.975694488
             },
             {
-              "latency": 48.316330198
+              "latency": 45.426381055
             },
             {
-              "latency": 46.993861273
+              "latency": 46.921007984
             },
             {
-              "latency": 46.216835815
+              "latency": 45.374440872
             },
             {
-              "latency": 44.39827094
+              "latency": 45.866453431
             },
             {
-              "latency": 43.080621074
+              "latency": 42.280475852
             },
             {
-              "latency": 45.626667655
+              "latency": 43.604913492
             }
           ],
           "implementation": "rust-libp2p",
@@ -609,34 +609,34 @@
         {
           "result": [
             {
-              "latency": 1.522142557
+              "latency": 1.5269195469999999
             },
             {
-              "latency": 1.417729633
+              "latency": 1.401511865
             },
             {
-              "latency": 1.393034921
+              "latency": 1.351604413
             },
             {
-              "latency": 1.507490663
+              "latency": 1.495406051
             },
             {
-              "latency": 1.461791297
+              "latency": 1.444137512
             },
             {
-              "latency": 1.482142431
+              "latency": 1.433565694
             },
             {
-              "latency": 1.511302416
+              "latency": 1.469279238
             },
             {
-              "latency": 1.452599762
+              "latency": 1.441981719
             },
             {
-              "latency": 1.435318631
+              "latency": 1.475345647
             },
             {
-              "latency": 1.5063716870000001
+              "latency": 1.4954403410000001
             }
           ],
           "implementation": "rust-libp2p",
@@ -646,34 +646,34 @@
         {
           "result": [
             {
-              "latency": 1.145026897
+              "latency": 1.018266091
             },
             {
-              "latency": 1.145951311
+              "latency": 1.16434628
             },
             {
-              "latency": 1.150830815
+              "latency": 1.078597881
             },
             {
-              "latency": 1.137472304
+              "latency": 1.068773445
             },
             {
-              "latency": 1.081245166
+              "latency": 1.18122069
             },
             {
-              "latency": 1.59943716
+              "latency": 1.666752361
             },
             {
-              "latency": 1.060731481
+              "latency": 1.079439141
             },
             {
-              "latency": 1.131600641
+              "latency": 1.079188576
             },
             {
-              "latency": 1.131655602
+              "latency": 1.18315602
             },
             {
-              "latency": 1.136339963
+              "latency": 1.211309013
             }
           ],
           "implementation": "https",
@@ -683,34 +683,34 @@
         {
           "result": [
             {
-              "latency": 2.191642927
+              "latency": 2.215776735
             },
             {
-              "latency": 2.171334143
+              "latency": 1.950393949
             },
             {
-              "latency": 2.070586889
+              "latency": 1.752649385
             },
             {
-              "latency": 1.9550119879999999
+              "latency": 1.914636944
             },
             {
-              "latency": 1.921357032
+              "latency": 2.140913856
             },
             {
-              "latency": 1.882647205
+              "latency": 1.8511913629999999
             },
             {
-              "latency": 2.072018102
+              "latency": 1.786344674
             },
             {
-              "latency": 2.334024597
+              "latency": 2.116697589
             },
             {
-              "latency": 1.995596629
+              "latency": 1.97959514
             },
             {
-              "latency": 2.278014819
+              "latency": 2.786357404
             }
           ],
           "implementation": "go-libp2p",
@@ -720,34 +720,34 @@
         {
           "result": [
             {
-              "latency": 1.435999635
+              "latency": 1.486444174
             },
             {
-              "latency": 1.484398551
+              "latency": 1.4239469200000001
             },
             {
-              "latency": 1.511891909
+              "latency": 1.447086572
             },
             {
-              "latency": 1.445660573
+              "latency": 1.513992215
             },
             {
-              "latency": 1.409702654
+              "latency": 5.081743365
             },
             {
-              "latency": 1.467694494
+              "latency": 1.486929825
             },
             {
-              "latency": 1.472078119
+              "latency": 1.530266978
             },
             {
-              "latency": 1.507179595
+              "latency": 1.437148686
             },
             {
-              "latency": 1.510345096
+              "latency": 1.442237815
             },
             {
-              "latency": 1.447301909
+              "latency": 1.463068032
             }
           ],
           "implementation": "go-libp2p",
@@ -757,34 +757,34 @@
         {
           "result": [
             {
-              "latency": 2.146156173
+              "latency": 1.984648098
             },
             {
-              "latency": 2.075221552
+              "latency": 1.915011154
             },
             {
-              "latency": 2.047962941
+              "latency": 2.174927185
             },
             {
-              "latency": 2.249664773
+              "latency": 2.127334374
             },
             {
-              "latency": 2.082968832
+              "latency": 1.829379466
             },
             {
-              "latency": 1.948727663
+              "latency": 1.976193457
             },
             {
-              "latency": 1.896993062
+              "latency": 1.816409833
             },
             {
-              "latency": 2.135594046
+              "latency": 2.213465902
             },
             {
-              "latency": 1.915084453
+              "latency": 1.9789948659999999
             },
             {
-              "latency": 2.082567107
+              "latency": 2.056144496
             }
           ],
           "implementation": "go-libp2p",
@@ -794,34 +794,34 @@
         {
           "result": [
             {
-              "latency": 1.474809036
+              "latency": 1.471732982
             },
             {
-              "latency": 1.428106063
+              "latency": 1.386400597
             },
             {
-              "latency": 1.3917085359999999
+              "latency": 1.4744533610000001
             },
             {
-              "latency": 1.432570517
+              "latency": 1.475587438
             },
             {
-              "latency": 1.525072228
+              "latency": 1.476875106
             },
             {
-              "latency": 1.402286782
+              "latency": 1.498334311
             },
             {
-              "latency": 1.507586734
+              "latency": 1.423239728
             },
             {
-              "latency": 1.437731482
+              "latency": 1.465852953
             },
             {
-              "latency": 1.441406052
+              "latency": 1.499112768
             },
             {
-              "latency": 1.398794559
+              "latency": 1.534331492
             }
           ],
           "implementation": "go-libp2p",
@@ -831,34 +831,34 @@
         {
           "result": [
             {
-              "latency": 1.918366026
+              "latency": 1.87368222
             },
             {
-              "latency": 1.946368828
+              "latency": 1.976366793
             },
             {
-              "latency": 2.073719545
+              "latency": 1.7837310610000001
             },
             {
-              "latency": 2.679087171
+              "latency": 2.137891339
             },
             {
-              "latency": 1.882131083
+              "latency": 2.190050614
             },
             {
-              "latency": 2.085750025
+              "latency": 1.8649698479999999
             },
             {
-              "latency": 1.904573458
+              "latency": 2.125164286
             },
             {
-              "latency": 1.89405567
+              "latency": 2.094308199
             },
             {
-              "latency": 2.100214433
+              "latency": 1.915074339
             },
             {
-              "latency": 2.328335638
+              "latency": 2.131227978
             }
           ],
           "implementation": "go-libp2p",
@@ -868,34 +868,34 @@
         {
           "result": [
             {
-              "latency": 1.524044261
+              "latency": 1.4503606470000001
             },
             {
-              "latency": 1.459599945
+              "latency": 1.466142601
             },
             {
-              "latency": 1.404364793
+              "latency": 1.483229164
             },
             {
-              "latency": 1.409729418
+              "latency": 1.4580926920000001
             },
             {
-              "latency": 1.48881558
+              "latency": 1.5389658659999998
             },
             {
-              "latency": 1.4973210780000001
+              "latency": 1.519644902
             },
             {
-              "latency": 1.524865366
+              "latency": 1.477906865
             },
             {
-              "latency": 1.3740197140000001
+              "latency": 1.4759470559999999
             },
             {
-              "latency": 1.360551944
+              "latency": 1.444991447
             },
             {
-              "latency": 1.432704833
+              "latency": 1.408619595
             }
           ],
           "implementation": "go-libp2p",
@@ -915,304 +915,304 @@
         {
           "result": [
             {
-              "latency": 0.124246247
+              "latency": 0.125762936
             },
             {
-              "latency": 0.129494685
+              "latency": 0.125532012
             },
             {
-              "latency": 0.117853665
+              "latency": 0.130680355
             },
             {
-              "latency": 0.124624591
+              "latency": 0.125002467
             },
             {
-              "latency": 0.126743944
+              "latency": 0.129832706
             },
             {
-              "latency": 0.127912663
+              "latency": 0.126789261
             },
             {
-              "latency": 0.132551522
+              "latency": 0.126112536
             },
             {
-              "latency": 0.117061497
+              "latency": 0.12648094
             },
             {
-              "latency": 0.129191266
+              "latency": 0.129648537
             },
             {
-              "latency": 0.125381281
+              "latency": 0.122423247
             },
             {
-              "latency": 0.125025389
+              "latency": 0.125126655
             },
             {
-              "latency": 0.128306711
+              "latency": 0.128063248
             },
             {
-              "latency": 0.127611785
+              "latency": 0.128997095
             },
             {
-              "latency": 0.12772622
+              "latency": 0.124706607
             },
             {
-              "latency": 0.127774628
+              "latency": 0.125246785
             },
             {
-              "latency": 0.128915143
+              "latency": 0.127441164
             },
             {
-              "latency": 0.119983678
+              "latency": 0.126592187
             },
             {
-              "latency": 0.124435906
+              "latency": 0.124894141
             },
             {
-              "latency": 0.123187389
+              "latency": 0.125709114
             },
             {
-              "latency": 0.128720933
+              "latency": 0.12913498
             },
             {
-              "latency": 0.125328242
+              "latency": 0.130439712
             },
             {
-              "latency": 0.131169863
+              "latency": 0.129369247
             },
             {
-              "latency": 0.119821383
+              "latency": 0.126821524
             },
             {
-              "latency": 0.129323549
+              "latency": 0.124599749
             },
             {
-              "latency": 0.122529144
+              "latency": 0.127713992
             },
             {
-              "latency": 0.129483228
+              "latency": 0.121446872
             },
             {
-              "latency": 0.123473249
+              "latency": 0.128051265
             },
             {
-              "latency": 0.124785337
+              "latency": 0.126931838
             },
             {
-              "latency": 0.129274754
+              "latency": 0.123857001
             },
             {
-              "latency": 0.129046192
+              "latency": 0.125986067
             },
             {
-              "latency": 0.13113493
+              "latency": 0.12480403
             },
             {
-              "latency": 0.127342624
+              "latency": 0.122271363
             },
             {
-              "latency": 0.121070875
+              "latency": 0.12591565
             },
             {
-              "latency": 0.127219784
+              "latency": 0.128481507
             },
             {
-              "latency": 0.129278852
+              "latency": 0.125585317
             },
             {
-              "latency": 0.128990921
+              "latency": 0.128365935
             },
             {
-              "latency": 0.125117716
+              "latency": 0.129465262
             },
             {
-              "latency": 0.119551292
+              "latency": 0.126937259
             },
             {
-              "latency": 0.120414643
+              "latency": 0.127662778
             },
             {
-              "latency": 0.124542201
+              "latency": 0.130185132
             },
             {
-              "latency": 0.129823602
+              "latency": 0.12860616
             },
             {
-              "latency": 0.130420942
+              "latency": 0.130559279
             },
             {
-              "latency": 0.124031798
+              "latency": 0.120208756
             },
             {
-              "latency": 0.125097723
+              "latency": 0.130442452
             },
             {
-              "latency": 0.123260582
+              "latency": 0.126745972
             },
             {
-              "latency": 0.129411106
+              "latency": 0.120316019
             },
             {
-              "latency": 0.124655781
+              "latency": 0.127710272
             },
             {
-              "latency": 0.124401481
+              "latency": 0.12985534
             },
             {
-              "latency": 0.127885914
+              "latency": 0.126844139
             },
             {
-              "latency": 0.128420281
+              "latency": 0.123207861
             },
             {
-              "latency": 0.126077545
+              "latency": 0.129726701
             },
             {
-              "latency": 0.118406288
+              "latency": 0.126182044
             },
             {
-              "latency": 0.123879802
+              "latency": 0.129656797
             },
             {
-              "latency": 0.126691883
+              "latency": 0.122401266
             },
             {
-              "latency": 0.119523982
+              "latency": 0.128554508
             },
             {
-              "latency": 0.125946407
+              "latency": 0.129179946
             },
             {
-              "latency": 0.130923777
+              "latency": 0.126667809
             },
             {
-              "latency": 0.124614335
+              "latency": 0.130729093
             },
             {
-              "latency": 0.131977811
+              "latency": 0.128035322
             },
             {
-              "latency": 0.122793368
+              "latency": 0.12727555
             },
             {
-              "latency": 0.129722405
+              "latency": 0.123530668
             },
             {
-              "latency": 0.120739302
+              "latency": 0.123798811
             },
             {
-              "latency": 0.130658315
+              "latency": 0.127614154
             },
             {
-              "latency": 0.120502544
+              "latency": 0.129787272
             },
             {
-              "latency": 0.126421406
+              "latency": 0.129313602
             },
             {
-              "latency": 0.123581155
+              "latency": 0.116634619
             },
             {
-              "latency": 0.127533772
+              "latency": 0.129093054
             },
             {
-              "latency": 0.124842633
+              "latency": 0.12668097
             },
             {
-              "latency": 0.123605808
+              "latency": 0.130769547
             },
             {
-              "latency": 0.130614831
+              "latency": 0.11989181
             },
             {
-              "latency": 0.127723109
+              "latency": 0.12361692
             },
             {
-              "latency": 0.124950639
+              "latency": 0.123713242
             },
             {
-              "latency": 0.125220007
+              "latency": 0.121143274
             },
             {
-              "latency": 0.12279533
+              "latency": 0.122933957
             },
             {
-              "latency": 0.129191733
+              "latency": 0.123485686
             },
             {
-              "latency": 0.129570249
+              "latency": 0.130484268
             },
             {
-              "latency": 0.12557528
+              "latency": 0.126988858
             },
             {
-              "latency": 0.121980542
+              "latency": 0.131100738
             },
             {
-              "latency": 0.12592364
+              "latency": 0.122147542
             },
             {
-              "latency": 0.130537319
+              "latency": 0.129422668
             },
             {
-              "latency": 0.126267656
+              "latency": 0.12742579
             },
             {
-              "latency": 0.129660961
+              "latency": 0.124992949
             },
             {
-              "latency": 0.131168635
+              "latency": 0.127668144
             },
             {
-              "latency": 0.1311578
+              "latency": 0.122618205
             },
             {
-              "latency": 0.120304684
+              "latency": 0.129735755
             },
             {
-              "latency": 0.121703085
+              "latency": 0.119158566
             },
             {
-              "latency": 0.118102561
+              "latency": 0.128970332
             },
             {
-              "latency": 0.127291005
+              "latency": 0.122207535
             },
             {
-              "latency": 0.124620954
+              "latency": 0.131265173
             },
             {
-              "latency": 0.127855618
+              "latency": 0.122236005
             },
             {
-              "latency": 0.132339447
+              "latency": 0.123582575
             },
             {
-              "latency": 0.127238333
+              "latency": 0.126172587
             },
             {
-              "latency": 0.129451661
+              "latency": 0.120163279
             },
             {
-              "latency": 0.120896661
+              "latency": 0.122660541
             },
             {
-              "latency": 0.126870447
+              "latency": 0.120163301
             },
             {
-              "latency": 0.127443842
+              "latency": 0.122411836
             },
             {
-              "latency": 0.124271851
+              "latency": 0.124202701
             },
             {
-              "latency": 0.124324532
+              "latency": 0.124915141
             },
             {
-              "latency": 0.129094137
+              "latency": 0.129693881
             },
             {
-              "latency": 0.130064921
+              "latency": 0.127959635
             }
           ],
           "implementation": "quic-go",
@@ -1222,304 +1222,304 @@
         {
           "result": [
             {
-              "latency": 0.187885427
+              "latency": 0.194368692
             },
             {
-              "latency": 0.173766773
+              "latency": 0.189691375
             },
             {
-              "latency": 0.186285448
+              "latency": 0.192411456
             },
             {
-              "latency": 0.176405942
+              "latency": 0.183154474
             },
             {
-              "latency": 0.185432008
+              "latency": 0.189793379
             },
             {
-              "latency": 0.176347023
+              "latency": 0.193699012
             },
             {
-              "latency": 0.186065336
+              "latency": 0.18104075
             },
             {
-              "latency": 0.18308146
+              "latency": 0.191544617
             },
             {
-              "latency": 0.185387647
+              "latency": 0.186680903
             },
             {
-              "latency": 0.174663199
+              "latency": 0.184681401
             },
             {
-              "latency": 0.190888998
+              "latency": 0.178201234
             },
             {
-              "latency": 0.186559259
+              "latency": 0.194998587
             },
             {
-              "latency": 0.193872109
+              "latency": 0.179636468
             },
             {
-              "latency": 0.187497267
+              "latency": 0.189925731
             },
             {
-              "latency": 0.194882763
+              "latency": 0.186969406
             },
             {
-              "latency": 0.1942011
+              "latency": 0.180127125
             },
             {
-              "latency": 0.180603789
+              "latency": 0.183475765
             },
             {
-              "latency": 0.190207711
+              "latency": 0.192985348
             },
             {
-              "latency": 0.192680613
+              "latency": 0.189097566
             },
             {
-              "latency": 0.191513062
+              "latency": 0.193951777
             },
             {
-              "latency": 0.189225212
+              "latency": 0.181436901
             },
             {
-              "latency": 0.188399391
+              "latency": 0.178586606
             },
             {
-              "latency": 0.189106909
+              "latency": 0.179856966
             },
             {
-              "latency": 0.175074515
+              "latency": 0.180201979
             },
             {
-              "latency": 0.184608229
+              "latency": 0.191594229
             },
             {
-              "latency": 0.189089824
+              "latency": 0.196091922
             },
             {
-              "latency": 0.192654121
+              "latency": 0.194219892
             },
             {
-              "latency": 0.177505065
+              "latency": 0.192522551
             },
             {
-              "latency": 0.18629863
+              "latency": 0.187786397
             },
             {
-              "latency": 0.186561763
+              "latency": 0.192274582
             },
             {
-              "latency": 0.177427279
+              "latency": 0.178288945
             },
             {
-              "latency": 0.195853172
+              "latency": 0.192671711
             },
             {
-              "latency": 0.190934272
+              "latency": 0.189423477
             },
             {
-              "latency": 0.190450403
+              "latency": 0.181164996
             },
             {
-              "latency": 0.183818528
+              "latency": 0.186369674
             },
             {
-              "latency": 0.187952646
+              "latency": 0.190700246
             },
             {
-              "latency": 0.192112249
+              "latency": 0.187744401
             },
             {
-              "latency": 0.179524853
+              "latency": 0.182324192
             },
             {
-              "latency": 0.19325288
+              "latency": 0.189598931
             },
             {
-              "latency": 0.196650124
+              "latency": 0.196607228
             },
             {
-              "latency": 0.193748149
+              "latency": 0.187071643
             },
             {
-              "latency": 0.196006019
+              "latency": 0.191964036
             },
             {
-              "latency": 0.183118388
+              "latency": 0.193843733
             },
             {
-              "latency": 0.19490404
+              "latency": 0.181391708
             },
             {
-              "latency": 0.190942743
+              "latency": 0.188757624
             },
             {
-              "latency": 0.191771953
+              "latency": 0.183353697
             },
             {
-              "latency": 0.190220998
+              "latency": 0.186387892
             },
             {
-              "latency": 0.186876802
+              "latency": 0.183802869
             },
             {
-              "latency": 0.185027346
+              "latency": 0.186582892
             },
             {
-              "latency": 0.184701586
+              "latency": 0.195209015
             },
             {
-              "latency": 0.180249303
+              "latency": 0.180370885
             },
             {
-              "latency": 0.186354886
+              "latency": 0.188749239
             },
             {
-              "latency": 0.187893121
+              "latency": 0.188363144
             },
             {
-              "latency": 0.195664788
+              "latency": 0.186546855
             },
             {
-              "latency": 0.182966189
+              "latency": 0.180555902
             },
             {
-              "latency": 0.177966943
+              "latency": 0.18824631
             },
             {
-              "latency": 0.187846701
+              "latency": 0.19458154
             },
             {
-              "latency": 0.192007943
+              "latency": 0.190109293
             },
             {
-              "latency": 0.184897233
+              "latency": 0.194537186
             },
             {
-              "latency": 0.182273479
+              "latency": 0.186403431
             },
             {
-              "latency": 0.184454299
+              "latency": 0.17951082
             },
             {
-              "latency": 0.186888274
+              "latency": 0.191254675
             },
             {
-              "latency": 0.186191167
+              "latency": 0.193843565
             },
             {
-              "latency": 0.190498346
+              "latency": 0.183220511
             },
             {
-              "latency": 0.189539205
+              "latency": 0.176310991
             },
             {
-              "latency": 0.192143847
+              "latency": 0.193939589
             },
             {
-              "latency": 0.1894574
+              "latency": 0.192416016
             },
             {
-              "latency": 0.187743951
+              "latency": 0.187443431
             },
             {
-              "latency": 0.186148253
+              "latency": 0.186505826
             },
             {
-              "latency": 0.182013175
+              "latency": 0.187148986
             },
             {
-              "latency": 0.189546266
+              "latency": 0.184515852
             },
             {
-              "latency": 0.183328261
+              "latency": 0.191141286
             },
             {
-              "latency": 0.192722045
+              "latency": 0.185594935
             },
             {
-              "latency": 0.192479726
+              "latency": 0.19103688
             },
             {
-              "latency": 0.194023483
+              "latency": 0.194180515
             },
             {
-              "latency": 0.180465866
+              "latency": 0.189610721
             },
             {
-              "latency": 0.18451437
+              "latency": 0.189543587
             },
             {
-              "latency": 0.18689978
+              "latency": 0.184003378
             },
             {
-              "latency": 0.191362332
+              "latency": 0.192176496
             },
             {
-              "latency": 0.181416606
+              "latency": 0.181398182
             },
             {
-              "latency": 0.194491003
+              "latency": 0.192565254
             },
             {
-              "latency": 0.177738279
+              "latency": 0.185139335
             },
             {
-              "latency": 0.192290574
+              "latency": 0.1914053
             },
             {
-              "latency": 0.178150788
+              "latency": 0.194573086
             },
             {
-              "latency": 0.193302716
+              "latency": 0.17961313
             },
             {
-              "latency": 0.189608437
+              "latency": 0.175065798
             },
             {
-              "latency": 0.184163772
+              "latency": 0.192552441
             },
             {
-              "latency": 0.187736359
+              "latency": 0.183442162
             },
             {
-              "latency": 0.191293837
+              "latency": 0.189579775
             },
             {
-              "latency": 0.194335151
+              "latency": 0.184564674
             },
             {
-              "latency": 0.184020802
+              "latency": 0.191932335
             },
             {
-              "latency": 0.196517381
+              "latency": 0.190904123
             },
             {
-              "latency": 0.185730992
+              "latency": 0.185644925
             },
             {
-              "latency": 0.182074276
+              "latency": 0.186823936
             },
             {
-              "latency": 0.184172047
+              "latency": 0.194164782
             },
             {
-              "latency": 0.193337752
+              "latency": 0.190613626
             },
             {
-              "latency": 0.185052817
+              "latency": 0.189539427
             },
             {
-              "latency": 0.182572869
+              "latency": 0.194340185
             },
             {
-              "latency": 0.191465903
+              "latency": 0.187782284
             },
             {
-              "latency": 0.181616939
+              "latency": 0.192670484
             }
           ],
           "implementation": "rust-libp2p",
@@ -1529,304 +1529,304 @@
         {
           "result": [
             {
-              "latency": 0.119845998
+              "latency": 0.123276392
             },
             {
-              "latency": 0.130142466
+              "latency": 0.120475341
             },
             {
-              "latency": 0.128370475
+              "latency": 0.130001909
             },
             {
-              "latency": 0.129222369
+              "latency": 0.129379616
             },
             {
-              "latency": 0.122353241
+              "latency": 0.12861122
             },
             {
-              "latency": 0.121593614
+              "latency": 0.116627012
             },
             {
-              "latency": 0.122236919
+              "latency": 0.124845813
             },
             {
-              "latency": 0.128402913
+              "latency": 0.127151755
             },
             {
-              "latency": 0.132424013
+              "latency": 0.12683793
             },
             {
-              "latency": 0.124329404
+              "latency": 0.122322219
             },
             {
-              "latency": 0.124243355
+              "latency": 0.123653201
             },
             {
-              "latency": 0.128347501
+              "latency": 0.130983224
             },
             {
-              "latency": 0.131018757
+              "latency": 0.128379513
             },
             {
-              "latency": 0.129350357
+              "latency": 0.124183694
             },
             {
-              "latency": 0.121616748
+              "latency": 0.12334287
             },
             {
-              "latency": 0.12960626
+              "latency": 0.129752007
             },
             {
-              "latency": 0.125121356
+              "latency": 0.126590695
             },
             {
-              "latency": 0.127564224
+              "latency": 0.123619453
             },
             {
-              "latency": 0.125380162
+              "latency": 0.124521745
             },
             {
-              "latency": 0.123578812
+              "latency": 0.122188226
             },
             {
-              "latency": 0.127403748
+              "latency": 0.127358426
             },
             {
-              "latency": 0.129620302
+              "latency": 0.12592717
             },
             {
-              "latency": 0.125642955
+              "latency": 0.119957896
             },
             {
-              "latency": 0.124485655
+              "latency": 0.129618406
             },
             {
-              "latency": 0.124489648
+              "latency": 0.118990386
             },
             {
-              "latency": 0.124281894
+              "latency": 0.126991864
             },
             {
-              "latency": 0.115382267
+              "latency": 0.120591392
             },
             {
-              "latency": 0.126949023
+              "latency": 0.12757593
             },
             {
-              "latency": 0.124708411
+              "latency": 0.130995569
             },
             {
-              "latency": 0.127284515
+              "latency": 0.123755555
             },
             {
-              "latency": 0.1275802
+              "latency": 0.126461191
             },
             {
-              "latency": 0.121152718
+              "latency": 0.129524831
             },
             {
-              "latency": 0.122635073
+              "latency": 0.121201289
             },
             {
-              "latency": 0.125914965
+              "latency": 0.1213488
             },
             {
-              "latency": 0.121389974
+              "latency": 0.126740105
             },
             {
-              "latency": 0.123763368
+              "latency": 0.122462219
             },
             {
-              "latency": 0.120778608
+              "latency": 0.129813433
             },
             {
-              "latency": 0.122173008
+              "latency": 0.12453865
             },
             {
-              "latency": 0.126302877
+              "latency": 0.128731273
             },
             {
-              "latency": 0.125574487
+              "latency": 0.131617495
             },
             {
-              "latency": 0.126255944
+              "latency": 0.121413546
             },
             {
-              "latency": 0.120185703
+              "latency": 0.128579371
             },
             {
-              "latency": 0.12581047
+              "latency": 0.129644786
             },
             {
-              "latency": 0.12097257
+              "latency": 0.127734079
             },
             {
-              "latency": 0.130527281
+              "latency": 0.117014776
             },
             {
-              "latency": 0.125371829
+              "latency": 0.127334311
             },
             {
-              "latency": 0.124272672
+              "latency": 0.120994042
             },
             {
-              "latency": 0.128551076
+              "latency": 0.129226169
             },
             {
-              "latency": 0.127083617
+              "latency": 0.126374601
             },
             {
-              "latency": 0.130898498
+              "latency": 0.122385816
             },
             {
-              "latency": 0.131964743
+              "latency": 0.125369074
             },
             {
-              "latency": 0.123922107
+              "latency": 0.12945342
             },
             {
-              "latency": 0.129761968
+              "latency": 0.130410394
             },
             {
-              "latency": 0.121467433
+              "latency": 0.124536901
             },
             {
-              "latency": 0.124291374
+              "latency": 0.130894383
             },
             {
-              "latency": 0.125832092
+              "latency": 0.126070284
             },
             {
-              "latency": 0.12098134
+              "latency": 0.123707233
             },
             {
-              "latency": 0.123958307
+              "latency": 0.125989785
             },
             {
-              "latency": 0.125526771
+              "latency": 0.129533527
             },
             {
-              "latency": 0.119141488
+              "latency": 0.125445686
             },
             {
-              "latency": 0.12858195
+              "latency": 0.11679691
             },
             {
-              "latency": 0.129935553
+              "latency": 0.129002178
             },
             {
-              "latency": 0.130833251
+              "latency": 0.124485696
             },
             {
-              "latency": 0.127976841
+              "latency": 0.123631551
             },
             {
-              "latency": 0.125755947
+              "latency": 0.123590584
             },
             {
-              "latency": 0.128658794
+              "latency": 0.120186334
             },
             {
-              "latency": 0.125333435
+              "latency": 0.130309507
             },
             {
-              "latency": 0.12177683
+              "latency": 0.127390056
             },
             {
-              "latency": 0.125108404
+              "latency": 0.12227457
             },
             {
-              "latency": 0.118920529
+              "latency": 0.121441414
             },
             {
-              "latency": 0.124151757
+              "latency": 0.123933561
             },
             {
-              "latency": 0.125573485
+              "latency": 0.12613447
             },
             {
-              "latency": 0.120217338
+              "latency": 0.129767597
             },
             {
-              "latency": 0.121248553
+              "latency": 0.128926516
             },
             {
-              "latency": 0.126122559
+              "latency": 0.126456323
             },
             {
-              "latency": 0.129720037
+              "latency": 0.115585511
             },
             {
-              "latency": 0.124818587
+              "latency": 0.131583219
             },
             {
-              "latency": 0.130848584
+              "latency": 0.126838957
             },
             {
-              "latency": 0.121945795
+              "latency": 0.126360132
             },
             {
-              "latency": 0.123748736
+              "latency": 0.126476447
             },
             {
-              "latency": 0.127744861
+              "latency": 0.120305065
             },
             {
-              "latency": 0.132332068
+              "latency": 0.131292257
             },
             {
-              "latency": 0.127574218
+              "latency": 0.128034558
             },
             {
-              "latency": 0.124493355
+              "latency": 0.127022279
             },
             {
-              "latency": 0.123166008
+              "latency": 0.126894805
             },
             {
-              "latency": 0.123632322
+              "latency": 0.130081538
             },
             {
-              "latency": 0.125838976
+              "latency": 0.118000286
             },
             {
-              "latency": 0.12742818
+              "latency": 0.127866032
             },
             {
-              "latency": 0.125742046
+              "latency": 0.122115477
             },
             {
-              "latency": 0.117168981
+              "latency": 0.128478789
             },
             {
-              "latency": 0.123137113
+              "latency": 0.132344615
             },
             {
-              "latency": 0.127353258
+              "latency": 0.125978719
             },
             {
-              "latency": 0.130367638
+              "latency": 0.126002943
             },
             {
-              "latency": 0.122569134
+              "latency": 0.126476129
             },
             {
-              "latency": 0.12102493
+              "latency": 0.128620826
             },
             {
-              "latency": 0.123774089
+              "latency": 0.129547225
             },
             {
-              "latency": 0.129964187
+              "latency": 0.128374094
             },
             {
-              "latency": 0.1228657
+              "latency": 0.127214501
             },
             {
-              "latency": 0.124129161
+              "latency": 0.123055021
             },
             {
-              "latency": 0.126898652
+              "latency": 0.129480901
             }
           ],
           "implementation": "rust-libp2p",
@@ -1836,304 +1836,304 @@
         {
           "result": [
             {
-              "latency": 0.180485473
+              "latency": 0.189179014
             },
             {
-              "latency": 0.186150166
+              "latency": 0.186346635
             },
             {
-              "latency": 0.183508665
+              "latency": 0.187458629
             },
             {
-              "latency": 0.184443951
+              "latency": 0.186704148
             },
             {
-              "latency": 0.188579424
+              "latency": 0.190423159
             },
             {
-              "latency": 0.189311749
+              "latency": 0.191635793
             },
             {
-              "latency": 0.186439114
+              "latency": 0.186393059
             },
             {
-              "latency": 0.185801274
+              "latency": 0.185044612
             },
             {
-              "latency": 0.191357691
+              "latency": 0.18150695
             },
             {
-              "latency": 0.188070199
+              "latency": 0.188685187
             },
             {
-              "latency": 0.188785144
+              "latency": 0.191944019
             },
             {
-              "latency": 0.182515775
+              "latency": 0.181788395
             },
             {
-              "latency": 0.19444946
+              "latency": 0.19406981
             },
             {
-              "latency": 0.186693664
+              "latency": 0.183321971
             },
             {
-              "latency": 0.181292031
+              "latency": 0.183121551
             },
             {
-              "latency": 0.193358963
+              "latency": 0.19046398
             },
             {
-              "latency": 0.188223368
+              "latency": 0.184391436
             },
             {
-              "latency": 0.190050935
+              "latency": 0.185649737
             },
             {
-              "latency": 0.186398448
+              "latency": 0.181835076
             },
             {
-              "latency": 0.190177538
+              "latency": 0.194197535
             },
             {
-              "latency": 0.181634344
+              "latency": 0.189615181
             },
             {
-              "latency": 0.183086376
+              "latency": 0.18176952
             },
             {
-              "latency": 0.195224724
+              "latency": 0.18991616
             },
             {
-              "latency": 0.194217032
+              "latency": 0.19000046
             },
             {
-              "latency": 0.185407557
+              "latency": 0.194041141
             },
             {
-              "latency": 0.177636831
+              "latency": 0.182471207
             },
             {
-              "latency": 0.176245609
+              "latency": 0.18668001
             },
             {
-              "latency": 0.183935824
+              "latency": 0.181737708
             },
             {
-              "latency": 0.178156484
+              "latency": 0.171228488
             },
             {
-              "latency": 0.189046508
+              "latency": 0.183275731
             },
             {
-              "latency": 0.179509317
+              "latency": 0.194024912
             },
             {
-              "latency": 0.184415695
+              "latency": 0.183181159
             },
             {
-              "latency": 0.184135375
+              "latency": 0.190331232
             },
             {
-              "latency": 0.191983537
+              "latency": 0.185401014
             },
             {
-              "latency": 0.185772459
+              "latency": 0.187804362
             },
             {
-              "latency": 0.185631514
+              "latency": 0.18304435
             },
             {
-              "latency": 0.194776269
+              "latency": 0.179683402
             },
             {
-              "latency": 0.18652965
+              "latency": 0.192879867
             },
             {
-              "latency": 0.191994324
+              "latency": 0.193431078
             },
             {
-              "latency": 0.189056933
+              "latency": 0.191187918
             },
             {
-              "latency": 0.194223088
+              "latency": 0.181496006
             },
             {
-              "latency": 0.186121544
+              "latency": 0.184528288
             },
             {
-              "latency": 0.176073501
+              "latency": 0.191416677
             },
             {
-              "latency": 0.18118799
+              "latency": 0.189034274
             },
             {
-              "latency": 0.18604319
+              "latency": 0.184923565
             },
             {
-              "latency": 0.185310662
+              "latency": 0.192400792
             },
             {
-              "latency": 0.19347909
+              "latency": 0.191932404
             },
             {
-              "latency": 0.190198112
+              "latency": 0.188265461
             },
             {
-              "latency": 0.184895716
+              "latency": 0.191339945
             },
             {
-              "latency": 0.194417191
+              "latency": 0.185692404
             },
             {
-              "latency": 0.181301792
+              "latency": 0.182550527
             },
             {
-              "latency": 0.174577958
+              "latency": 0.1711929
             },
             {
-              "latency": 0.187663332
+              "latency": 0.189663679
             },
             {
-              "latency": 0.193901354
+              "latency": 0.186539819
             },
             {
-              "latency": 0.191457223
+              "latency": 0.186568841
             },
             {
-              "latency": 0.187550297
+              "latency": 0.189258068
             },
             {
-              "latency": 0.193505168
+              "latency": 0.185281066
             },
             {
-              "latency": 0.175543758
+              "latency": 0.192096482
             },
             {
-              "latency": 0.184956693
+              "latency": 0.192633475
             },
             {
-              "latency": 0.184967182
+              "latency": 0.185156903
             },
             {
-              "latency": 0.185784003
+              "latency": 0.195944712
             },
             {
-              "latency": 0.174491883
+              "latency": 0.186097869
             },
             {
-              "latency": 0.188142003
+              "latency": 0.196481881
             },
             {
-              "latency": 0.189713152
+              "latency": 0.185460374
             },
             {
-              "latency": 0.18795817
+              "latency": 0.195286529
             },
             {
-              "latency": 0.183549492
+              "latency": 0.194138365
             },
             {
-              "latency": 0.175936926
+              "latency": 0.183172296
             },
             {
-              "latency": 0.187805179
+              "latency": 0.19030241
             },
             {
-              "latency": 0.190370684
+              "latency": 0.174690789
             },
             {
-              "latency": 0.190526952
+              "latency": 0.186198331
             },
             {
-              "latency": 0.191537369
+              "latency": 0.190711052
             },
             {
-              "latency": 0.182199145
+              "latency": 0.188637751
             },
             {
-              "latency": 0.190720383
+              "latency": 0.186032353
             },
             {
-              "latency": 0.189024631
+              "latency": 0.187738757
             },
             {
-              "latency": 0.191143403
+              "latency": 0.187848413
             },
             {
-              "latency": 0.176173754
+              "latency": 0.179948131
             },
             {
-              "latency": 0.183611064
+              "latency": 0.191664828
             },
             {
-              "latency": 0.186337569
+              "latency": 0.196891139
             },
             {
-              "latency": 0.183304273
+              "latency": 0.189586728
             },
             {
-              "latency": 0.19310219
+              "latency": 0.178231102
             },
             {
-              "latency": 0.188705496
+              "latency": 0.180020154
             },
             {
-              "latency": 0.183240372
+              "latency": 0.187977917
             },
             {
-              "latency": 0.175390484
+              "latency": 0.18105511
             },
             {
-              "latency": 0.181669703
+              "latency": 0.192553155
             },
             {
-              "latency": 0.18704744
+              "latency": 0.187516972
             },
             {
-              "latency": 0.186297405
+              "latency": 0.192787903
             },
             {
-              "latency": 0.181500429
+              "latency": 0.182182042
             },
             {
-              "latency": 0.184474763
+              "latency": 0.193602734
             },
             {
-              "latency": 0.191667047
+              "latency": 0.175529324
             },
             {
-              "latency": 0.182959952
+              "latency": 0.176361646
             },
             {
-              "latency": 0.192005956
+              "latency": 0.183293024
             },
             {
-              "latency": 0.187195933
+              "latency": 0.174766487
             },
             {
-              "latency": 0.190582209
+              "latency": 0.187906582
             },
             {
-              "latency": 0.186385877
+              "latency": 0.186062804
             },
             {
-              "latency": 0.196791502
+              "latency": 0.184865748
             },
             {
-              "latency": 0.189300867
+              "latency": 0.17803894
             },
             {
-              "latency": 0.180051982
+              "latency": 0.186880066
             },
             {
-              "latency": 0.189286262
+              "latency": 0.181575613
             },
             {
-              "latency": 0.18272447
+              "latency": 0.183426629
             },
             {
-              "latency": 0.189204956
+              "latency": 0.179988641
             }
           ],
           "implementation": "rust-libp2p",
@@ -2143,304 +2143,304 @@
         {
           "result": [
             {
-              "latency": 0.13157223
+              "latency": 0.125275028
             },
             {
-              "latency": 0.123848467
+              "latency": 0.128610092
             },
             {
-              "latency": 0.132563273
+              "latency": 0.127767896
             },
             {
-              "latency": 0.122516475
+              "latency": 0.119150259
             },
             {
-              "latency": 0.126803353
+              "latency": 0.129707389
             },
             {
-              "latency": 0.124881153
+              "latency": 0.126236746
             },
             {
-              "latency": 0.127646164
+              "latency": 0.129556083
             },
             {
-              "latency": 0.127391157
+              "latency": 0.129954142
             },
             {
-              "latency": 0.125065177
+              "latency": 0.128610501
             },
             {
-              "latency": 0.119116634
+              "latency": 0.123633907
             },
             {
-              "latency": 0.126306771
+              "latency": 0.122607639
             },
             {
-              "latency": 0.127982877
+              "latency": 0.122904711
             },
             {
-              "latency": 0.124149431
+              "latency": 0.120406318
             },
             {
-              "latency": 0.116876198
+              "latency": 0.126972133
             },
             {
-              "latency": 0.131855722
+              "latency": 0.125638089
             },
             {
-              "latency": 0.127334863
+              "latency": 0.122936983
             },
             {
-              "latency": 0.128639766
+              "latency": 0.126958994
             },
             {
-              "latency": 0.122401963
+              "latency": 0.129229477
             },
             {
-              "latency": 0.121553947
+              "latency": 0.128917869
             },
             {
-              "latency": 0.12594812
+              "latency": 0.130111267
             },
             {
-              "latency": 0.128334748
+              "latency": 0.128079818
             },
             {
-              "latency": 0.120064975
+              "latency": 0.130073164
             },
             {
-              "latency": 0.130498457
+              "latency": 0.119589406
             },
             {
-              "latency": 0.130438126
+              "latency": 0.127874729
             },
             {
-              "latency": 0.129234311
+              "latency": 0.121316621
             },
             {
-              "latency": 0.123784775
+              "latency": 0.13108835
             },
             {
-              "latency": 0.123613866
+              "latency": 0.131576367
             },
             {
-              "latency": 0.123485357
+              "latency": 0.129212126
             },
             {
-              "latency": 0.124333363
+              "latency": 0.126707831
             },
             {
-              "latency": 0.121002628
+              "latency": 0.120374625
             },
             {
-              "latency": 0.12247266
+              "latency": 0.117397549
             },
             {
-              "latency": 0.119991224
+              "latency": 0.131366279
             },
             {
-              "latency": 0.125649333
+              "latency": 0.128216324
             },
             {
-              "latency": 0.124897657
+              "latency": 0.127677644
             },
             {
-              "latency": 0.124924898
+              "latency": 0.12390403
             },
             {
-              "latency": 0.122758444
+              "latency": 0.120458983
             },
             {
-              "latency": 0.127004029
+              "latency": 0.132903025
             },
             {
-              "latency": 0.125453277
+              "latency": 0.125948439
             },
             {
-              "latency": 0.127184156
+              "latency": 0.128720886
             },
             {
-              "latency": 0.122909104
+              "latency": 0.124130668
             },
             {
-              "latency": 0.130525106
+              "latency": 0.120326974
             },
             {
-              "latency": 0.126600769
+              "latency": 0.12731677
             },
             {
-              "latency": 0.126561531
+              "latency": 0.127286387
             },
             {
-              "latency": 0.128304498
+              "latency": 0.124155115
             },
             {
-              "latency": 0.122456948
+              "latency": 0.131223057
             },
             {
-              "latency": 0.123660483
+              "latency": 0.129846572
             },
             {
-              "latency": 0.128908627
+              "latency": 0.128608705
             },
             {
-              "latency": 0.127027495
+              "latency": 0.12854944
             },
             {
-              "latency": 0.124844664
+              "latency": 0.126078115
             },
             {
-              "latency": 0.131118911
+              "latency": 0.128550889
             },
             {
-              "latency": 0.129338571
+              "latency": 0.131828498
             },
             {
-              "latency": 0.130025975
+              "latency": 0.124863586
             },
             {
-              "latency": 0.130427722
+              "latency": 0.123962945
             },
             {
-              "latency": 0.115631164
+              "latency": 0.127910346
             },
             {
-              "latency": 0.131228222
+              "latency": 0.122275632
             },
             {
-              "latency": 0.122708113
+              "latency": 0.125074754
             },
             {
-              "latency": 0.124963875
+              "latency": 0.128078063
             },
             {
-              "latency": 0.130570201
+              "latency": 0.122388484
             },
             {
-              "latency": 0.124979494
+              "latency": 0.12726112
             },
             {
-              "latency": 0.126649047
+              "latency": 0.121659235
             },
             {
-              "latency": 0.12935314
+              "latency": 0.128019582
             },
             {
-              "latency": 0.12056468
+              "latency": 0.128676694
             },
             {
-              "latency": 0.123971523
+              "latency": 0.126196227
             },
             {
-              "latency": 0.125357388
+              "latency": 0.123339628
             },
             {
-              "latency": 0.124928547
+              "latency": 0.129252279
             },
             {
-              "latency": 0.123874147
+              "latency": 0.126272745
             },
             {
-              "latency": 0.122598622
+              "latency": 0.126274096
             },
             {
-              "latency": 0.127058844
+              "latency": 0.128744713
             },
             {
-              "latency": 0.119779108
+              "latency": 0.123731
             },
             {
-              "latency": 0.127789556
+              "latency": 0.128264633
             },
             {
-              "latency": 0.125032086
+              "latency": 0.122572575
             },
             {
-              "latency": 0.127388559
+              "latency": 0.12752454
             },
             {
-              "latency": 0.126140948
+              "latency": 0.129481963
             },
             {
-              "latency": 0.124460125
+              "latency": 0.128034632
             },
             {
-              "latency": 0.123929923
+              "latency": 0.123716736
             },
             {
-              "latency": 0.126760272
+              "latency": 0.128572592
             },
             {
-              "latency": 0.124115006
+              "latency": 0.128029892
             },
             {
-              "latency": 0.125762218
+              "latency": 0.131069824
             },
             {
-              "latency": 0.123419162
+              "latency": 0.125063496
             },
             {
-              "latency": 0.129520247
+              "latency": 0.132692692
             },
             {
-              "latency": 0.122425398
+              "latency": 0.123567987
             },
             {
-              "latency": 0.122067045
+              "latency": 0.128061669
             },
             {
-              "latency": 0.125524727
+              "latency": 0.128295648
             },
             {
-              "latency": 0.12318089
+              "latency": 0.127830816
             },
             {
-              "latency": 0.125489802
+              "latency": 0.130509406
             },
             {
-              "latency": 0.130312235
+              "latency": 0.126723756
             },
             {
-              "latency": 0.125918248
+              "latency": 0.118282894
             },
             {
-              "latency": 0.120572033
+              "latency": 0.13006055
             },
             {
-              "latency": 0.11807764
+              "latency": 0.123958645
             },
             {
-              "latency": 0.12493122
+              "latency": 0.129924661
             },
             {
-              "latency": 0.130435669
+              "latency": 0.126205173
             },
             {
-              "latency": 0.11962244
+              "latency": 0.129743403
             },
             {
-              "latency": 0.124535759
+              "latency": 0.125261128
             },
             {
-              "latency": 0.130132873
+              "latency": 0.123806895
             },
             {
-              "latency": 0.125300416
+              "latency": 0.131155726
             },
             {
-              "latency": 0.122831343
+              "latency": 0.125406105
             },
             {
-              "latency": 0.121365586
+              "latency": 0.124214683
             },
             {
-              "latency": 0.123445417
+              "latency": 0.129591095
             },
             {
-              "latency": 0.122592537
+              "latency": 0.122420879
             },
             {
-              "latency": 0.122297784
+              "latency": 0.126166731
             }
           ],
           "implementation": "rust-libp2p",
@@ -2450,304 +2450,304 @@
         {
           "result": [
             {
-              "latency": 0.185103189
+              "latency": 0.192217083
             },
             {
-              "latency": 0.188694883
+              "latency": 0.188112098
             },
             {
-              "latency": 0.188597605
+              "latency": 0.184690269
             },
             {
-              "latency": 0.19301797
+              "latency": 0.170675526
             },
             {
-              "latency": 0.187378076
+              "latency": 0.187434557
             },
             {
-              "latency": 0.19142034
+              "latency": 0.18587156
             },
             {
-              "latency": 0.185358784
+              "latency": 0.18107949
             },
             {
-              "latency": 0.179558898
+              "latency": 0.192015944
             },
             {
-              "latency": 0.189891228
+              "latency": 0.18633219
             },
             {
-              "latency": 0.176503108
+              "latency": 0.194150176
             },
             {
-              "latency": 0.180154453
+              "latency": 0.189018544
             },
             {
-              "latency": 0.193373753
+              "latency": 0.186161411
             },
             {
-              "latency": 0.183361574
+              "latency": 0.190369555
             },
             {
-              "latency": 0.175585704
+              "latency": 0.17929416
             },
             {
-              "latency": 0.179226581
+              "latency": 0.186739068
             },
             {
-              "latency": 0.182209775
+              "latency": 0.184651014
             },
             {
-              "latency": 0.191560021
+              "latency": 0.183799811
             },
             {
-              "latency": 0.189236235
+              "latency": 0.189356855
             },
             {
-              "latency": 0.185626315
+              "latency": 0.19352993
             },
             {
-              "latency": 0.187206367
+              "latency": 0.184778849
             },
             {
-              "latency": 0.187751323
+              "latency": 0.19223893
             },
             {
-              "latency": 0.191988954
+              "latency": 0.189195866
             },
             {
-              "latency": 0.190150548
+              "latency": 0.184757286
             },
             {
-              "latency": 0.191200187
+              "latency": 0.191856286
             },
             {
-              "latency": 0.182548148
+              "latency": 0.182276109
             },
             {
-              "latency": 0.185461038
+              "latency": 0.192178893
             },
             {
-              "latency": 0.18518695
+              "latency": 0.194787832
             },
             {
-              "latency": 0.190265888
+              "latency": 0.193568496
             },
             {
-              "latency": 0.193448759
+              "latency": 0.184829939
             },
             {
-              "latency": 0.189384
+              "latency": 0.18352955
             },
             {
-              "latency": 0.184453226
+              "latency": 0.186601817
             },
             {
-              "latency": 0.189993669
+              "latency": 0.188776197
             },
             {
-              "latency": 0.183245476
+              "latency": 0.18319026
             },
             {
-              "latency": 0.17764358
+              "latency": 0.190396565
             },
             {
-              "latency": 0.180633104
+              "latency": 0.180793266
             },
             {
-              "latency": 0.183508428
+              "latency": 0.189609173
             },
             {
-              "latency": 0.184267867
+              "latency": 0.18737005
             },
             {
-              "latency": 0.187276065
+              "latency": 0.191660098
             },
             {
-              "latency": 0.182137428
+              "latency": 0.180611805
             },
             {
-              "latency": 0.193781775
+              "latency": 0.189401186
             },
             {
-              "latency": 0.172662395
+              "latency": 0.193172233
             },
             {
-              "latency": 0.181634671
+              "latency": 0.181449265
             },
             {
-              "latency": 0.194044304
+              "latency": 0.192369124
             },
             {
-              "latency": 0.186855084
+              "latency": 0.190733356
             },
             {
-              "latency": 0.179433531
+              "latency": 0.189280974
             },
             {
-              "latency": 0.181049535
+              "latency": 0.182930565
             },
             {
-              "latency": 0.1856744
+              "latency": 0.193022756
             },
             {
-              "latency": 0.189222782
+              "latency": 0.186147802
             },
             {
-              "latency": 0.175861652
+              "latency": 0.187602504
             },
             {
-              "latency": 0.191689304
+              "latency": 0.186031488
             },
             {
-              "latency": 0.18812646
+              "latency": 0.186570516
             },
             {
-              "latency": 0.191178252
+              "latency": 0.192286486
             },
             {
-              "latency": 0.190583972
+              "latency": 0.181390233
             },
             {
-              "latency": 0.178512175
+              "latency": 0.177657325
             },
             {
-              "latency": 0.184659856
+              "latency": 0.192050131
             },
             {
-              "latency": 0.178716709
+              "latency": 0.1916059
             },
             {
-              "latency": 0.180439508
+              "latency": 0.184643452
             },
             {
-              "latency": 0.18560001
+              "latency": 0.185367246
             },
             {
-              "latency": 0.187271667
+              "latency": 0.184145772
             },
             {
-              "latency": 0.182626845
+              "latency": 0.190495395
             },
             {
-              "latency": 0.193704512
+              "latency": 0.191298168
             },
             {
-              "latency": 0.194319702
+              "latency": 0.189013052
             },
             {
-              "latency": 0.192920897
+              "latency": 0.191208059
             },
             {
-              "latency": 0.194231974
+              "latency": 0.184269597
             },
             {
-              "latency": 0.174012121
+              "latency": 0.183106917
             },
             {
-              "latency": 0.191511569
+              "latency": 0.187749555
             },
             {
-              "latency": 0.185713405
+              "latency": 0.184991296
             },
             {
-              "latency": 0.185075832
+              "latency": 0.193826954
             },
             {
-              "latency": 0.195798471
+              "latency": 0.178223782
             },
             {
-              "latency": 0.174768264
+              "latency": 0.190726535
             },
             {
-              "latency": 0.190303276
+              "latency": 0.179372425
             },
             {
-              "latency": 0.184872402
+              "latency": 0.172664516
             },
             {
-              "latency": 0.185001426
+              "latency": 0.184251488
             },
             {
-              "latency": 0.189920774
+              "latency": 0.190163511
             },
             {
-              "latency": 0.185214084
+              "latency": 0.195192407
             },
             {
-              "latency": 0.184582448
+              "latency": 0.192936307
             },
             {
-              "latency": 0.187735052
+              "latency": 0.183610187
             },
             {
-              "latency": 0.188610502
+              "latency": 0.178241551
             },
             {
-              "latency": 0.180589916
+              "latency": 0.192386722
             },
             {
-              "latency": 0.19192717
+              "latency": 0.193685116
             },
             {
-              "latency": 0.19602933
+              "latency": 0.184594255
             },
             {
-              "latency": 0.193350282
+              "latency": 0.172252605
             },
             {
-              "latency": 0.181196561
+              "latency": 0.186092129
             },
             {
-              "latency": 0.174655644
+              "latency": 0.178878851
             },
             {
-              "latency": 0.191128316
+              "latency": 0.187011399
             },
             {
-              "latency": 0.183366416
+              "latency": 0.184491136
             },
             {
-              "latency": 0.190008769
+              "latency": 0.176620408
             },
             {
-              "latency": 0.185273161
+              "latency": 0.183093737
             },
             {
-              "latency": 0.191561015
+              "latency": 0.192989067
             },
             {
-              "latency": 0.185720607
+              "latency": 0.188982369
             },
             {
-              "latency": 0.189580764
+              "latency": 0.18714761
             },
             {
-              "latency": 0.18279041
+              "latency": 0.191018486
             },
             {
-              "latency": 0.195449628
+              "latency": 0.186367345
             },
             {
-              "latency": 0.189558663
+              "latency": 0.195896297
             },
             {
-              "latency": 0.189122374
+              "latency": 0.177907831
             },
             {
-              "latency": 0.184844807
+              "latency": 0.193055878
             },
             {
-              "latency": 0.181579248
+              "latency": 0.18566966
             },
             {
-              "latency": 0.188462207
+              "latency": 0.186067086
             },
             {
-              "latency": 0.192760418
+              "latency": 0.191816208
             },
             {
-              "latency": 0.18606756
+              "latency": 0.184365671
             }
           ],
           "implementation": "https",
@@ -2757,304 +2757,304 @@
         {
           "result": [
             {
-              "latency": 0.361175268
+              "latency": 0.376317157
             },
             {
-              "latency": 0.30275689
+              "latency": 0.306057682
             },
             {
-              "latency": 0.308378693
+              "latency": 0.371006317
             },
             {
-              "latency": 0.367169458
+              "latency": 0.322710859
             },
             {
-              "latency": 0.311008599
+              "latency": 0.382943603
             },
             {
-              "latency": 0.355918851
+              "latency": 0.371200558
             },
             {
-              "latency": 0.308726832
+              "latency": 0.31244236
             },
             {
-              "latency": 0.328630544
+              "latency": 0.305396238
             },
             {
-              "latency": 0.370112243
+              "latency": 0.31479173
             },
             {
-              "latency": 0.326939344
+              "latency": 0.391939558
             },
             {
-              "latency": 0.318540244
+              "latency": 0.313222323
             },
             {
-              "latency": 0.300511465
+              "latency": 0.302328505
             },
             {
-              "latency": 0.310771298
+              "latency": 0.309499095
             },
             {
-              "latency": 0.314146345
+              "latency": 0.322475989
             },
             {
-              "latency": 0.304800098
+              "latency": 0.380464776
             },
             {
-              "latency": 0.307291346
+              "latency": 0.322381975
             },
             {
-              "latency": 0.31031901
+              "latency": 0.367018623
             },
             {
-              "latency": 0.304484812
+              "latency": 0.365384292
             },
             {
-              "latency": 0.354304786
+              "latency": 0.312495026
             },
             {
-              "latency": 0.311014654
+              "latency": 0.316982439
             },
             {
-              "latency": 0.380720874
+              "latency": 0.382773901
             },
             {
-              "latency": 0.368915304
+              "latency": 0.310454677
             },
             {
-              "latency": 0.31312659
+              "latency": 0.307204646
             },
             {
-              "latency": 0.360102333
+              "latency": 0.322141504
             },
             {
-              "latency": 0.312724539
+              "latency": 0.385754359
             },
             {
-              "latency": 0.325452886
+              "latency": 0.392232399
             },
             {
-              "latency": 0.316612881
+              "latency": 0.317533688
             },
             {
-              "latency": 0.307712598
+              "latency": 0.370203763
             },
             {
-              "latency": 0.308352151
+              "latency": 0.304397095
             },
             {
-              "latency": 0.307286397
+              "latency": 0.368483721
             },
             {
-              "latency": 0.322531939
+              "latency": 0.323683721
             },
             {
-              "latency": 0.314525351
+              "latency": 0.306611966
             },
             {
-              "latency": 0.30996224
+              "latency": 0.324728695
             },
             {
-              "latency": 0.373016242
+              "latency": 0.304455114
             },
             {
-              "latency": 0.315682768
+              "latency": 0.362719075
             },
             {
-              "latency": 0.376301532
+              "latency": 0.310731453
             },
             {
-              "latency": 0.302718924
+              "latency": 0.374273606
             },
             {
-              "latency": 0.367739517
+              "latency": 0.321010151
             },
             {
-              "latency": 0.357284019
+              "latency": 0.300020537
             },
             {
-              "latency": 0.305407461
+              "latency": 0.303348512
             },
             {
-              "latency": 0.296566085
+              "latency": 0.320662076
             },
             {
-              "latency": 0.29871731
+              "latency": 0.375507086
             },
             {
-              "latency": 0.303875109
+              "latency": 0.376148002
             },
             {
-              "latency": 0.316953361
+              "latency": 0.367309344
             },
             {
-              "latency": 0.308843925
+              "latency": 0.31412059
             },
             {
-              "latency": 0.384137947
+              "latency": 0.295873942
             },
             {
-              "latency": 0.325296112
+              "latency": 0.310184489
             },
             {
-              "latency": 0.305455686
+              "latency": 0.30114126
             },
             {
-              "latency": 0.308921425
+              "latency": 0.305295443
             },
             {
-              "latency": 0.360697001
+              "latency": 0.315479252
             },
             {
-              "latency": 0.305522539
+              "latency": 0.392413074
             },
             {
-              "latency": 0.385620665
+              "latency": 0.316496871
             },
             {
-              "latency": 0.296085128
+              "latency": 0.382461403
             },
             {
-              "latency": 0.39240176
+              "latency": 0.365227582
             },
             {
-              "latency": 0.362554436
+              "latency": 0.355268542
             },
             {
-              "latency": 0.370016779
+              "latency": 0.383690159
             },
             {
-              "latency": 0.298452941
+              "latency": 0.309240762
             },
             {
-              "latency": 0.307355417
+              "latency": 0.306509242
             },
             {
-              "latency": 0.321745003
+              "latency": 0.38330132
             },
             {
-              "latency": 0.315082818
+              "latency": 0.309438074
             },
             {
-              "latency": 0.301602783
+              "latency": 0.378588582
             },
             {
-              "latency": 0.37632363
+              "latency": 0.366827452
             },
             {
-              "latency": 0.38017455
+              "latency": 0.315929131
             },
             {
-              "latency": 0.312710169
+              "latency": 0.297017123
             },
             {
-              "latency": 0.385396091
+              "latency": 0.368913557
             },
             {
-              "latency": 0.30292301
+              "latency": 0.316837176
             },
             {
-              "latency": 0.319213105
+              "latency": 0.353323857
             },
             {
-              "latency": 0.312815685
+              "latency": 0.301625424
             },
             {
-              "latency": 0.320632716
+              "latency": 0.387999799
             },
             {
-              "latency": 0.320164322
+              "latency": 0.306238546
             },
             {
-              "latency": 0.307515072
+              "latency": 0.293840581
             },
             {
-              "latency": 0.311269813
+              "latency": 0.322324953
             },
             {
-              "latency": 0.316374179
+              "latency": 0.298316945
             },
             {
-              "latency": 0.374962081
+              "latency": 0.306935389
             },
             {
-              "latency": 0.310939086
+              "latency": 0.317264648
             },
             {
-              "latency": 0.296580305
+              "latency": 0.312872275
             },
             {
-              "latency": 0.308087703
+              "latency": 0.372826689
             },
             {
-              "latency": 0.318682255
+              "latency": 0.366174549
             },
             {
-              "latency": 0.303351387
+              "latency": 0.380254827
             },
             {
-              "latency": 0.375706666
+              "latency": 0.384410085
             },
             {
-              "latency": 0.351676581
+              "latency": 0.314303694
             },
             {
-              "latency": 0.307963658
+              "latency": 0.301084158
             },
             {
-              "latency": 0.387126661
+              "latency": 0.370230686
             },
             {
-              "latency": 0.304663055
+              "latency": 0.303849343
             },
             {
-              "latency": 0.316688567
+              "latency": 0.363079228
             },
             {
-              "latency": 0.376212246
+              "latency": 0.374156599
             },
             {
-              "latency": 0.30517305
+              "latency": 0.370801659
             },
             {
-              "latency": 0.378628976
+              "latency": 0.319587912
             },
             {
-              "latency": 0.320191005
+              "latency": 0.318035087
             },
             {
-              "latency": 0.311069042
+              "latency": 0.381502162
             },
             {
-              "latency": 0.295520318
+              "latency": 0.322719002
             },
             {
-              "latency": 0.305927208
+              "latency": 0.312373382
             },
             {
-              "latency": 0.316546666
+              "latency": 0.389811596
             },
             {
-              "latency": 0.30786616
+              "latency": 0.311728363
             },
             {
-              "latency": 0.297869031
+              "latency": 0.315704929
             },
             {
-              "latency": 0.314197386
+              "latency": 0.375620709
             },
             {
-              "latency": 0.381471379
+              "latency": 0.382014545
             },
             {
-              "latency": 0.315354254
+              "latency": 0.314126693
             },
             {
-              "latency": 0.323793011
+              "latency": 0.318440181
             },
             {
-              "latency": 0.315832317
+              "latency": 0.302484761
             }
           ],
           "implementation": "go-libp2p",
@@ -3064,304 +3064,304 @@
         {
           "result": [
             {
-              "latency": 0.187441926
+              "latency": 0.18459799
             },
             {
-              "latency": 0.187519826
+              "latency": 0.185395657
             },
             {
-              "latency": 0.194523127
+              "latency": 0.196001093
             },
             {
-              "latency": 0.188636796
+              "latency": 0.18803513
             },
             {
-              "latency": 0.187295547
+              "latency": 0.188890528
             },
             {
-              "latency": 0.187616337
+              "latency": 0.189242405
             },
             {
-              "latency": 0.18616792
+              "latency": 0.186821505
             },
             {
-              "latency": 0.195532521
+              "latency": 0.19786605
             },
             {
-              "latency": 0.189303543
+              "latency": 0.182365512
             },
             {
-              "latency": 0.188699086
+              "latency": 0.193277067
             },
             {
-              "latency": 0.19619727
+              "latency": 0.19593583
             },
             {
-              "latency": 0.193585372
+              "latency": 0.195189427
             },
             {
-              "latency": 0.191223504
+              "latency": 0.184202604
             },
             {
-              "latency": 0.192024019
+              "latency": 0.193460842
             },
             {
-              "latency": 0.186947658
+              "latency": 0.191349363
             },
             {
-              "latency": 0.179771654
+              "latency": 0.191023173
             },
             {
-              "latency": 0.191989536
+              "latency": 0.189019516
             },
             {
-              "latency": 0.191372521
+              "latency": 0.190223488
             },
             {
-              "latency": 0.186488854
+              "latency": 0.197302975
             },
             {
-              "latency": 0.195771459
+              "latency": 0.197742084
             },
             {
-              "latency": 0.193486765
+              "latency": 0.185972929
             },
             {
-              "latency": 0.186664918
+              "latency": 0.192939091
             },
             {
-              "latency": 0.189571419
+              "latency": 0.186962865
             },
             {
-              "latency": 0.187541772
+              "latency": 0.195953848
             },
             {
-              "latency": 0.179203986
+              "latency": 0.194447799
             },
             {
-              "latency": 0.180173435
+              "latency": 0.195343821
             },
             {
-              "latency": 0.18615946
+              "latency": 0.178995951
             },
             {
-              "latency": 0.18667274
+              "latency": 0.19379857
             },
             {
-              "latency": 0.19287719
+              "latency": 0.192325996
             },
             {
-              "latency": 0.193519864
+              "latency": 0.191343916
             },
             {
-              "latency": 0.193939548
+              "latency": 0.184999077
             },
             {
-              "latency": 0.187744769
+              "latency": 0.180677926
             },
             {
-              "latency": 0.197202707
+              "latency": 0.195227463
             },
             {
-              "latency": 0.195331149
+              "latency": 0.18811245
             },
             {
-              "latency": 0.181942645
+              "latency": 0.198817861
             },
             {
-              "latency": 0.186778251
+              "latency": 0.194008737
             },
             {
-              "latency": 0.191285484
+              "latency": 0.19505053
             },
             {
-              "latency": 0.194842366
+              "latency": 0.191672474
             },
             {
-              "latency": 0.194688086
+              "latency": 0.192448807
             },
             {
-              "latency": 0.187802968
+              "latency": 0.192557627
             },
             {
-              "latency": 0.188976577
+              "latency": 0.198582017
             },
             {
-              "latency": 0.192033011
+              "latency": 0.183451701
             },
             {
-              "latency": 0.186824432
+              "latency": 0.195071134
             },
             {
-              "latency": 0.19139243
+              "latency": 0.187093376
             },
             {
-              "latency": 0.188556894
+              "latency": 0.192748342
             },
             {
-              "latency": 0.186626756
+              "latency": 0.194477518
             },
             {
-              "latency": 0.187351655
+              "latency": 0.189969332
             },
             {
-              "latency": 0.181379875
+              "latency": 0.190898593
             },
             {
-              "latency": 0.18775405
+              "latency": 4.380195799
             },
             {
-              "latency": 0.187001403
+              "latency": 0.192346761
             },
             {
-              "latency": 0.188667014
+              "latency": 0.193775336
             },
             {
-              "latency": 0.189902037
+              "latency": 0.188028174
             },
             {
-              "latency": 0.181211041
+              "latency": 0.189799884
             },
             {
-              "latency": 0.185219427
+              "latency": 0.19453083
             },
             {
-              "latency": 0.190117437
+              "latency": 0.190743583
             },
             {
-              "latency": 0.178794197
+              "latency": 0.188161168
             },
             {
-              "latency": 0.193689757
+              "latency": 0.190660841
             },
             {
-              "latency": 0.186274477
+              "latency": 0.185695763
             },
             {
-              "latency": 0.195265522
+              "latency": 0.191936496
             },
             {
-              "latency": 0.198959727
+              "latency": 0.184785452
             },
             {
-              "latency": 0.19064636
+              "latency": 0.190590851
             },
             {
-              "latency": 0.196609054
+              "latency": 0.180526757
             },
             {
-              "latency": 0.197537579
+              "latency": 0.182705083
             },
             {
-              "latency": 0.193061468
+              "latency": 0.189903952
             },
             {
-              "latency": 0.175183251
+              "latency": 0.190079205
             },
             {
-              "latency": 0.180245272
+              "latency": 0.192051443
             },
             {
-              "latency": 0.195846626
+              "latency": 0.196812704
             },
             {
-              "latency": 0.175054923
+              "latency": 0.187464296
             },
             {
-              "latency": 0.183034878
+              "latency": 0.189166966
             },
             {
-              "latency": 0.186330551
+              "latency": 0.187600151
             },
             {
-              "latency": 0.187038336
+              "latency": 0.187550946
             },
             {
-              "latency": 0.187643005
+              "latency": 0.183998533
             },
             {
-              "latency": 0.187739424
+              "latency": 0.183971675
             },
             {
-              "latency": 0.183758499
+              "latency": 0.188934445
             },
             {
-              "latency": 0.179761235
+              "latency": 0.191226129
             },
             {
-              "latency": 0.189645963
+              "latency": 0.193838859
             },
             {
-              "latency": 0.183288398
+              "latency": 0.184236094
             },
             {
-              "latency": 0.185467371
+              "latency": 0.19477038
             },
             {
-              "latency": 0.195381213
+              "latency": 0.18724714
             },
             {
-              "latency": 0.189426895
+              "latency": 0.187968977
             },
             {
-              "latency": 0.185906265
+              "latency": 0.183836416
             },
             {
-              "latency": 0.186748227
+              "latency": 0.183600203
             },
             {
-              "latency": 0.188339919
+              "latency": 0.194291511
             },
             {
-              "latency": 0.188589445
+              "latency": 0.182355171
             },
             {
-              "latency": 0.188076936
+              "latency": 0.188816034
             },
             {
-              "latency": 0.187328752
+              "latency": 0.191630685
             },
             {
-              "latency": 0.187582266
+              "latency": 0.177400691
             },
             {
-              "latency": 0.189095235
+              "latency": 0.188934558
             },
             {
-              "latency": 0.193144269
+              "latency": 0.185439673
             },
             {
-              "latency": 0.183220856
+              "latency": 0.186015979
             },
             {
-              "latency": 0.185579554
+              "latency": 0.198036308
             },
             {
-              "latency": 0.196126716
+              "latency": 0.198119648
             },
             {
-              "latency": 0.18693908
+              "latency": 0.190713888
             },
             {
-              "latency": 0.179407387
+              "latency": 0.185456165
             },
             {
-              "latency": 0.184532938
+              "latency": 0.194871408
             },
             {
-              "latency": 0.192201946
+              "latency": 0.195810787
             },
             {
-              "latency": 0.194854126
+              "latency": 0.19079062
             },
             {
-              "latency": 0.19805576
+              "latency": 0.181880737
             },
             {
-              "latency": 0.192467695
+              "latency": 0.192683653
             },
             {
-              "latency": 0.187013304
+              "latency": 0.185732271
             }
           ],
           "implementation": "go-libp2p",
@@ -3371,304 +3371,304 @@
         {
           "result": [
             {
-              "latency": 0.309072689
+              "latency": 0.374807067
             },
             {
-              "latency": 0.318168175
+              "latency": 0.374259564
             },
             {
-              "latency": 0.304624288
+              "latency": 0.312939902
             },
             {
-              "latency": 0.307521111
+              "latency": 0.359249902
             },
             {
-              "latency": 0.305563561
+              "latency": 0.307032956
             },
             {
-              "latency": 0.322874446
+              "latency": 0.324519744
             },
             {
-              "latency": 0.31090352
+              "latency": 0.316593986
             },
             {
-              "latency": 0.310687574
+              "latency": 0.306647122
             },
             {
-              "latency": 0.370563082
+              "latency": 0.323329378
             },
             {
-              "latency": 0.322631255
+              "latency": 0.322298001
             },
             {
-              "latency": 0.317373569
+              "latency": 0.379261346
             },
             {
-              "latency": 0.287180588
+              "latency": 0.305279711
             },
             {
-              "latency": 0.318415455
+              "latency": 0.36685664
             },
             {
-              "latency": 0.379779538
+              "latency": 0.360760132
             },
             {
-              "latency": 0.376509042
+              "latency": 0.361958065
             },
             {
-              "latency": 0.319863867
+              "latency": 0.306196239
             },
             {
-              "latency": 0.316111866
+              "latency": 0.310889814
             },
             {
-              "latency": 0.404091316
+              "latency": 0.298184875
             },
             {
-              "latency": 0.308407764
+              "latency": 0.390102105
             },
             {
-              "latency": 0.31095061
+              "latency": 0.302551415
             },
             {
-              "latency": 0.307131318
+              "latency": 0.390765534
             },
             {
-              "latency": 0.359516033
+              "latency": 0.385131715
             },
             {
-              "latency": 0.296082618
+              "latency": 0.309707407
             },
             {
-              "latency": 0.316308482
+              "latency": 0.377401682
             },
             {
-              "latency": 0.36403645
+              "latency": 0.322871755
             },
             {
-              "latency": 0.311093597
+              "latency": 0.361493688
             },
             {
-              "latency": 0.367762055
+              "latency": 0.309233972
             },
             {
-              "latency": 0.394056294
+              "latency": 0.37082291
             },
             {
-              "latency": 0.376632485
+              "latency": 0.306732215
             },
             {
-              "latency": 0.312395596
+              "latency": 0.325476359
             },
             {
-              "latency": 0.385554358
+              "latency": 0.316628309
             },
             {
-              "latency": 0.314945643
+              "latency": 0.300713991
             },
             {
-              "latency": 0.371723816
+              "latency": 0.371440484
             },
             {
-              "latency": 0.3197937
+              "latency": 0.316708978
             },
             {
-              "latency": 0.319095304
+              "latency": 0.372238331
             },
             {
-              "latency": 0.30718548
+              "latency": 0.315972468
             },
             {
-              "latency": 0.310700662
+              "latency": 0.320223145
             },
             {
-              "latency": 0.388759514
+              "latency": 0.380184173
             },
             {
-              "latency": 0.318451931
+              "latency": 0.370825214
             },
             {
-              "latency": 0.292938895
+              "latency": 0.383781226
             },
             {
-              "latency": 0.305128687
+              "latency": 0.356976784
             },
             {
-              "latency": 0.289186272
+              "latency": 0.31347973
             },
             {
-              "latency": 0.323047358
+              "latency": 0.322337233
             },
             {
-              "latency": 0.324731199
+              "latency": 0.314891263
             },
             {
-              "latency": 0.312795852
+              "latency": 0.373959729
             },
             {
-              "latency": 0.302302707
+              "latency": 0.3046607
             },
             {
-              "latency": 0.368018246
+              "latency": 0.327652602
             },
             {
-              "latency": 0.317737999
+              "latency": 0.367226073
             },
             {
-              "latency": 0.319690914
+              "latency": 0.348002216
             },
             {
-              "latency": 0.323475302
+              "latency": 0.321017954
             },
             {
-              "latency": 0.318348864
+              "latency": 0.312083731
             },
             {
-              "latency": 0.299457498
+              "latency": 0.369931746
             },
             {
-              "latency": 0.306095393
+              "latency": 0.318498045
             },
             {
-              "latency": 0.37206899
+              "latency": 0.312247021
             },
             {
-              "latency": 0.311674166
+              "latency": 0.322443303
             },
             {
-              "latency": 0.289112292
+              "latency": 0.315057166
             },
             {
-              "latency": 0.313807919
+              "latency": 0.365983797
             },
             {
-              "latency": 0.313827453
+              "latency": 0.381319167
             },
             {
-              "latency": 0.329102501
+              "latency": 0.34457003
             },
             {
-              "latency": 0.312134606
+              "latency": 0.314634586
             },
             {
-              "latency": 0.303494547
+              "latency": 0.30172012
             },
             {
-              "latency": 0.309971535
+              "latency": 0.304371267
             },
             {
-              "latency": 0.378485704
+              "latency": 0.326793879
             },
             {
-              "latency": 0.321655824
+              "latency": 0.307221186
             },
             {
-              "latency": 0.30797697
+              "latency": 0.361344547
             },
             {
-              "latency": 0.390553848
+              "latency": 0.359921782
             },
             {
-              "latency": 0.376435431
+              "latency": 0.308853834
             },
             {
-              "latency": 0.304978538
+              "latency": 0.377802618
             },
             {
-              "latency": 0.301892458
+              "latency": 0.320152763
             },
             {
-              "latency": 0.384375216
+              "latency": 0.319787748
             },
             {
-              "latency": 0.365216576
+              "latency": 0.385121005
             },
             {
-              "latency": 0.37683604
+              "latency": 0.324511702
             },
             {
-              "latency": 0.369576997
+              "latency": 0.318074667
             },
             {
-              "latency": 0.312533651
+              "latency": 0.355704786
             },
             {
-              "latency": 0.308957754
+              "latency": 0.36599909
             },
             {
-              "latency": 0.372783063
+              "latency": 0.313563125
             },
             {
-              "latency": 0.37415111
+              "latency": 0.294834549
             },
             {
-              "latency": 0.385521639
+              "latency": 0.32017521
             },
             {
-              "latency": 0.369218748
+              "latency": 0.388315765
             },
             {
-              "latency": 0.37531192
+              "latency": 0.31771058
             },
             {
-              "latency": 0.304338805
+              "latency": 0.300520732
             },
             {
-              "latency": 0.32215669
+              "latency": 0.315472005
             },
             {
-              "latency": 0.312822132
+              "latency": 0.312797001
             },
             {
-              "latency": 0.30671321
+              "latency": 0.299452776
             },
             {
-              "latency": 0.362460625
+              "latency": 0.321465302
             },
             {
-              "latency": 0.31416601
+              "latency": 0.311021185
             },
             {
-              "latency": 0.300409678
+              "latency": 0.311042426
             },
             {
-              "latency": 0.296452198
+              "latency": 0.313078597
             },
             {
-              "latency": 0.32282151
+              "latency": 0.318201546
             },
             {
-              "latency": 0.379581942
+              "latency": 0.322313895
             },
             {
-              "latency": 0.366892289
+              "latency": 0.310776704
             },
             {
-              "latency": 0.382105521
+              "latency": 0.301867679
             },
             {
-              "latency": 0.379978514
+              "latency": 0.316292779
             },
             {
-              "latency": 0.379192505
+              "latency": 0.305750114
             },
             {
-              "latency": 0.392271604
+              "latency": 0.363610344
             },
             {
-              "latency": 0.319351348
+              "latency": 0.375510697
             },
             {
-              "latency": 0.317076947
+              "latency": 0.373411509
             },
             {
-              "latency": 0.313510644
+              "latency": 0.30680601
             },
             {
-              "latency": 0.37590546
+              "latency": 0.320114241
             },
             {
-              "latency": 0.378761533
+              "latency": 0.369615994
             }
           ],
           "implementation": "go-libp2p",
@@ -3678,304 +3678,304 @@
         {
           "result": [
             {
-              "latency": 0.1867361
+              "latency": 0.196620692
             },
             {
-              "latency": 0.190153712
+              "latency": 0.185999633
             },
             {
-              "latency": 0.182258067
+              "latency": 0.183760526
             },
             {
-              "latency": 0.193481088
+              "latency": 0.191757043
             },
             {
-              "latency": 0.182297895
+              "latency": 0.192498279
             },
             {
-              "latency": 0.186475253
+              "latency": 0.19122281
             },
             {
-              "latency": 0.185550444
+              "latency": 0.187209843
             },
             {
-              "latency": 0.185361432
+              "latency": 0.190032811
             },
             {
-              "latency": 0.189504418
+              "latency": 0.200740452
             },
             {
-              "latency": 0.194361042
+              "latency": 0.185890531
             },
             {
-              "latency": 0.187504795
+              "latency": 0.187034573
             },
             {
-              "latency": 0.185536181
+              "latency": 0.178578857
             },
             {
-              "latency": 0.190820973
+              "latency": 0.192287145
             },
             {
-              "latency": 0.187160913
+              "latency": 0.190748458
             },
             {
-              "latency": 0.186384962
+              "latency": 0.185887005
             },
             {
-              "latency": 0.191407403
+              "latency": 0.185883821
             },
             {
-              "latency": 0.200277032
+              "latency": 0.188081622
             },
             {
-              "latency": 0.192498428
+              "latency": 0.188146091
             },
             {
-              "latency": 0.19337702
+              "latency": 0.196414865
             },
             {
-              "latency": 0.193518513
+              "latency": 0.186037242
             },
             {
-              "latency": 0.186369648
+              "latency": 0.186767458
             },
             {
-              "latency": 0.187738661
+              "latency": 0.191531008
             },
             {
-              "latency": 0.195823516
+              "latency": 0.182928327
             },
             {
-              "latency": 0.19114493
+              "latency": 0.195184985
             },
             {
-              "latency": 0.192637577
+              "latency": 0.200388548
             },
             {
-              "latency": 0.182547405
+              "latency": 0.191591117
             },
             {
-              "latency": 0.195843713
+              "latency": 0.193895551
             },
             {
-              "latency": 0.181915911
+              "latency": 0.187002339
             },
             {
-              "latency": 0.186468204
+              "latency": 0.189109685
             },
             {
-              "latency": 0.195439877
+              "latency": 0.20045243
             },
             {
-              "latency": 0.193666488
+              "latency": 0.187288408
             },
             {
-              "latency": 0.182720092
+              "latency": 0.18885219
             },
             {
-              "latency": 0.195536301
+              "latency": 0.198171782
             },
             {
-              "latency": 0.185027363
+              "latency": 0.193152243
             },
             {
-              "latency": 0.18624842
+              "latency": 0.192433855
             },
             {
-              "latency": 0.198401959
+              "latency": 0.176876225
             },
             {
-              "latency": 0.196669168
+              "latency": 0.192069667
             },
             {
-              "latency": 0.194487057
+              "latency": 0.197400712
             },
             {
-              "latency": 0.194322495
+              "latency": 0.195686907
             },
             {
-              "latency": 0.182821091
+              "latency": 0.188248126
             },
             {
-              "latency": 0.185630383
+              "latency": 0.195470745
             },
             {
-              "latency": 0.200197485
+              "latency": 0.189194294
             },
             {
-              "latency": 0.191200188
+              "latency": 0.189135962
             },
             {
-              "latency": 0.17998716
+              "latency": 0.198183611
             },
             {
-              "latency": 0.195832796
+              "latency": 0.184908574
             },
             {
-              "latency": 0.19844318
+              "latency": 0.187499113
             },
             {
-              "latency": 0.185293982
+              "latency": 0.18706434
             },
             {
-              "latency": 0.197682954
+              "latency": 0.195673484
             },
             {
-              "latency": 0.190124741
+              "latency": 0.190705484
             },
             {
-              "latency": 0.19560742
+              "latency": 0.18913505
             },
             {
-              "latency": 0.188218398
+              "latency": 0.194545787
             },
             {
-              "latency": 0.18838037
+              "latency": 0.194063675
             },
             {
-              "latency": 0.185657297
+              "latency": 0.185765357
             },
             {
-              "latency": 0.198957868
+              "latency": 0.19575294
             },
             {
-              "latency": 0.19163254
+              "latency": 0.190158784
             },
             {
-              "latency": 0.191866536
+              "latency": 0.192472982
             },
             {
-              "latency": 0.197497888
+              "latency": 0.186928858
             },
             {
-              "latency": 0.186902633
+              "latency": 0.192361228
             },
             {
-              "latency": 0.182904442
+              "latency": 0.19602117
             },
             {
-              "latency": 0.186932653
+              "latency": 0.200513982
             },
             {
-              "latency": 0.192144865
+              "latency": 0.180614561
             },
             {
-              "latency": 0.181066201
+              "latency": 0.188091232
             },
             {
-              "latency": 0.189496607
+              "latency": 0.18159724
             },
             {
-              "latency": 0.187153405
+              "latency": 0.186541406
             },
             {
-              "latency": 0.178815064
+              "latency": 0.1897679
             },
             {
-              "latency": 0.192378832
+              "latency": 0.198226696
             },
             {
-              "latency": 0.188256957
+              "latency": 0.192550144
             },
             {
-              "latency": 0.186715938
+              "latency": 0.185757076
             },
             {
-              "latency": 0.179875519
+              "latency": 0.183500851
             },
             {
-              "latency": 0.189579122
+              "latency": 0.185132907
             },
             {
-              "latency": 0.193858299
+              "latency": 0.194121619
             },
             {
-              "latency": 0.185741056
+              "latency": 0.188769913
             },
             {
-              "latency": 0.178837601
+              "latency": 0.188872481
             },
             {
-              "latency": 0.196788114
+              "latency": 0.188586828
             },
             {
-              "latency": 0.189336894
+              "latency": 0.196366904
             },
             {
-              "latency": 0.197320509
+              "latency": 0.185812387
             },
             {
-              "latency": 0.174864471
+              "latency": 0.190578305
             },
             {
-              "latency": 0.194226924
+              "latency": 0.20088663
             },
             {
-              "latency": 0.183450965
+              "latency": 0.189074246
             },
             {
-              "latency": 0.190592953
+              "latency": 0.186800658
             },
             {
-              "latency": 0.181039599
+              "latency": 0.190384793
             },
             {
-              "latency": 0.199946949
+              "latency": 0.191895166
             },
             {
-              "latency": 0.191023624
+              "latency": 0.18824756
             },
             {
-              "latency": 0.186301499
+              "latency": 0.187374645
             },
             {
-              "latency": 0.188890727
+              "latency": 0.186648579
             },
             {
-              "latency": 0.191870335
+              "latency": 0.18374025
             },
             {
-              "latency": 0.195288797
+              "latency": 0.193660625
             },
             {
-              "latency": 0.185763467
+              "latency": 0.188952514
             },
             {
-              "latency": 0.17946677
+              "latency": 0.198427537
             },
             {
-              "latency": 0.181670015
+              "latency": 0.190624352
             },
             {
-              "latency": 0.188398112
+              "latency": 0.190610929
             },
             {
-              "latency": 0.192125456
+              "latency": 0.196313032
             },
             {
-              "latency": 0.196169976
+              "latency": 0.197518607
             },
             {
-              "latency": 0.183919601
+              "latency": 0.19078892
             },
             {
-              "latency": 0.189079999
+              "latency": 0.193349048
             },
             {
-              "latency": 0.192747121
+              "latency": 0.187446995
             },
             {
-              "latency": 0.192453605
+              "latency": 0.195072376
             },
             {
-              "latency": 0.186734274
+              "latency": 0.198266569
             },
             {
-              "latency": 0.194210217
+              "latency": 0.176649628
             },
             {
-              "latency": 0.179194811
+              "latency": 0.187666865
             }
           ],
           "implementation": "go-libp2p",
@@ -3985,304 +3985,304 @@
         {
           "result": [
             {
-              "latency": 0.357594952
+              "latency": 0.375144926
             },
             {
-              "latency": 0.291781738
+              "latency": 0.365778564
             },
             {
-              "latency": 0.321685464
+              "latency": 0.392624919
             },
             {
-              "latency": 0.317243951
+              "latency": 0.312743939
             },
             {
-              "latency": 0.361208899
+              "latency": 0.36525608
             },
             {
-              "latency": 0.306440258
+              "latency": 0.311740815
             },
             {
-              "latency": 0.32007977
+              "latency": 0.319389212
             },
             {
-              "latency": 0.324097897
+              "latency": 0.36953231
             },
             {
-              "latency": 0.303882428
+              "latency": 0.3281115
             },
             {
-              "latency": 0.367345149
+              "latency": 0.311122979
             },
             {
-              "latency": 0.318353043
+              "latency": 0.38391715
             },
             {
-              "latency": 0.372087784
+              "latency": 0.314881956
             },
             {
-              "latency": 0.300387264
+              "latency": 0.315565435
             },
             {
-              "latency": 0.350097173
+              "latency": 0.375084466
             },
             {
-              "latency": 0.309794582
+              "latency": 0.305129394
             },
             {
-              "latency": 0.310683393
+              "latency": 0.299137835
             },
             {
-              "latency": 0.307342644
+              "latency": 0.320030178
             },
             {
-              "latency": 0.319632116
+              "latency": 0.308719376
             },
             {
-              "latency": 0.305418588
+              "latency": 0.372604871
             },
             {
-              "latency": 0.368631633
+              "latency": 0.295132457
             },
             {
-              "latency": 0.322799153
+              "latency": 0.305466681
             },
             {
-              "latency": 0.306653151
+              "latency": 0.380717838
             },
             {
-              "latency": 0.321725966
+              "latency": 0.293780755
             },
             {
-              "latency": 0.322081597
+              "latency": 0.321136067
             },
             {
-              "latency": 0.302419388
+              "latency": 0.324875546
             },
             {
-              "latency": 0.302098864
+              "latency": 0.317895578
             },
             {
-              "latency": 0.386883962
+              "latency": 0.320745576
             },
             {
-              "latency": 0.303306016
+              "latency": 0.306861105
             },
             {
-              "latency": 0.310818506
+              "latency": 0.374810412
             },
             {
-              "latency": 0.377746872
+              "latency": 0.316579673
             },
             {
-              "latency": 0.311379396
+              "latency": 0.310426278
             },
             {
-              "latency": 0.314993353
+              "latency": 0.308815659
             },
             {
-              "latency": 0.387252403
+              "latency": 0.311649087
             },
             {
-              "latency": 0.301338534
+              "latency": 0.378426948
             },
             {
-              "latency": 0.305435236
+              "latency": 0.392215717
             },
             {
-              "latency": 0.326784157
+              "latency": 0.365561236
             },
             {
-              "latency": 0.371309738
+              "latency": 0.361255594
             },
             {
-              "latency": 0.297016941
+              "latency": 0.322731313
             },
             {
-              "latency": 0.306432795
+              "latency": 0.316359774
             },
             {
-              "latency": 0.304999845
+              "latency": 0.313956376
             },
             {
-              "latency": 0.306436335
+              "latency": 0.308169296
             },
             {
-              "latency": 0.284873063
+              "latency": 0.316855409
             },
             {
-              "latency": 0.366089053
+              "latency": 0.31435849
             },
             {
-              "latency": 0.302260364
+              "latency": 0.378851435
             },
             {
-              "latency": 0.348582388
+              "latency": 0.315548884
             },
             {
-              "latency": 0.291819145
+              "latency": 0.358555657
             },
             {
-              "latency": 0.371600076
+              "latency": 0.382924976
             },
             {
-              "latency": 0.323627274
+              "latency": 0.315891622
             },
             {
-              "latency": 0.307718964
+              "latency": 0.378234852
             },
             {
-              "latency": 0.297197636
+              "latency": 0.361003556
             },
             {
-              "latency": 0.362124734
+              "latency": 0.387576649
             },
             {
-              "latency": 0.319022554
+              "latency": 0.382795871
             },
             {
-              "latency": 0.357229598
+              "latency": 0.373459938
             },
             {
-              "latency": 0.388282253
+              "latency": 0.378389278
             },
             {
-              "latency": 0.318673521
+              "latency": 0.383551989
             },
             {
-              "latency": 0.32713238
+              "latency": 0.307418163
             },
             {
-              "latency": 0.315780772
+              "latency": 0.383974463
             },
             {
-              "latency": 0.365680066
+              "latency": 0.308079098
             },
             {
-              "latency": 0.370515193
+              "latency": 0.36635653
             },
             {
-              "latency": 0.35332436
+              "latency": 0.377807789
             },
             {
-              "latency": 0.306907926
+              "latency": 0.378940313
             },
             {
-              "latency": 0.32319414
+              "latency": 0.304893981
             },
             {
-              "latency": 0.36079156
+              "latency": 0.324041352
             },
             {
-              "latency": 0.365805526
+              "latency": 0.35270859
             },
             {
-              "latency": 0.319552784
+              "latency": 0.29366276
             },
             {
-              "latency": 0.383328978
+              "latency": 0.382129049
             },
             {
-              "latency": 0.316867233
+              "latency": 0.38799702
             },
             {
-              "latency": 0.365319624
+              "latency": 0.384028647
             },
             {
-              "latency": 0.307977111
+              "latency": 0.370623515
             },
             {
-              "latency": 0.377433849
+              "latency": 0.380036665
             },
             {
-              "latency": 0.315091042
+              "latency": 0.311771191
             },
             {
-              "latency": 0.309205889
+              "latency": 0.369208556
             },
             {
-              "latency": 0.305468272
+              "latency": 0.304924313
             },
             {
-              "latency": 0.355506605
+              "latency": 0.385444229
             },
             {
-              "latency": 0.371627248
+              "latency": 0.305460765
             },
             {
-              "latency": 0.320874942
+              "latency": 0.374515765
             },
             {
-              "latency": 0.31739913
+              "latency": 0.317470977
             },
             {
-              "latency": 0.308500274
+              "latency": 0.374709628
             },
             {
-              "latency": 0.370943253
+              "latency": 0.354798833
             },
             {
-              "latency": 0.316919536
+              "latency": 0.365318581
             },
             {
-              "latency": 0.324417982
+              "latency": 0.377419131
             },
             {
-              "latency": 0.320444528
+              "latency": 0.311937899
             },
             {
-              "latency": 0.318700443
+              "latency": 0.315817419
             },
             {
-              "latency": 0.371720315
+              "latency": 0.311045539
             },
             {
-              "latency": 0.307048465
+              "latency": 0.359639441
             },
             {
-              "latency": 0.311665669
+              "latency": 0.36589914
             },
             {
-              "latency": 0.307450982
+              "latency": 0.291778956
             },
             {
-              "latency": 0.306206241
+              "latency": 0.288599933
             },
             {
-              "latency": 0.358668605
+              "latency": 0.324092583
             },
             {
-              "latency": 0.353735759
+              "latency": 0.319516178
             },
             {
-              "latency": 0.300398957
+              "latency": 0.307812499
             },
             {
-              "latency": 0.309843183
+              "latency": 0.304748825
             },
             {
-              "latency": 0.312107538
+              "latency": 0.321009849
             },
             {
-              "latency": 0.317694276
+              "latency": 0.311142664
             },
             {
-              "latency": 0.310318429
+              "latency": 0.290793839
             },
             {
-              "latency": 0.371181488
+              "latency": 0.319213995
             },
             {
-              "latency": 0.312660156
+              "latency": 0.37910792
             },
             {
-              "latency": 0.317124679
+              "latency": 0.390957792
             },
             {
-              "latency": 0.314004683
+              "latency": 0.316499917
             },
             {
-              "latency": 0.371184118
+              "latency": 0.309537188
             }
           ],
           "implementation": "go-libp2p",
@@ -4292,304 +4292,304 @@
         {
           "result": [
             {
-              "latency": 0.184784819
+              "latency": 0.197169269
             },
             {
-              "latency": 0.188181003
+              "latency": 0.198751322
             },
             {
-              "latency": 0.188074649
+              "latency": 0.198650845
             },
             {
-              "latency": 0.193739718
+              "latency": 0.19784868
             },
             {
-              "latency": 0.192608196
+              "latency": 0.18951009
             },
             {
-              "latency": 0.184191057
+              "latency": 0.195939065
             },
             {
-              "latency": 0.193444848
+              "latency": 0.187773599
             },
             {
-              "latency": 0.188803624
+              "latency": 0.191357964
             },
             {
-              "latency": 0.197717965
+              "latency": 0.188436378
             },
             {
-              "latency": 0.186332626
+              "latency": 0.196633812
             },
             {
-              "latency": 0.193857622
+              "latency": 0.191721848
             },
             {
-              "latency": 0.189474125
+              "latency": 0.194254886
             },
             {
-              "latency": 0.184924786
+              "latency": 0.188457443
             },
             {
-              "latency": 0.189075056
+              "latency": 0.192788241
             },
             {
-              "latency": 0.195276115
+              "latency": 0.195765146
             },
             {
-              "latency": 0.189382887
+              "latency": 0.197249529
             },
             {
-              "latency": 0.184836815
+              "latency": 0.196170867
             },
             {
-              "latency": 0.190504217
+              "latency": 0.200116519
             },
             {
-              "latency": 0.182271961
+              "latency": 0.186574715
             },
             {
-              "latency": 0.193364684
+              "latency": 0.195838835
             },
             {
-              "latency": 0.186283028
+              "latency": 0.19416503
             },
             {
-              "latency": 0.187001549
+              "latency": 0.190306897
             },
             {
-              "latency": 0.193400721
+              "latency": 0.18568374
             },
             {
-              "latency": 0.190175584
+              "latency": 0.198574642
             },
             {
-              "latency": 0.189883666
+              "latency": 0.199410656
             },
             {
-              "latency": 0.193233214
+              "latency": 0.192103993
             },
             {
-              "latency": 0.17445127
+              "latency": 0.185566253
             },
             {
-              "latency": 0.193349832
+              "latency": 0.187034148
             },
             {
-              "latency": 0.193776559
+              "latency": 0.188076892
             },
             {
-              "latency": 0.187484886
+              "latency": 0.190572074
             },
             {
-              "latency": 0.189092619
+              "latency": 0.18800255
             },
             {
-              "latency": 0.195496051
+              "latency": 0.193822392
             },
             {
-              "latency": 0.190295353
+              "latency": 0.187719455
             },
             {
-              "latency": 0.195191725
+              "latency": 0.186640985
             },
             {
-              "latency": 0.189271977
+              "latency": 0.190244259
             },
             {
-              "latency": 0.197552994
+              "latency": 0.189053242
             },
             {
-              "latency": 0.175447684
+              "latency": 0.191868562
             },
             {
-              "latency": 0.192702092
+              "latency": 0.18167821
             },
             {
-              "latency": 0.194345183
+              "latency": 0.19078117
             },
             {
-              "latency": 0.187562806
+              "latency": 0.180227769
             },
             {
-              "latency": 0.184493141
+              "latency": 0.182051893
             },
             {
-              "latency": 0.192578828
+              "latency": 0.185279257
             },
             {
-              "latency": 0.190393759
+              "latency": 0.193969699
             },
             {
-              "latency": 0.18595881
+              "latency": 0.196103816
             },
             {
-              "latency": 0.187733854
+              "latency": 0.191829101
             },
             {
-              "latency": 0.195715713
+              "latency": 0.194351761
             },
             {
-              "latency": 0.177167162
+              "latency": 0.192721129
             },
             {
-              "latency": 0.185887741
+              "latency": 0.187010527
             },
             {
-              "latency": 0.191911289
+              "latency": 0.189895364
             },
             {
-              "latency": 0.187433992
+              "latency": 0.195719136
             },
             {
-              "latency": 0.187112579
+              "latency": 0.185413399
             },
             {
-              "latency": 0.185305075
+              "latency": 0.186960104
             },
             {
-              "latency": 0.195277148
+              "latency": 0.185546385
             },
             {
-              "latency": 0.181028571
+              "latency": 0.196370318
             },
             {
-              "latency": 0.185835632
+              "latency": 0.196279566
             },
             {
-              "latency": 0.185120904
+              "latency": 0.183035582
             },
             {
-              "latency": 0.188649626
+              "latency": 0.192582338
             },
             {
-              "latency": 0.182626849
+              "latency": 0.199423918
             },
             {
-              "latency": 0.189461416
+              "latency": 0.197515111
             },
             {
-              "latency": 0.193938837
+              "latency": 0.189327901
             },
             {
-              "latency": 0.18580676
+              "latency": 0.193889314
             },
             {
-              "latency": 0.194586257
+              "latency": 0.191183674
             },
             {
-              "latency": 0.189347734
+              "latency": 0.193086462
             },
             {
-              "latency": 0.196793367
+              "latency": 0.198898212
             },
             {
-              "latency": 0.186930185
+              "latency": 0.192799096
             },
             {
-              "latency": 0.196209787
+              "latency": 0.191050344
             },
             {
-              "latency": 0.190248446
+              "latency": 0.196552045
             },
             {
-              "latency": 0.185263321
+              "latency": 0.191643207
             },
             {
-              "latency": 0.189314094
+              "latency": 0.192119892
             },
             {
-              "latency": 0.195023408
+              "latency": 0.180426059
             },
             {
-              "latency": 0.196141163
+              "latency": 0.192615952
             },
             {
-              "latency": 0.19395669
+              "latency": 0.188478335
             },
             {
-              "latency": 0.189196091
+              "latency": 0.192272539
             },
             {
-              "latency": 0.194072201
+              "latency": 0.190172541
             },
             {
-              "latency": 0.191245396
+              "latency": 0.188555607
             },
             {
-              "latency": 0.183056738
+              "latency": 0.198969273
             },
             {
-              "latency": 0.191182965
+              "latency": 0.194132954
             },
             {
-              "latency": 0.187593245
+              "latency": 0.19240791
             },
             {
-              "latency": 0.189379136
+              "latency": 0.194100337
             },
             {
-              "latency": 0.191940849
+              "latency": 0.196370915
             },
             {
-              "latency": 0.186880156
+              "latency": 0.196373268
             },
             {
-              "latency": 0.199915922
+              "latency": 0.198667754
             },
             {
-              "latency": 0.183027872
+              "latency": 0.190597659
             },
             {
-              "latency": 0.192547251
+              "latency": 0.194847716
             },
             {
-              "latency": 0.185216271
+              "latency": 0.196733188
             },
             {
-              "latency": 0.185432805
+              "latency": 0.194730005
             },
             {
-              "latency": 0.190760251
+              "latency": 0.188612041
             },
             {
-              "latency": 0.190800449
+              "latency": 0.189992786
             },
             {
-              "latency": 0.186134974
+              "latency": 0.193479234
             },
             {
-              "latency": 0.18548809
+              "latency": 0.182603198
             },
             {
-              "latency": 0.188371132
+              "latency": 0.193309143
             },
             {
-              "latency": 0.187530822
+              "latency": 0.194503333
             },
             {
-              "latency": 0.195767263
+              "latency": 0.190437294
             },
             {
-              "latency": 0.18404208
+              "latency": 0.180342709
             },
             {
-              "latency": 0.193704777
+              "latency": 0.19663589
             },
             {
-              "latency": 0.185406641
+              "latency": 0.196405317
             },
             {
-              "latency": 0.184979712
+              "latency": 0.192049488
             },
             {
-              "latency": 0.195741564
+              "latency": 0.190754249
             },
             {
-              "latency": 0.186051107
+              "latency": 0.196142325
             },
             {
-              "latency": 0.19227316
+              "latency": 0.190650149
             }
           ],
           "implementation": "go-libp2p",
@@ -4606,147 +4606,112 @@
   "pings": {
     "unit": "s",
     "results": [
-      0.0615,
-      0.0613,
-      0.0613,
-      0.0616,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0616,
-      0.0613,
-      0.0616,
-      0.061399999999999996,
-      0.061399999999999996,
-      0.0613,
-      0.0613,
-      0.061799999999999994,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.061399999999999996,
-      0.0613,
-      0.061399999999999996,
-      0.061700000000000005,
-      0.0615,
-      0.0613,
-      0.061399999999999996,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.061700000000000005,
-      0.0616,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0616,
-      0.0613,
-      0.061399999999999996,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.061399999999999996,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.061399999999999996,
-      0.0613,
-      0.0613,
-      0.061399999999999996,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613,
-      0.0613
+      0.0765,
+      0.07390000000000001,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.06409999999999999,
+      0.0638,
+      0.0649,
+      0.0691,
+      0.0691,
+      0.0691,
+      0.0691,
+      0.0691,
+      0.0691,
+      0.0691,
+      0.0691,
+      0.0691,
+      0.0634,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638,
+      0.0638
     ]
   },
   "iperf": {
     "unit": "bit/s",
     "results": [
-      2029999999.9999998,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
-      4780000000,
+      2049999999.9999998,
       4780000000,
       4780000000,
       4780000000,
@@ -4772,7 +4737,42 @@
       4780000000,
       4780000000,
       4740000000,
-      4720000000
+      4650000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4780000000,
+      4510000000,
+      3880000000,
+      3950000000,
+      4070000000.0000005,
+      4139999999.9999995,
+      4200000000,
+      4290000000,
+      4330000000,
+      4380000000,
+      4440000000,
+      4460000000,
+      4500000000,
+      4520000000,
+      4540000000,
+      4570000000,
+      4620000000,
+      4600000000
     ]
   }
 }

--- a/perf/terraform/modules/long_lived/main.tf
+++ b/perf/terraform/modules/long_lived/main.tf
@@ -117,4 +117,6 @@ resource "aws_launch_template" "perf" {
       delete_on_termination = true
     }
   }
+
+  update_default_version = true
 }

--- a/perf/terraform/modules/short_lived/main.tf
+++ b/perf/terraform/modules/short_lived/main.tf
@@ -19,7 +19,7 @@ resource "aws_instance" "perf" {
 
   launch_template {
     name = "perf-node"
-    version = "3"
+    version = "$Latest"
   }
 
   key_name = aws_key_pair.perf.key_name

--- a/perf/terraform/modules/short_lived/main.tf
+++ b/perf/terraform/modules/short_lived/main.tf
@@ -19,7 +19,6 @@ resource "aws_instance" "perf" {
 
   launch_template {
     name = "perf-node"
-    version = "$Latest"
   }
 
   key_name = aws_key_pair.perf.key_name


### PR DESCRIPTION
Our perf terraform setup differentiates in long lived and short lived resources.

On CI, our long lived resources are spun up once and our short lived resources are spun up on each CI run. From time to time we have to adjust the long lived resources. End result is a new launch template that needs to be referenced in the short lived resources by version.

Next to our CI, the perf terraform setup can as well be used on personal AWS accounts. Their long lived launch template version likely doesn't match the configured launch template version of the short lived aws_instance.

Instead of specifying a specific version, instruct terraform to use the latest, thus supporting both our CI and personal AWS account use-case.

See also terraform `aws_instance` specification.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#launch-template-specification