### PR TITLE
fix: apply timeout to ping in js tests

### DIFF
--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -41,6 +41,9 @@ inputs:
     description: "How many workers to use for the test"
     required: false
     default: "2"
+  timeout:
+    description: "How many seconds to let each test run for"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -122,6 +125,7 @@ runs:
         EXTRA_VERSION: ${{ inputs.extra-versions }}
         NAME_FILTER: ${{ inputs.test-filter }}
         NAME_IGNORE: ${{ inputs.test-ignore }}
+        TIMEOUT: ${{ inputs.timeout }}
       run: npm run test -- --extra-version=$EXTRA_VERSION --name-filter=$NAME_FILTER --name-ignore=$NAME_IGNORE
       shell: bash
 

--- a/transport-interop/impl/js/v1.x/Dockerfile
+++ b/transport-interop/impl/js/v1.x/Dockerfile
@@ -14,4 +14,4 @@ ENV CI=true
 RUN npm ci
 RUN npm run build
 
-ENTRYPOINT npm test -- -t node
+ENTRYPOINT npm test -- -t node -- --exit

--- a/transport-interop/impl/js/v1.x/test/dialer.spec.ts
+++ b/transport-interop/impl/js/v1.x/test/dialer.spec.ts
@@ -32,6 +32,8 @@ describe('ping test (dialer)', function () {
   })
 
   it('should dial and ping', async function () {
+    this.timeout(timeoutMs + 30_000)
+
     let [, otherMaStr]: string[] = await redisProxy(['BLPOP', 'listenerAddr', `${timeoutMs / 1000}`])
 
     // Hack until these are merged:
@@ -42,7 +44,9 @@ describe('ping test (dialer)', function () {
     const handshakeStartInstant = Date.now()
 
     console.error(`node ${node.peerId.toString()} dials: ${otherMa}`)
-    await node.dial(otherMa)
+    await node.dial(otherMa, {
+      signal: AbortSignal.timeout(timeoutMs)
+    })
 
     console.error(`node ${node.peerId.toString()} pings: ${otherMa}`)
     const pingRTT = await node.services.ping.ping(multiaddr(otherMa), {

--- a/transport-interop/impl/js/v1.x/test/listener.spec.ts
+++ b/transport-interop/impl/js/v1.x/test/listener.spec.ts
@@ -67,6 +67,7 @@ describe('ping test (listener)', function () {
     }
 
     console.error('inform redis of dial address')
+    console.error(multiaddrs)
     // Send the listener addr over the proxy server so this works on both the Browser and Node
     await redisProxy(['RPUSH', 'listenerAddr', multiaddrs[0]])
     // Wait

--- a/transport-interop/impl/js/v2.x/Dockerfile
+++ b/transport-interop/impl/js/v2.x/Dockerfile
@@ -14,4 +14,4 @@ ENV CI=true
 RUN npm ci
 RUN npm run build
 
-ENTRYPOINT npm test -- -t node
+ENTRYPOINT npm test -- -t node -- --exit

--- a/transport-interop/impl/js/v2.x/test/dialer.spec.ts
+++ b/transport-interop/impl/js/v2.x/test/dialer.spec.ts
@@ -32,6 +32,8 @@ describe('ping test (dialer)', function () {
   })
 
   it('should dial and ping', async function () {
+    this.timeout(timeoutMs + 30_000)
+
     let [, otherMaStr]: string[] = await redisProxy(['BLPOP', 'listenerAddr', `${timeoutMs / 1000}`])
 
     // Hack until these are merged:
@@ -42,7 +44,9 @@ describe('ping test (dialer)', function () {
     const handshakeStartInstant = Date.now()
 
     console.error(`node ${node.peerId.toString()} dials: ${otherMa}`)
-    await node.dial(otherMa)
+    await node.dial(otherMa, {
+      signal: AbortSignal.timeout(timeoutMs)
+    })
 
     console.error(`node ${node.peerId.toString()} pings: ${otherMa}`)
     const pingRTT = await node.services.ping.ping(multiaddr(otherMa), {

--- a/transport-interop/impl/js/v2.x/test/listener.spec.ts
+++ b/transport-interop/impl/js/v2.x/test/listener.spec.ts
@@ -67,6 +67,7 @@ describe('ping test (listener)', function () {
     }
 
     console.error('inform redis of dial address')
+    console.error(multiaddrs)
     // Send the listener addr over the proxy server so this works on both the Browser and Node
     await redisProxy(['RPUSH', 'listenerAddr', multiaddrs[0]])
     // Wait

--- a/transport-interop/src/compose-runner.ts
+++ b/transport-interop/src/compose-runner.ts
@@ -14,7 +14,7 @@ function getTimeout (): number {
     const timeout = parseInt(process.env.TIMEOUT, 10)
 
     if (isNaN(timeout)) {
-        return 3 * 60
+        return 10 * 60
     }
 
     return timeout

--- a/transport-interop/src/compose-runner.ts
+++ b/transport-interop/src/compose-runner.ts
@@ -8,7 +8,17 @@ import { stringify } from 'yaml';
 import { dialerStdout, dialerTimings } from './compose-stdout-helper';
 
 const exec = util.promisify(execStd);
-const timeoutSecs = 3 * 60
+const timeoutSecs = getTimeout();
+
+function getTimeout (): number {
+    const timeout = parseInt(process.env.TIMEOUT, 10)
+
+    if (isNaN(timeout)) {
+        return 3 * 60
+    }
+
+    return timeout
+}
 
 export type RunOpts = {
     up: {


### PR DESCRIPTION
Pass a specified or default timeout to the ping operation in the js transport interop test implementation, otherwise the default timeout is used which may be too short for running under Docker in underpowered CI environments.

This can fix some perceived flakiness in test runs.

Also prints listening multiaddrs like other implementations.