### PR TITLE
fix: update dependabot to point to latest js release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: npm
   # this should point to the latest js-libp2p major in order to automate
   # updating deps automatically after a release
-  directory: "/transport-interop/impl/js/v1.x"
+  directory: "/transport-interop/impl/js/v2.x"
   schedule:
     interval: daily
     time: "10:00"


### PR DESCRIPTION
Only try to update deps for the latest js-libp2p version.