### PR TITLE
fix: make `rust-chromium` a separate implementation

### DIFF
--- a/multidim-interop/impl/rust-chromium/.gitignore
+++ b/multidim-interop/impl/rust-chromium/.gitignore
@@ -1,0 +1,5 @@
+rust-libp2p-*.zip
+rust-libp2p-*
+rust-libp2p-*/*
+image.json
+chromium-image.json

--- a/multidim-interop/impl/rust-chromium/v0.52/Makefile
+++ b/multidim-interop/impl/rust-chromium/v0.52/Makefile
@@ -4,7 +4,7 @@ commitSha := 54fa53af393adac83f9aab273c3d30efbc31ba57
 all: image.json
 
 image.json: rust-libp2p-${commitSha}
-	cd rust-libp2p-${commitSha} && IMAGE_NAME=${image_name} ../../../../dockerBuildWrapper.sh -f interop-tests/Dockerfile.native .
+	cd rust-libp2p-${commitSha} && IMAGE_NAME=${image_name} ../../../../dockerBuildWrapper.sh -f interop-tests/Dockerfile.chromium .
 	docker image inspect ${image_name} -f "{{.Id}}" | \
 		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
 

--- a/multidim-interop/versions.ts
+++ b/multidim-interop/versions.ts
@@ -63,8 +63,7 @@ export const versions: Array<Version> = [
         muxers: ["mplex", "yamux"],
     },
     {
-        id: "chromium-rust-v0.52",
-        containerImageID: browserImageIDLookup,
+        id: "rust-chromium-v0.52",
         transports: [{ name: "webtransport", onlyDial: true }],
         secureChannels: [],
         muxers: [],


### PR DESCRIPTION
The current caching implementation expects only a single docker container per implementation directory. This was not true for Rust `v0.52` which produced two containers: A native one and one with chromium and a WASM build.

Thus, the latter never got cached and we were rebuilding it on every run. By making it a separate implementation, the cache should be picked up again.

I refrained from extending the cache implementation to handle this because I think it would get too complicated.

Resolves: #301.