### PR TITLE
multidim-interop: Disable flaky browser webrtc tests

### DIFF
--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -103,14 +103,14 @@ export const versions: Array<Version> = [
     {
         id: "chromium-js-v0.45",
         containerImageID: browserImageIDLookup,
-        transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }, { name: "webrtc-direct", onlyDial: true }, "webrtc"],
+        transports: [{ name: "webtransport", onlyDial: true }, { name: "wss", onlyDial: true }, { name: "webrtc-direct", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },
     {
         id: "firefox-js-v0.45",
         containerImageID: browserImageIDLookup,
-        transports: [{ name: "wss", onlyDial: true }, { name: "webrtc-direct", onlyDial: true }, "webrtc"],
+        transports: [{ name: "wss", onlyDial: true }, { name: "webrtc-direct", onlyDial: true }],
         secureChannels: ["noise"],
         muxers: ["mplex", "yamux"],
     },


### PR DESCRIPTION
The browser webrtc tests are too flaky. They've failed the last 6 master runs: https://github.com/libp2p/test-plans/actions/workflows/multidim-interop.yml?query=event%3Apush. 

I think we should remove them until we fix the flakiness issue (see #235).