### PR TITLE
Feat/java v0.9

### DIFF
--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -44,6 +44,10 @@ inputs:
   timeout:
     description: "How many seconds to let each test run for"
     required: false
+  verbose:
+    description: "Enable verbose output"
+    required: false
+    default: false
 runs:
   using: "composite"
   steps:
@@ -126,7 +130,8 @@ runs:
         NAME_FILTER: ${{ inputs.test-filter }}
         NAME_IGNORE: ${{ inputs.test-ignore }}
         TIMEOUT: ${{ inputs.timeout }}
-      run: npm run test -- --extra-version=$EXTRA_VERSION --name-filter="$NAME_FILTER" --name-ignore="$NAME_IGNORE"
+        VERBOSE: ${{ inputs.verbose }}
+      run: npm run test -- --extra-version=$EXTRA_VERSION --name-filter="$NAME_FILTER" --name-ignore="$NAME_IGNORE" --verbose="$VERBOSE"
       shell: bash
 
     - name: Print the results

--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -126,7 +126,7 @@ runs:
         NAME_FILTER: ${{ inputs.test-filter }}
         NAME_IGNORE: ${{ inputs.test-ignore }}
         TIMEOUT: ${{ inputs.timeout }}
-      run: npm run test -- --extra-version=$EXTRA_VERSION --name-filter=$NAME_FILTER --name-ignore=$NAME_IGNORE
+      run: npm run test -- --extra-version=$EXTRA_VERSION --name-filter="$NAME_FILTER" --name-ignore="$NAME_IGNORE"
       shell: bash
 
     - name: Print the results

--- a/.github/workflows/transport-interop.yml
+++ b/.github/workflows/transport-interop.yml
@@ -25,7 +25,6 @@ jobs:
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           worker-count: 16
           test-ignore: "java-v0.9 x zig-v0.0.1 (quic-v1)|zig-v0.0.1 x java-v0.9 (quic-v1)"
-          verbose: true
   build-without-secrets:
     runs-on: ["self-hosted", "linux", "x64", "4xlarge"] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
     steps:

--- a/.github/workflows/transport-interop.yml
+++ b/.github/workflows/transport-interop.yml
@@ -24,6 +24,7 @@ jobs:
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           worker-count: 16
+          test-ignore: "java-v0.9 x zig-v0.0.1 (quic-v1),zig-v0.0.1 x java-v0.9 (quic-v1)"
   build-without-secrets:
     runs-on: ["self-hosted", "linux", "x64", "4xlarge"] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
     steps:

--- a/.github/workflows/transport-interop.yml
+++ b/.github/workflows/transport-interop.yml
@@ -24,7 +24,7 @@ jobs:
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           worker-count: 16
-          test-ignore: "java-v0.9 x zig-v0.0.1 (quic-v1),zig-v0.0.1 x java-v0.9 (quic-v1)"
+          test-ignore: "java-v0.9 x zig-v0.0.1 (quic-v1)|zig-v0.0.1 x java-v0.9 (quic-v1)"
   build-without-secrets:
     runs-on: ["self-hosted", "linux", "x64", "4xlarge"] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
     steps:

--- a/.github/workflows/transport-interop.yml
+++ b/.github/workflows/transport-interop.yml
@@ -25,6 +25,7 @@ jobs:
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           worker-count: 16
           test-ignore: "java-v0.9 x zig-v0.0.1 (quic-v1)|zig-v0.0.1 x java-v0.9 (quic-v1)"
+          verbose: true
   build-without-secrets:
     runs-on: ["self-hosted", "linux", "x64", "4xlarge"] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
     steps:

--- a/transport-interop/impl/java/v0.9/Makefile
+++ b/transport-interop/impl/java/v0.9/Makefile
@@ -1,5 +1,5 @@
 image_name := java-v0.9
-commitSha := 9b7aa8833073782de98160fddfa3140fe6e01fd0
+commitSha := 2f0aca35aee2cd6b2e2eb4db50fe92810a767600
 
 all: image.json
 

--- a/transport-interop/impl/java/v0.9/Makefile
+++ b/transport-interop/impl/java/v0.9/Makefile
@@ -1,0 +1,14 @@
+image_name := java-v0.9
+commitSha := 9b7aa8833073782de98160fddfa3140fe6e01fd0
+
+all: image.json
+
+image.json:
+	wget -O java-libp2p-${commitSha}.zip "https://github.com/Peergos/nabu/archive/${commitSha}.zip"
+	unzip -o java-libp2p-${commitSha}.zip
+	cd nabu-${commitSha} && docker build -t ${image_name} -f Dockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+clean:
+	rm -rf image.json java-libp2p-*.zip nabu-*

