### PR TITLE
Add custom graph option for custom graph generation

### DIFF
--- a/gossipsub-interop/README.md
+++ b/gossipsub-interop/README.md
@@ -68,6 +68,25 @@ example, the output folder is
   - analysis_*.txt: A text file containing a high level analysis of the 3 key results
   - Charts visualizing the results.
 
+### Network graph
+By default, the graph that is generated and fed into shadow selects the type (supernode or fullnode) and location (Australia, Europe, East Asia, West Asia, NA East, NA West, South Africa, South America) of a node randomly.
+
+Users can also specify their own custom network graph by using the `--graph` option.
+```
+uv run run.py --node_count <> --composition rust-and-go --scenario subnet-blob-msg --graph custom --nodes_file <> --edges_file <>
+```
+Where the nodes_file and edges_file are CSVs that have the following columns
+```
+nodes.csv:
+id,bandwidth_up,bandwidth_down
+
+edges.csv:
+src,dst,latency
+```
+Where `id` can be any unique string and the `src` and `dst` correspond to an `id` from `nodes.csv`. Fields other than `id` will have default values if not specified.
+
+The argument into `--node_count` should be the number of nodes specified in `nodes.csv`.
+
 ## Adding an implementation
 
 To build the implementation reference `./test-specs/implementation.md`.

--- a/gossipsub-interop/README.md
+++ b/gossipsub-interop/README.md
@@ -85,7 +85,7 @@ src,dst,latency
 ```
 Where `id` can be any unique string and the `src` and `dst` correspond to an `id` from `nodes.csv`. Fields other than `id` will have default values if not specified.
 
-The argument into `--node_count` should be the number of nodes specified in `nodes.csv`.
+The argument into `--node_count` can be the same, more, or less than the number of nodes in `nodes.csv`. If the node count is higher, it would essentially be like two gossipsub implementaions running on the same machine. If the node count is lower, it will randomly choose some nodes from `nodes.csv` to place on the network graph.
 
 ## Adding an implementation
 

--- a/gossipsub-interop/network_graph.py
+++ b/gossipsub-interop/network_graph.py
@@ -238,16 +238,14 @@ def generate_custom_graph(
 
     config["hosts"] = {}
 
-    binaries = kwargs["binaries"]
-    binary_paths = random.choices(
-        [b.path for b in binaries],
-        weights=[b.percent_of_nodes for b in binaries],
-        k=node_count
-    )
+    if node_count == len(binary_paths):
+        nodes = list(range(node_count))
+    else:
+        nodes = random.choices(range(node_count), k=len(binary_paths))
 
     for i, binary_path in enumerate(binary_paths):
         config["hosts"][f"node{i}"] = {
-            "network_node_id": i,
+            "network_node_id": nodes[i],
             "processes": [
                 {
                     "args": f"--params {params_file_location}",

--- a/gossipsub-interop/run.py
+++ b/gossipsub-interop/run.py
@@ -70,7 +70,6 @@ def main():
     optional_args = {
         "nodes_file": args.nodes_file,
         "edges_file": args.edges_file,
-        "binaries": binaries,
     }
     # Generate the network graph and the Shadow config for the binaries
     generate_graph(

--- a/gossipsub-interop/run.py
+++ b/gossipsub-interop/run.py
@@ -28,6 +28,9 @@ def main():
         "--scenario", type=str, required=False, default="subnet-blob-msg"
     )
     parser.add_argument("--composition", type=str, required=False, default="all-go")
+    parser.add_argument("--graph", type=str, choices=["random", "custom"], required=False, default="random")
+    parser.add_argument("--nodes_file", type=str, required=False, default="", help="File containing nodes information for custom graph")
+    parser.add_argument("--edges_file", type=str, required=False, default="", help="File containing edges information for cusotmg raph")
     parser.add_argument("--output_dir", type=str, required=False)
     args = parser.parse_args()
 
@@ -64,12 +67,19 @@ def main():
         k=args.node_count,
     )
 
+    optional_args = {
+        "nodes_file": args.nodes_file,
+        "edges_file": args.edges_file,
+        "binaries": binaries,
+    }
     # Generate the network graph and the Shadow config for the binaries
     generate_graph(
+        args.graph,
         binary_paths,
         "graph.gml",
         "shadow.yaml",
         params_file_location=os.path.join(os.getcwd(), params_file_name),
+        **optional_args,
     )
 
     if args.dry_run:


### PR DESCRIPTION
The goal of this PR is to allow user defined network graphs for the gossipsub-interop testing using shadow. It branches off of https://github.com/libp2p/test-plans/pull/648 and will need to be merged after this.

It allows a user to
- Specify a node's upload and download bandwidth
- Specify latencies between specific nodes

Changes
- Add new arguments for specifying graph type and file paths for the "custom" option
- Modify `network_graph.py` to support the "random" graph generation (the existing one) and "custom" graph generation.

The graph is specified with two csv files, one for nodes and one for edges (more in the Readme). This change is part of an ongoing effort to replicate mainnet as close as possible. As we get more accurate latencies between nodes and the available bandwidth on each node, we should be able to recreate the libp2p layer of the mainnet network.

TODO

- [ ] Address PR feedback