### PR TITLE
feat(hole-punch): update rust `v0.52` to `master`

### DIFF
--- a/hole-punch-interop/impl/rust/master/Makefile
+++ b/hole-punch-interop/impl/rust/master/Makefile
@@ -1,5 +1,5 @@
-image_name := rust-v0.52
-commitSha := 1ead41ed04ce89e50b11a078586e47d89e17d3c4
+image_name := rust-master
+commitSha := 7517934a0f629309f83b69dc00eef44c44ddbc72
 
 all: image.json
 

--- a/hole-punch-interop/impl/rust/master/Makefile
+++ b/hole-punch-interop/impl/rust/master/Makefile
@@ -1,5 +1,5 @@
 image_name := rust-master
-commitSha := 7517934a0f629309f83b69dc00eef44c44ddbc72
+commitSha := 461209ab1ba6b8e2a653ca354a5aad38802a35f9
 
 all: image.json
 

--- a/hole-punch-interop/versions.ts
+++ b/hole-punch-interop/versions.ts
@@ -15,6 +15,15 @@ export const versions: Array<Version> = [
     },
 ].map((v: Version) => (typeof v.containerImageID === "undefined" ? ({ ...v, containerImageID: canonicalImageIDLookup(v.id) }) : v))
 
+// Loads the container image id for the given version id. Expects the form of
+// "<impl>-vX.Y.Z" or "<impl>vX.Y" and the image id to be in the file
+// "./impl/<impl>/vX.Y/image.json" or "./impl/<impl>/v0.0.Z/image.json"
+function canonicalImageIDLookup(id: string): string {
+    const imageIDJSON = fs.readFileSync(canonicalImagePath(id), "utf8")
+    const imageID = JSON.parse(imageIDJSON).imageID
+    return imageID
+}
+
 function canonicalImagePath(id: string): string {
     // Split by implementation and version
     const [impl, version] = id.split("-v")
@@ -27,13 +36,4 @@ function canonicalImagePath(id: string): string {
     }
     // Read the image ID from the JSON file on the filesystem
     return `./impl/${impl}/${versionFolder}/image.json`
-}
-
-// Loads the container image id for the given version id. Expects the form of
-// "<impl>-vX.Y.Z" or "<impl>vX.Y" and the image id to be in the file
-// "./impl/<impl>/vX.Y/image.json" or "./impl/<impl>/v0.0.Z/image.json"
-function canonicalImageIDLookup(id: string): string {
-    const imageIDJSON = fs.readFileSync(canonicalImagePath(id), "utf8")
-    const imageID = JSON.parse(imageIDJSON).imageID
-    return imageID
 }

--- a/hole-punch-interop/versions.ts
+++ b/hole-punch-interop/versions.ts
@@ -13,19 +13,16 @@ export const versions: Array<Version> = [
         id: "rust-v0.52",
         transports: ["tcp", "quic"],
     },
-].map((v: Version) => (typeof v.containerImageID === "undefined" ? ({ ...v, containerImageID: canonicalImageIDLookup(v.id) }) : v))
-
-// Loads the container image id for the given version id. Expects the form of
-// "<impl>-vX.Y.Z" or "<impl>vX.Y" and the image id to be in the file
-// "./impl/<impl>/vX.Y/image.json" or "./impl/<impl>/v0.0.Z/image.json"
-function canonicalImageIDLookup(id: string): string {
-    return readImageId(canonicalImagePath(id))
-}
+].map((v: Version) => (typeof v.containerImageID === "undefined" ? ({ ...v, containerImageID: readImageId(canonicalImagePath(v.id)) }) : v))
 
 function readImageId(path: string) {
     return JSON.parse(fs.readFileSync(path, "utf8")).imageID;
 }
 
+// Finds the `image.json` for the given version id.
+//
+// Expects the form of "<impl>-vX.Y.Z" or "<impl>vX.Y".
+// The image id must be in the file "./impl/<impl>/vX.Y/image.json" or "./impl/<impl>/v0.0.Z/image.json".
 function canonicalImagePath(id: string): string {
     // Split by implementation and version
     const [impl, version] = id.split("-v")

--- a/hole-punch-interop/versions.ts
+++ b/hole-punch-interop/versions.ts
@@ -10,12 +10,13 @@ export type Version = {
 
 export const versions: Array<Version> = [
     {
-        id: "rust-v0.52",
+        id: "rust-master",
         transports: ["tcp", "quic"],
-    },
+        containerImageID: readImageId("./impl/rust/master/image.json"),
+    } as Version,
 ].map((v: Version) => (typeof v.containerImageID === "undefined" ? ({ ...v, containerImageID: readImageId(canonicalImagePath(v.id)) }) : v))
 
-function readImageId(path: string) {
+function readImageId(path: string): string {
     return JSON.parse(fs.readFileSync(path, "utf8")).imageID;
 }
 

--- a/hole-punch-interop/versions.ts
+++ b/hole-punch-interop/versions.ts
@@ -19,9 +19,11 @@ export const versions: Array<Version> = [
 // "<impl>-vX.Y.Z" or "<impl>vX.Y" and the image id to be in the file
 // "./impl/<impl>/vX.Y/image.json" or "./impl/<impl>/v0.0.Z/image.json"
 function canonicalImageIDLookup(id: string): string {
-    const imageIDJSON = fs.readFileSync(canonicalImagePath(id), "utf8")
-    const imageID = JSON.parse(imageIDJSON).imageID
-    return imageID
+    return readImageId(canonicalImagePath(id))
+}
+
+function readImageId(path: string) {
+    return JSON.parse(fs.readFileSync(path, "utf8")).imageID;
 }
 
 function canonicalImagePath(id: string): string {


### PR DESCRIPTION
The `v0.52` version string was really just a placeholder. Initially, I thought that we might merge https://github.com/libp2p/rust-libp2p/pull/4549 before the release cut-off for `v0.53` but that didn't happen.

To communicate this more clearly, we rename the current image to `rust-master`. We are also updating it to actually point _to_ a commit on master. Previously, it was pointing to a commit in https://github.com/libp2p/rust-libp2p/pull/4549. This new commit includes an important bug-fix (https://github.com/libp2p/rust-libp2p/pull/4747) that caused the QUIC hole-punch test to occasionally fail.

Once we cut the v0.53 release, this version should be promoted to that.

As a side-benefit, the new commit points to a version that includes the updated Dockerfile and allows the tests to be run on ARM64.