### PR TITLE
fix: add mystery comment

### DIFF
--- a/transport-interop/impl/js/v2.x/test/fixtures/relay.ts
+++ b/transport-interop/impl/js/v2.x/test/fixtures/relay.ts
@@ -32,3 +32,6 @@ export async function createRelay (): Promise<Libp2p> {
 
   return server
 }
+
+// why is this comment necessary?
+// it seems to bust a mystery cache used by CI


### PR DESCRIPTION
Not quite sure why this is necessary but it means the correct file ends up in the docker container when building from scratch.

----

Investigation from the [Slack thread](https://ipshipyard.slack.com/archives/C03K82MU486/p1732214608601959):


Ok, I’ve been digging into this and what I’ve found is that when there’s a cache miss, we [build from scratch](https://github.com/libp2p/test-plans/blob/master/transport-interop/helpers/cache.ts#L115-L116).

The v1.x and v2.x Makefiles both run `docker build` in the correct implementation directory:

* https://github.com/libp2p/test-plans/blob/master/transport-interop/impl/js/v1.x/Makefile#L28
* https://github.com/libp2p/test-plans/blob/master/transport-interop/impl/js/v2.x/Makefile#L28

I have a branch in the `test-plans` repo called `fix/debug-js-build`.  In the branch it does the following:

1. cat the `test/fixtures/relay.js` file before running `docker build` - https://github.com/libp2p/test-plans/blob/a7ff620c43ceae5cae2cbcd402fb57b28e502db7/transport-interop/impl/js/v2.x/Makefile#L28
2. cat it during the build after it’s been added to the container - https://github.com/libp2p/test-plans/blob/a7ff620c43ceae5cae2cbcd402fb57b28e502db7/transport-interop/impl/js/v2.x/Dockerfile#L14

If I use this branch to run the ping interop test, the `test/fixtures/relay.js` file in the container does not have the same content as the one in the context directory (see `connectionEncrypters` vs `connectionEncryption`):

* before running `docker build` - https://github.com/libp2p/js-libp2p/actions/runs/12235431303/job/34137698038#step:6:886
* after adding the file to the container - https://github.com/libp2p/js-libp2p/actions/runs/12235431303/job/34137698038#step:6:954

Very strange.

The only way I’ve been able to get the `test/fixtures/relay.js` file to have the correct content is to change it’s name so the v2.x file doesn’t have the same path as the v1.x file.  I only get the renamed file in the docker image, not the one with the original name.

Also, if I remove the v1.x folder so only build the v2.x version, the file has the correct contents, so some cache must be getting reused between the `v1.x` and `v2.x` builds, though both build from the `node:lts` image without using any other base images.

I’m at a bit of a loss about how this is possible, perhaps someone with a bit more docker knowledge has some ideas?