### PR TITLE
feat(perf): use m7i.xlarge

### DIFF
--- a/perf/terraform/configs/local/terraform.tf
+++ b/perf/terraform/configs/local/terraform.tf
@@ -67,7 +67,7 @@ module "long_lived_server" {
   source = "../../modules/long_lived"
 
   region = "us-west-2"
-  ami    = "ami-0747e613a2a1ff483"
+  ami    = "ami-002829755fa238bfa"
 
   providers = {
     aws = aws.us-west-2
@@ -80,7 +80,7 @@ module "long_lived_client" {
   source = "../../modules/long_lived"
 
   region = "us-east-1"
-  ami    = "ami-06e46074ae430fba6"
+  ami    = "ami-051f7e7f6c2f40dc1"
 
   providers = {
     aws = aws.us-east-1

--- a/perf/terraform/modules/long_lived/main.tf
+++ b/perf/terraform/modules/long_lived/main.tf
@@ -94,7 +94,7 @@ resource "aws_security_group" "restricted_inbound" {
 resource "aws_launch_template" "perf" {
   name          = "perf-node"
   image_id      = var.ami
-  instance_type = "m7i.xlarge"
+  instance_type = "m5.xlarge"
 
   # Debug via:
   # - /var/log/cloud-init.log and

--- a/perf/terraform/modules/long_lived/main.tf
+++ b/perf/terraform/modules/long_lived/main.tf
@@ -94,7 +94,7 @@ resource "aws_security_group" "restricted_inbound" {
 resource "aws_launch_template" "perf" {
   name          = "perf-node"
   image_id      = var.ami
-  instance_type = "m5n.8xlarge"
+  instance_type = "m7i.xlarge"
 
   # Debug via:
   # - /var/log/cloud-init.log and


### PR DESCRIPTION
Instead of `m5n.8xlarge`, use `m7i.xlarge`.

Rational:
- Closer to real-world libp2p deployments (e.g. < 25 Gibps)
- Cheaper (~2 USD vs ~0.2 USD)

m5n.8xlarge:
- 32 vCPUs
- 128.0 GiB of memory
- 25 Gibps of bandwidth
- Intel Xeon Platinum 8259CL - 2019

m7i.xlarge:
- 4 vCPUs
- 16.0 GiB of memory
- up to 12.5 Gibps
- Intel Xeon Scalable (Sapphire Rapids) - 2023