### PR TITLE
ci: only run interop tests on changes to multidim-interop dir

### DIFF
--- a/.github/workflows/multidim-interop.yml
+++ b/.github/workflows/multidim-interop.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "master"
+    paths:
+      - 'multidim-interop/**'
 
 name: libp2p multidimensional interop test
 


### PR DESCRIPTION
Only run interop tests on changes to the multidim-interop/ directory (no use running them on changes to perf directory)