### PR TITLE
chore: increase the timeout for resource cleanup in perf tests

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -22,7 +22,7 @@ jobs:
   perf:
     name: Perf
     runs-on: ubuntu-latest
-    timeout-minutes: 540
+    timeout-minutes: 360 # 6 hours is the maximum job execution time
     defaults:
       run:
         shell: bash

--- a/perf/terraform/modules/ci/cleanup.tf
+++ b/perf/terraform/modules/ci/cleanup.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "cleanup" {
     variables = {
       REGIONS         = jsonencode(var.regions)
       TAGS            = jsonencode(var.tags)
-      MAX_AGE_MINUTES = 120
+      MAX_AGE_MINUTES = 360
     }
   }
 }

--- a/perf/terraform/modules/ci/test/cleanup.yml
+++ b/perf/terraform/modules/ci/test/cleanup.yml
@@ -13,7 +13,7 @@ Resources:
         Variables:
           REGIONS: '["us-west-2", "us-east-1"]'
           TAGS: '{"Project":"perf", "Name":"node"}'
-          MAX_AGE_MINUTES: '120'
+          MAX_AGE_MINUTES: '360'
       Policies:
         - AmazonEC2FullAccess
       Timeout: 30


### PR DESCRIPTION
This increases the timeout for resource cleanup in perf tests to 6 hours, which is the equivalent of max job execution time in GitHub Actions.