### PR TITLE
fix: don't upload test results from build-only workflow. Support artifact suffixes

### DIFF
--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -153,7 +153,7 @@ runs:
       if: ${{ inputs.upload-results == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: test-plans-output${{ inputs.test-results-suffix != '' ? '-' + inputs.test-results-suffix : '' }}
+        name: test-plans-output${{ (inputs.test-results-suffix && ('-' + inputs.test-results-suffix)) || '' }}
         path: |
           ${{ steps.find-workdir.outputs.WORK_DIR }}/results.csv
           ${{ steps.find-workdir.outputs.WORK_DIR }}/dashboard.md

--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -153,7 +153,7 @@ runs:
       if: ${{ inputs.upload-results == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: test-plans-output${{ (inputs.test-results-suffix && ('-' + inputs.test-results-suffix)) || '' }}
+        name: ${{ inputs.test-results-suffix && format('test-plans-output-{0}', inputs.test-results-suffix) || 'test-plans-output' }}
         path: |
           ${{ steps.find-workdir.outputs.WORK_DIR }}/results.csv
           ${{ steps.find-workdir.outputs.WORK_DIR }}/dashboard.md

--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Filter which tests to run out of the created matrix"
     required: false
     default: ""
+  upload-results:
+    description: "Upload the test results as an artifact"
+    required: false
+    default: "true"
   test-ignore:
     description: "Exclude tests from the created matrix that include this string in their name"
     required: false
@@ -141,8 +145,9 @@ runs:
           exit 0
         fi
       shell: bash
-
-    - uses: actions/upload-artifact@v4
+    - name: Upload test results
+      if: ${{ inputs.upload-results == 'true' }}
+      uses: actions/upload-artifact@v4
       with:
         name: test-plans-output
         path: |

--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "Upload the test results as an artifact"
     required: false
     default: "true"
+  test-results-suffix:
+    description: "Suffix to add to the test results artifact name"
+    required: false
+    default: ""
   test-ignore:
     description: "Exclude tests from the created matrix that include this string in their name"
     required: false
@@ -149,7 +153,7 @@ runs:
       if: ${{ inputs.upload-results == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: test-plans-output
+        name: test-plans-output${{ inputs.test-results-suffix != '' ? '-' + inputs.test-results-suffix : '' }}
         path: |
           ${{ steps.find-workdir.outputs.WORK_DIR }}/results.csv
           ${{ steps.find-workdir.outputs.WORK_DIR }}/dashboard.md

--- a/.github/workflows/transport-interop.yml
+++ b/.github/workflows/transport-interop.yml
@@ -30,4 +30,5 @@ jobs:
       - uses: ./.github/actions/run-transport-interop-test
         with:
           # It's okay to not run the tests, we only care to check if the tests build without cache.
+          upload-results: false
           test-filter: '"no test matches this, skip all"'

--- a/.github/workflows/transport-interop.yml
+++ b/.github/workflows/transport-interop.yml
@@ -2,18 +2,20 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'transport-interop/**'
+      - "transport-interop/**"
+      - ".github/actions/run-transport-interop-test/action.yml"
+      - ".github/workflows/transport-interop.yml"
   push:
     branches:
       - "master"
     paths:
-      - 'transport-interop/**'
+      - "transport-interop/**"
 
 name: libp2p transport interop test
 
 jobs:
   run-transport-interop:
-    runs-on: ['self-hosted', 'linux', 'x64', '4xlarge'] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
+    runs-on: ["self-hosted", "linux", "x64", "4xlarge"] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/run-transport-interop-test
@@ -23,7 +25,7 @@ jobs:
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           worker-count: 16
   build-without-secrets:
-    runs-on: ['self-hosted', 'linux', 'x64', '4xlarge'] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
+    runs-on: ["self-hosted", "linux", "x64", "4xlarge"] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
     steps:
       - uses: actions/checkout@v3
       # Purposely not using secrets to replicate how forks will behave.


### PR DESCRIPTION
The build-without-secrets flow was broken because it was trying to upload an empty results artifact to the same name as the interop test. This no longer works in upload-artifacts v4.

This fixes it by not uploading that empty file.