### PR TITLE
transport-interop - add java-v0.6

### DIFF
--- a/transport-interop/impl/java/v0.6/Makefile
+++ b/transport-interop/impl/java/v0.6/Makefile
@@ -1,0 +1,14 @@
+image_name := java-v0.6
+commitSha := f917cc40060fcffc0b7ee9c66a04b35fb1b0a9bd
+
+all: image.json
+
+image.json:
+	wget -O java-libp2p-${commitSha}.zip "https://github.com/Peergos/nabu/archive/${commitSha}.zip"
+	unzip -o java-libp2p-${commitSha}.zip
+	cd nabu-${commitSha} && docker build -t ${image_name} -f Dockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+clean:
+	rm -rf image.json java-libp2p-*.zip nabu-*

--- a/transport-interop/versions.ts
+++ b/transport-interop/versions.ts
@@ -130,4 +130,10 @@ export const versions: Array<Version> = [
         secureChannels: ["tls", "noise"],
         muxers: ["mplex", "yamux"],
     },
+    {
+        id: "java-v0.6",
+        transports: ["tcp"],
+        secureChannels: ["tls", "noise"],
+        muxers: ["mplex", "yamux"],
+    },
 ].map((v: Version) => (typeof v.containerImageID === "undefined" ? ({ ...v, containerImageID: canonicalImageIDLookup }) : v))


### PR DESCRIPTION
bring java transport-interop test up-to-date with latest changes