### PR TITLE
chore(perf): update to rust-libp2p v0.53.2

### DIFF
--- a/perf/impl/rust-libp2p/v0.53/Makefile
+++ b/perf/impl/rust-libp2p/v0.53/Makefile
@@ -1,4 +1,4 @@
-commitSha := d15bb69a9d2b353d73ead79a29f668dca3e1dc4a
+commitSha := b7914e407da34c99fb76dcc300b3d44b9af97fac
 
 all: perf
 


### PR DESCRIPTION
Update `perf/impl/rust-libp2p/v0.53` to rust-libp2p `v0.53.2`. With this patch release comes the rust-yamux stream receive window auto-tuning.

https://github.com/libp2p/rust-libp2p/pull/4970

https://github.com/libp2p/rust-libp2p/releases/tag/libp2p-v0.53.2