### PR TITLE
Revert "chore(perf): update to rust-libp2p v0.53.2"

### DIFF
--- a/perf/impl/rust-libp2p/v0.53/Makefile
+++ b/perf/impl/rust-libp2p/v0.53/Makefile
@@ -1,4 +1,4 @@
-commitSha := b7914e407da34c99fb76dcc300b3d44b9af97fac
+commitSha := d15bb69a9d2b353d73ead79a29f668dca3e1dc4a
 
 all: perf
 


### PR DESCRIPTION
Reverts libp2p/test-plans#339

The pull request was merged before the automated commit with the perf results. Thus reverting here. Sorry, I should have set it to draft.