### PR TITLE
fix: use lts node

### DIFF
--- a/.github/actions/run-interop-hole-punch-test/action.yml
+++ b/.github/actions/run-interop-hole-punch-test/action.yml
@@ -50,9 +50,9 @@ runs:
       shell: bash
       id: find-workdir
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: lts/*
 
     # Existence of /etc/buildkit/buildkitd.toml indicates that this is a
     # self-hosted runner. If so, we need to pass the config to the buildx

--- a/.github/actions/run-interop-ping-test/action.yml
+++ b/.github/actions/run-interop-ping-test/action.yml
@@ -50,9 +50,9 @@ runs:
       shell: bash
       id: find-workdir
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: lts/*
 
     # Existence of /etc/buildkit/buildkitd.toml indicates that this is a
     # self-hosted runner. If so, we need to pass the config to the buildx

--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -50,9 +50,9 @@ runs:
       shell: bash
       id: find-workdir
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: lts/*
 
     # Existence of /etc/buildkit/buildkitd.toml indicates that this is a
     # self-hosted runner. If so, we need to pass the config to the buildx


### PR DESCRIPTION
Node 18 is in maintenance mode and reaches EOL at the end of April so switch to evergreen LTS node.