### PR TITLE
chore: build webkit images during test run

### DIFF
--- a/transport-interop/impl/js/v0.45/Makefile
+++ b/transport-interop/impl/js/v0.45/Makefile
@@ -17,6 +17,11 @@ firefox-image.json: load-image-json BrowserDockerfile
 	docker image inspect firefox-${image_name} -f "{{.Id}}" | \
 		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
 
+webkit-image.json: load-image-json BrowserDockerfile
+	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=webkit -t webkit-${image_name} .
+	docker image inspect webkit-${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
 # We update the lock file here so that we make sure we are always using the correct lock file.
 # If this changes, CI will fail since there are unstaged changes.
 update-lock-file: image.json

--- a/transport-interop/impl/js/v0.46/Makefile
+++ b/transport-interop/impl/js/v0.46/Makefile
@@ -1,7 +1,6 @@
 image_name := js-v0.46
 
-# TODO Enable webkit once https://github.com/libp2p/js-libp2p/pull/1627 is in
-all: image.json chromium-image.json firefox-image.json update-lock-file
+all: image.json chromium-image.json firefox-image.json webkit-image.json update-lock-file
 
 # Necessary because multistage builds require a docker image name rather than a digest to be used
 load-image-json: image.json
@@ -15,6 +14,11 @@ chromium-image.json: load-image-json BrowserDockerfile
 firefox-image.json: load-image-json BrowserDockerfile
 	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=firefox -t firefox-${image_name} .
 	docker image inspect firefox-${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+webkit-image.json: load-image-json BrowserDockerfile
+	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=webkit -t webkit-${image_name} .
+	docker image inspect webkit-${image_name} -f "{{.Id}}" | \
 		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
 
 # We update the lock file here so that we make sure we are always using the correct lock file.

--- a/transport-interop/impl/js/v1.x/Makefile
+++ b/transport-interop/impl/js/v1.x/Makefile
@@ -1,7 +1,6 @@
 image_name := js-v1.x
 
-# TODO Enable webkit once https://github.com/libp2p/js-libp2p/pull/1627 is in
-all: image.json chromium-image.json firefox-image.json update-lock-file
+all: image.json chromium-image.json firefox-image.json webkit-image.json update-lock-file
 
 # Necessary because multistage builds require a docker image name rather than a digest to be used
 load-image-json: image.json
@@ -15,6 +14,11 @@ chromium-image.json: load-image-json BrowserDockerfile
 firefox-image.json: load-image-json BrowserDockerfile
 	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=firefox -t firefox-${image_name} .
 	docker image inspect firefox-${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+webkit-image.json: load-image-json BrowserDockerfile
+	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=webkit -t webkit-${image_name} .
+	docker image inspect webkit-${image_name} -f "{{.Id}}" | \
 		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
 
 # We update the lock file here so that we make sure we are always using the correct lock file.

--- a/transport-interop/impl/js/v2.x/Makefile
+++ b/transport-interop/impl/js/v2.x/Makefile
@@ -1,7 +1,6 @@
 image_name := js-v2.x
 
-# TODO Enable webkit once https://github.com/libp2p/js-libp2p/pull/1627 is in
-all: image.json chromium-image.json firefox-image.json update-lock-file
+all: image.json chromium-image.json firefox-image.json webkit-image.json update-lock-file
 
 # Necessary because multistage builds require a docker image name rather than a digest to be used
 load-image-json: image.json
@@ -15,6 +14,11 @@ chromium-image.json: load-image-json BrowserDockerfile
 firefox-image.json: load-image-json BrowserDockerfile
 	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=firefox -t firefox-${image_name} .
 	docker image inspect firefox-${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+webkit-image.json: load-image-json BrowserDockerfile
+	docker build -f BrowserDockerfile --build-arg=BASE_IMAGE=${image_name} --build-arg=BROWSER=webkit -t webkit-${image_name} .
+	docker image inspect webkit-${image_name} -f "{{.Id}}" | \
 		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
 
 # We update the lock file here so that we make sure we are always using the correct lock file.


### PR DESCRIPTION
In order to test webkit interop, build docker images with the `BROWSER` build arg set to `webkit`.

I think we might need this before the tests in https://github.com/libp2p/js-libp2p/pull/2541 will actually run.