### PR TITLE
chore(interop): update to nim 1.6.16

### DIFF
--- a/transport-interop/impl/nim/v1.0/Dockerfile
+++ b/transport-interop/impl/nim/v1.0/Dockerfile
@@ -1,4 +1,4 @@
-ARG NimVersion="1.6.10"
+ARG NimVersion="1.6.16"
 FROM nimlang/nim:${NimVersion}-alpine as builder
 
 WORKDIR /app


### PR DESCRIPTION
Because of nimble limitations - our package manager - the build can fail even though nothing changed. It can happen when new dependencies of libraries (that can be transitive) are released. We need to upgrade nim to fix the current build issue.