### PR TITLE
feat(.github/perf): reference metrics dashboard

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -84,10 +84,13 @@ jobs:
         working-directory: perf/runner
       - name: Push
         if: github.event.inputs.push == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git add benchmark-results.json
           git commit -m "perf: update benchmark results"
           git push
+          gh pr comment --body "See new metrics at https://observablehq.com/@libp2p-workspace/performance-dashboard?branch=$(git rev-parse HEAD)" || true
         working-directory: perf/runner
       - name: Archive
         if: github.event.intputs.push == 'false'


### PR DESCRIPTION
Alternative to https://github.com/libp2p/test-plans/pull/296 which ties the PR commenting to the perf job instead.