### PR TITLE
deps(rust-libp2p): point hole-punch tests to released version

### DIFF
--- a/hole-punch-interop/impl/rust/v0.53/Makefile
+++ b/hole-punch-interop/impl/rust/v0.53/Makefile
@@ -1,5 +1,5 @@
-image_name := rust-master
-commitSha := 461209ab1ba6b8e2a653ca354a5aad38802a35f9
+image_name := rust-v0.53
+commitSha := 7f4ba690e87a867403f6266d8ee7d7db5e7a15bc
 
 all: image.json
 

--- a/hole-punch-interop/versions.ts
+++ b/hole-punch-interop/versions.ts
@@ -10,9 +10,8 @@ export type Version = {
 
 export const versions: Array<Version> = [
     {
-        id: "rust-master",
-        transports: ["tcp", "quic"],
-        containerImageID: readImageId("./impl/rust/master/image.json"),
+        id: "rust-v0.53",
+        transports: ["tcp", "quic"]
     } as Version,
 ].map((v: Version) => (typeof v.containerImageID === "undefined" ? ({ ...v, containerImageID: readImageId(canonicalImagePath(v.id)) }) : v))
 


### PR DESCRIPTION
Now that we have a released version of `rust-libp2p` that includes the hole-punching tests, point the test suite to that version instead of a commit on `master`.