### PR TITLE
add java v0.9 - support for quic-v1 to transport-interop

### DIFF
--- a/transport-interop/impl/java/v0.9/Makefile
+++ b/transport-interop/impl/java/v0.9/Makefile
@@ -1,5 +1,5 @@
 image_name := java-v0.9
-commitSha := 9b7aa8833073782de98160fddfa3140fe6e01fd0
+commitSha := 2f0aca35aee2cd6b2e2eb4db50fe92810a767600
 
 all: image.json
 

--- a/transport-interop/impl/java/v0.9/Makefile
+++ b/transport-interop/impl/java/v0.9/Makefile
@@ -1,0 +1,14 @@
+image_name := java-v0.9
+commitSha := 9b7aa8833073782de98160fddfa3140fe6e01fd0
+
+all: image.json
+
+image.json:
+	wget -O java-libp2p-${commitSha}.zip "https://github.com/Peergos/nabu/archive/${commitSha}.zip"
+	unzip -o java-libp2p-${commitSha}.zip
+	cd nabu-${commitSha} && docker build -t ${image_name} -f Dockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+clean:
+	rm -rf image.json java-libp2p-*.zip nabu-*

--- a/transport-interop/impl/java/v0.9/Makefile
+++ b/transport-interop/impl/java/v0.9/Makefile
@@ -1,5 +1,5 @@
 image_name := java-v0.9
-commitSha := 2f0aca35aee2cd6b2e2eb4db50fe92810a767600
+commitSha := 2678425df28132e98307c825c90cc6efa58240a8
 
 all: image.json
 

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -228,6 +228,21 @@
     ]
   },
   {
+    "id": "java-v0.9",
+    "transports": [
+      "tcp",
+      "quic-v1",
+    ],
+    "secureChannels": [
+      "tls",
+      "noise"
+    ],
+    "muxers": [
+      "mplex",
+      "yamux"
+    ]
+  },
+  {
     "id": "js-v1.x",
     "transports": [
       "tcp",

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -231,7 +231,7 @@
     "id": "java-v0.9",
     "transports": [
       "tcp",
-      "quic-v1",
+      "quic-v1"
     ],
     "secureChannels": [
       "tls",


### PR DESCRIPTION
Have confirmed test results locally (at least those implementation that will build on apple m2 - go, rust, java, js).
Zig - uses ed25519 certs which netty quic doesn't support - https://github.com/netty/netty-incubator-codec-quic/issues/487

The Nim build error seems unrelated to this PR.