--- a/transport-interop/impl/java/v0.9/Makefile
+++ b/transport-interop/impl/java/v0.9/Makefile
@@ -1,5 +1,5 @@
 image_name := java-v0.9
-commitSha := 2f0aca35aee2cd6b2e2eb4db50fe92810a767600
+commitSha := 2678425df28132e98307c825c90cc6efa58240a8
 
 all: image.json
 

--- a/transport-interop/src/generator.ts
+++ b/transport-interop/src/generator.ts
@@ -8,7 +8,7 @@ function buildExtraEnv(timeoutOverride: { [key: string]: number }, test1ID: stri
     return maxTimeout > 0 ? { "test_timeout_seconds": maxTimeout.toString(10) } : {}
 }
 
-export async function buildTestSpecs(versions: Array<Version>, nameFilter: string | null, nameIgnore: string | null): Promise<Array<ComposeSpecification>> {
+export async function buildTestSpecs(versions: Array<Version>, nameFilter: string | null, nameIgnore: string[] | null): Promise<Array<ComposeSpecification>> {
     const containerImages: { [key: string]: () => string } = {}
     const timeoutOverride: { [key: string]: number } = {}
     versions.forEach(v => containerImages[v.id] = () => {
@@ -100,11 +100,11 @@ export async function buildTestSpecs(versions: Array<Version>, nameFilter: strin
     return testSpecs
 }
 
-function buildSpec(containerImages: { [key: string]: () => string }, { name, dialerID, listenerID, transport, muxer, security, extraEnv }: { name: string, dialerID: string, listenerID: string, transport: string, muxer?: string, security?: string, extraEnv?: { [key: string]: string } }, nameFilter: string | null, nameIgnore: string | null): ComposeSpecification | null {
+function buildSpec(containerImages: { [key: string]: () => string }, { name, dialerID, listenerID, transport, muxer, security, extraEnv }: { name: string, dialerID: string, listenerID: string, transport: string, muxer?: string, security?: string, extraEnv?: { [key: string]: string } }, nameFilter: string | null, nameIgnore: string[] | null): ComposeSpecification | null {
     if (nameFilter && !name.includes(nameFilter)) {
         return null
     }
-    if (nameIgnore && name.includes(nameIgnore)) {
+    if (nameIgnore && nameIgnore.some(n => name.includes(n))) {
         return null
     }
     return {

--- a/transport-interop/src/generator.ts
+++ b/transport-interop/src/generator.ts
@@ -102,9 +102,11 @@ export async function buildTestSpecs(versions: Array<Version>, nameFilter: strin
 
 function buildSpec(containerImages: { [key: string]: () => string }, { name, dialerID, listenerID, transport, muxer, security, extraEnv }: { name: string, dialerID: string, listenerID: string, transport: string, muxer?: string, security?: string, extraEnv?: { [key: string]: string } }, nameFilter: string[] | null, nameIgnore: string[] | null): ComposeSpecification | null {
     if (nameFilter && !nameFilter.some(n => name.includes(n))) {
+        console.log("Filtering out test spec: " + name)
         return null
     }
     if (nameIgnore && nameIgnore.some(n => name.includes(n))) {
+        console.log("Ignoring test spec: " + name)
         return null
     }
     return {

--- a/transport-interop/src/generator.ts
+++ b/transport-interop/src/generator.ts
@@ -105,9 +105,9 @@ function acceptSpec(name: string, nameFilter: string[] | null, nameIgnore: strin
     let reason: string = ""
     let result: string[] = ["Checking " + name]
 
-    let filterMatch: string = ""
+    let filterMatch: string = "*"
     if (nameFilter && !nameFilter.some(n => {
-        let msg: string = "filter match (" + n + ")"
+        let msg: string = "filter match ('" + n + "')"
         let included: boolean = name.includes(n)
 
         if (included) {
@@ -127,7 +127,7 @@ function acceptSpec(name: string, nameFilter: string[] | null, nameIgnore: strin
         accept = false
     } else {
         if (verbose) {
-            result.push("...selected because of (" + filterMatch + ")")
+            result.push("...selected because of ('" + filterMatch + "')")
         }
         reason = "filter match: '" + filterMatch + "'"
     }
@@ -135,7 +135,7 @@ function acceptSpec(name: string, nameFilter: string[] | null, nameIgnore: strin
     if (accept) {
         let ignoreMatch: string = ""
         if (nameIgnore && nameIgnore.some(n => {
-            let msg: string = "ignore match (" + n + ")"
+            let msg: string = "ignore match ('" + n + "')"
             let included: boolean = name.includes(n)
 
             if (included) {
@@ -149,7 +149,7 @@ function acceptSpec(name: string, nameFilter: string[] | null, nameIgnore: strin
             return included
         })) {
             if (verbose) {
-                result.push("...ignored because of (" + ignoreMatch + ")")
+                result.push("...ignored because of ('" + ignoreMatch + "')")
             }
             reason = "ignore match: '" + ignoreMatch + "'"
             accept = false

--- a/transport-interop/src/generator.ts
+++ b/transport-interop/src/generator.ts
@@ -101,14 +101,38 @@ export async function buildTestSpecs(versions: Array<Version>, nameFilter: strin
 }
 
 function buildSpec(containerImages: { [key: string]: () => string }, { name, dialerID, listenerID, transport, muxer, security, extraEnv }: { name: string, dialerID: string, listenerID: string, transport: string, muxer?: string, security?: string, extraEnv?: { [key: string]: string } }, nameFilter: string[] | null, nameIgnore: string[] | null): ComposeSpecification | null {
-    if (nameFilter && !nameFilter.some(n => name.includes(n))) {
-        console.log("Filtering out test spec: " + name)
+    console.log("Checking" + name)
+    let filterMatch: string = ""
+    if (nameFilter && !nameFilter.some(n => {
+        let included: boolean = name.includes(n)
+        if (included) {
+            console.log("\t" + n + "...included")
+            filterMatch = n
+        } else {
+            console.log("\t" + n + "...NOT included")
+        }
+        return included
+    })) {
+        console.log("\tFiltering out test spec: " + name)
+        return null
+    } else {
+        console.log("\tSelecting because " + filterMatch + " is in " + name)
+    }
+    let ignoreMatch: string = ""
+    if (nameIgnore && nameIgnore.some(n => {
+        let included: boolean = name.includes(n)
+        if (included) {
+            console.log("\t" + n + "...included")
+            ignoreMatch = n
+        } else {
+            console.log("\t" + n + "...NOT included")
+        }
+        return included
+    })) {
+        console.log("\tIgnoring because " + ignoreMatch + " is in " + name)
         return null
     }
-    if (nameIgnore && nameIgnore.some(n => name.includes(n))) {
-        console.log("Ignoring test spec: " + name)
-        return null
-    }
+    console.log("WINNER: " + name)
     return {
         name,
         services: {

--- a/transport-interop/src/generator.ts
+++ b/transport-interop/src/generator.ts
@@ -8,7 +8,7 @@ function buildExtraEnv(timeoutOverride: { [key: string]: number }, test1ID: stri
     return maxTimeout > 0 ? { "test_timeout_seconds": maxTimeout.toString(10) } : {}
 }
 
-export async function buildTestSpecs(versions: Array<Version>, nameFilter: string | null, nameIgnore: string[] | null): Promise<Array<ComposeSpecification>> {
+export async function buildTestSpecs(versions: Array<Version>, nameFilter: string[] | null, nameIgnore: string[] | null): Promise<Array<ComposeSpecification>> {
     const containerImages: { [key: string]: () => string } = {}
     const timeoutOverride: { [key: string]: number } = {}
     versions.forEach(v => containerImages[v.id] = () => {
@@ -100,8 +100,8 @@ export async function buildTestSpecs(versions: Array<Version>, nameFilter: strin
     return testSpecs
 }
 
-function buildSpec(containerImages: { [key: string]: () => string }, { name, dialerID, listenerID, transport, muxer, security, extraEnv }: { name: string, dialerID: string, listenerID: string, transport: string, muxer?: string, security?: string, extraEnv?: { [key: string]: string } }, nameFilter: string | null, nameIgnore: string[] | null): ComposeSpecification | null {
-    if (nameFilter && !name.includes(nameFilter)) {
+function buildSpec(containerImages: { [key: string]: () => string }, { name, dialerID, listenerID, transport, muxer, security, extraEnv }: { name: string, dialerID: string, listenerID: string, transport: string, muxer?: string, security?: string, extraEnv?: { [key: string]: string } }, nameFilter: string[] | null, nameIgnore: string[] | null): ComposeSpecification | null {
+    if (nameFilter && !nameFilter.some(n => name.includes(n))) {
         return null
     }
     if (nameIgnore && nameIgnore.some(n => name.includes(n))) {

--- a/transport-interop/testplans.ts
+++ b/transport-interop/testplans.ts
@@ -63,12 +63,22 @@ import path from "path";
     let nameFilter: string[] | null = null
     const rawNameFilter: string | undefined = argv["name-filter"]
     if (rawNameFilter) {
+        console.log("rawNameFilter: " + rawNameFilter)
         nameFilter = rawNameFilter.split('|').map(item => item.trim());
+    }
+    if (nameFilter) {
+        console.log("Name Filters:")
+        nameFilter.map(n => console.log("\t" + n))
     }
     let nameIgnore: string[] | null = null
     const rawNameIgnore: string | undefined = argv["name-ignore"]
     if (rawNameIgnore) {
+        console.log("rawNameIgnore: " + rawNameIgnore)
         nameIgnore = rawNameIgnore.split('|').map(item => item.trim());
+    }
+    if (nameIgnore) {
+        console.log("Name Ignores:")
+        nameIgnore.map(n => console.log("\t" + n))
     }
     let testSpecs = await buildTestSpecs(versions.concat(extraVersions), nameFilter, nameIgnore)
 

--- a/transport-interop/testplans.ts
+++ b/transport-interop/testplans.ts
@@ -61,12 +61,12 @@ import path from "path";
 
 
     let nameFilter: string[] | null = null
-    const rawNameFilter = string | undefined = argv["name-filter"]
+    const rawNameFilter: string | undefined = argv["name-filter"]
     if (rawNameFilter) {
         nameFilter = rawNameFilter.split(',').map(item => item.trim());
     }
     let nameIgnore: string[] | null = null
-    const rawNameIgnore = string | undefined = argv["name-ignore"]
+    const rawNameIgnore: string | undefined = argv["name-ignore"]
     if (rawNameIgnore) {
         nameIgnore = rawNameIgnore.split(',').map(item => item.trim());
     }

--- a/transport-interop/testplans.ts
+++ b/transport-interop/testplans.ts
@@ -64,9 +64,10 @@ import path from "path";
     if (nameFilter === "") {
         nameFilter = null
     }
-    let nameIgnore: string | null = argv["name-ignore"]
-    if (nameIgnore === "") {
-        nameIgnore = null
+    let nameIgnore: string[] | null = null
+    const rawNameIgnore = string | null = argv["name-ignore"]
+    if (rawNameIgnore) {
+        nameIgnore = rawNameIgnore.split(',').map(item => item.trim());
     }
     let testSpecs = await buildTestSpecs(versions.concat(extraVersions), nameFilter, nameIgnore)
 

--- a/transport-interop/testplans.ts
+++ b/transport-interop/testplans.ts
@@ -12,11 +12,11 @@ import path from "path";
     const argv = await yargs(process.argv.slice(2))
         .options({
             'name-filter': {
-                description: 'Only run tests including this name',
+                description: 'Only run tests including any of these names (comma separated)',
                 default: "",
             },
             'name-ignore': {
-                description: 'Do not run any tests including this name ',
+                description: 'Do not run any tests including any of these names (comma separated)',
                 default: "",
             },
             'emit-only': {
@@ -60,12 +60,13 @@ import path from "path";
     }
 
 
-    let nameFilter: string | null = argv["name-filter"]
-    if (nameFilter === "") {
-        nameFilter = null
+    let nameFilter: string[] | null = null
+    const rawNameFilter = string | undefined = argv["name-filter"]
+    if (rawNameFilter) {
+        nameFilter = rawNameFilter.split(',').map(item => item.trim());
     }
     let nameIgnore: string[] | null = null
-    const rawNameIgnore = string | null = argv["name-ignore"]
+    const rawNameIgnore = string | undefined = argv["name-ignore"]
     if (rawNameIgnore) {
         nameIgnore = rawNameIgnore.split(',').map(item => item.trim());
     }

--- a/transport-interop/testplans.ts
+++ b/transport-interop/testplans.ts
@@ -35,6 +35,11 @@ import path from "path";
                 default: [],
                 type: 'array'
             },
+            'verbose': {
+                description: 'Enable verbose logging',
+                default: false,
+                type: 'boolean'
+            }
         })
         .help()
         .version(false)
@@ -59,11 +64,14 @@ import path from "path";
         extraVersions.push(JSON.parse(contents.toString()))
     }
 
+    const verbose: boolean = argv.verbose
 
     let nameFilter: string[] | null = null
     const rawNameFilter: string | undefined = argv["name-filter"]
     if (rawNameFilter) {
-        console.log("rawNameFilter: " + rawNameFilter)
+        if (verbose) {
+            console.log("rawNameFilter: " + rawNameFilter)
+        }
         nameFilter = rawNameFilter.split('|').map(item => item.trim());
     }
     if (nameFilter) {
@@ -73,15 +81,17 @@ import path from "path";
     let nameIgnore: string[] | null = null
     const rawNameIgnore: string | undefined = argv["name-ignore"]
     if (rawNameIgnore) {
-        console.log("rawNameIgnore: " + rawNameIgnore)
+        if (verbose) {
+            console.log("rawNameIgnore: " + rawNameIgnore)
+        }
         nameIgnore = rawNameIgnore.split('|').map(item => item.trim());
     }
     if (nameIgnore) {
         console.log("Name Ignores:")
         nameIgnore.map(n => console.log("\t" + n))
     }
-    let testSpecs = await buildTestSpecs(versions.concat(extraVersions), nameFilter, nameIgnore)
 
+    let testSpecs = await buildTestSpecs(versions.concat(extraVersions), nameFilter, nameIgnore, verbose)
 
     if (argv["emit-only"]) {
         for (const testSpec of testSpecs) {

--- a/transport-interop/testplans.ts
+++ b/transport-interop/testplans.ts
@@ -12,11 +12,11 @@ import path from "path";
     const argv = await yargs(process.argv.slice(2))
         .options({
             'name-filter': {
-                description: 'Only run tests including any of these names (comma separated)',
+                description: 'Only run tests including any of these names (pipe separated)',
                 default: "",
             },
             'name-ignore': {
-                description: 'Do not run any tests including any of these names (comma separated)',
+                description: 'Do not run any tests including any of these names (pipe separated)',
                 default: "",
             },
             'emit-only': {
@@ -63,12 +63,12 @@ import path from "path";
     let nameFilter: string[] | null = null
     const rawNameFilter: string | undefined = argv["name-filter"]
     if (rawNameFilter) {
-        nameFilter = rawNameFilter.split(',').map(item => item.trim());
+        nameFilter = rawNameFilter.split('|').map(item => item.trim());
     }
     let nameIgnore: string[] | null = null
     const rawNameIgnore: string | undefined = argv["name-ignore"]
     if (rawNameIgnore) {
-        nameIgnore = rawNameIgnore.split(',').map(item => item.trim());
+        nameIgnore = rawNameIgnore.split('|').map(item => item.trim());
     }
     let testSpecs = await buildTestSpecs(versions.concat(extraVersions), nameFilter, nameIgnore)
 

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -228,6 +228,21 @@
     ]
   },
   {
+    "id": "java-v0.9",
+    "transports": [
+      "tcp",
+      "quic-v1",
+    ],
+    "secureChannels": [
+      "tls",
+      "noise"
+    ],
+    "muxers": [
+      "mplex",
+      "yamux"
+    ]
+  },
+  {
     "id": "js-v1.x",
     "transports": [
       "tcp",

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -231,7 +231,7 @@
     "id": "java-v0.9",
     "transports": [
       "tcp",
-      "quic-v1",
+      "quic-v1"
     ],
     "secureChannels": [
       "tls",


### PR DESCRIPTION
from @kevodwyer:
> Have confirmed test results locally (at least those implementation that will build on apple m2 - go, rust, java, js).
> Zig - uses ed25519 certs which netty quic doesn't support - https://github.com/netty/netty-incubator-codec-quic/issues/487
>
> The Nim build error seems unrelated to this PR.

This is a PR from a local copy of the branch on the fork: https://github.com/kevodwyer/test-plans/tree/feat/java-v0.9

I did this so that the checks will have access to the secrets and we can get a clean CI/CD pass.

This is in lieu of #638 