### PR TITLE
webtransport-go next release will be incompatible with older versions

### DIFF
--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -164,7 +164,6 @@
       "tcp",
       "ws",
       "quic-v1",
-      "webtransport",
       "webrtc-direct"
     ],
     "secureChannels": [
@@ -181,7 +180,6 @@
       "tcp",
       "ws",
       "quic-v1",
-      "webtransport",
       "webrtc-direct"
     ],
     "secureChannels": [
@@ -197,8 +195,7 @@
     "transports": [
       "tcp",
       "ws",
-      "quic-v1",
-      "webtransport"
+      "quic-v1"
     ],
     "secureChannels": [
       "tls",
@@ -213,8 +210,7 @@
     "transports": [
       "tcp",
       "ws",
-      "quic-v1",
-      "webtransport"
+      "quic-v1"
     ],
     "secureChannels": [
       "tls",
@@ -230,8 +226,7 @@
       "tcp",
       "ws",
       "quic",
-      "quic-v1",
-      "webtransport"
+      "quic-v1"
     ],
     "secureChannels": [
       "tls",


### PR DESCRIPTION
I'm removing webtransport from the older versions of go-libp2p so that when the next go-libp2p release comes out it doesn't run webtransport against older versions.

A bit more context here: https://github.com/libp2p/go-libp2p/issues/2789