### PR TITLE
specify known-good image by hash to force the correct version

### DIFF
--- a/transport-interop/impl/nim/v1.0/Dockerfile
+++ b/transport-interop/impl/nim/v1.0/Dockerfile
@@ -1,5 +1,6 @@
 ARG NimVersion="1.6.16"
-FROM nimlang/nim:${NimVersion}-alpine as builder
+ARG ImageHash="sha256:b4bb14fb74465a91a4e042194e1e9308965e7f2f824a06a7092ed938dc04015f"
+FROM nimlang/nim:${NimVersion}-alpine@${ImageHash} AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
for some reason the incorrect nim docker image is being pulled in other PRs. i am testing if specifying a known-good version of the image via the hash will fix this.