### PR TITLE
feat: adding python to transport-interop tests

### DIFF
--- a/transport-interop/Makefile
+++ b/transport-interop/Makefile
@@ -1,16 +1,68 @@
+# To build in parallel, run: make all-parallel -j$(nproc) or make parallel -j$(nproc)
+# where $(nproc) is the number of CPU cores available
+# 
+# make all          - builds everything sequentially (original behavior)
+# make all-parallel - builds everything in parallel (including within subdirectories)
+
 GO_SUBDIRS := $(wildcard impl/go/*/.)
 JS_SUBDIRS := $(wildcard impl/js/*/.)
 RUST_SUBDIRS := $(wildcard impl/rust/*/.)
+RUST_CHROMIUM_SUBDIRS := $(wildcard impl/rust-chromium/*/.)
 NIM_SUBDIRS := $(wildcard impl/nim/*/.)
 ZIG_SUBDIRS := $(wildcard impl/zig/*/.)
 JAVA_SUBDIRS := $(wildcard impl/java/*/.)
+PYTHON_SUBDIRS := $(wildcard impl/python/*/.)
 
-all: $(GO_SUBDIRS) $(JS_SUBDIRS) $(RUST_SUBDIRS) $(NIM_SUBDIRS) $(ZIG_SUBDIRS) $(JAVA_SUBDIRS)
+# Create parallel versions of subdirectory lists
+GO_SUBDIRS_PARALLEL := $(addsuffix -parallel,$(GO_SUBDIRS))
+JS_SUBDIRS_PARALLEL := $(addsuffix -parallel,$(JS_SUBDIRS))
+RUST_SUBDIRS_PARALLEL := $(addsuffix -parallel,$(RUST_SUBDIRS))
+RUST_CHROMIUM_SUBDIRS_PARALLEL := $(addsuffix -parallel,$(RUST_CHROMIUM_SUBDIRS))
+NIM_SUBDIRS_PARALLEL := $(addsuffix -parallel,$(NIM_SUBDIRS))
+ZIG_SUBDIRS_PARALLEL := $(addsuffix -parallel,$(ZIG_SUBDIRS))
+JAVA_SUBDIRS_PARALLEL := $(addsuffix -parallel,$(JAVA_SUBDIRS))
+PYTHON_SUBDIRS_PARALLEL := $(addsuffix -parallel,$(PYTHON_SUBDIRS))
+
+# Extract the number of jobs from MAKEFLAGS or use all available cores
+JOBS := $(filter -j%,$(MAKEFLAGS))
+ifeq ($(JOBS),)
+    JOBS := -j$(shell nproc)
+endif
+
+# Original sequential build (default target)
+all: $(GO_SUBDIRS) $(JS_SUBDIRS) $(RUST_SUBDIRS) $(RUST_CHROMIUM_SUBDIRS) $(NIM_SUBDIRS) $(ZIG_SUBDIRS) $(JAVA_SUBDIRS) $(PYTHON_SUBDIRS)
+
+# New parallel build target - uses separate parallel targets
+all-parallel:
+	$(MAKE) $(JOBS) $(GO_SUBDIRS_PARALLEL) $(JS_SUBDIRS_PARALLEL) $(RUST_SUBDIRS_PARALLEL) $(RUST_CHROMIUM_SUBDIRS_PARALLEL) $(NIM_SUBDIRS_PARALLEL) $(ZIG_SUBDIRS_PARALLEL) $(JAVA_SUBDIRS_PARALLEL) $(PYTHON_SUBDIRS_PARALLEL)
+
+# Parallel target - same as 'all-parallel' but explicitly indicates parallel execution
+parallel: all-parallel
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  all          - builds everything sequentially (original behavior)"
+	@echo "  all-parallel - builds everything in parallel (including within subdirectories)"
+	@echo "  parallel     - same as all-parallel"
+	@echo "  clean        - remove all Docker images and build artifacts"
+	@echo "  help         - show this help message"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make all                    # sequential build"
+	@echo "  make all-parallel           # parallel build using all cores"
+	@echo "  make all-parallel -j4       # parallel build using 4 cores"
+	@echo "  make parallel -j$(shell nproc)  # parallel build using all cores"
+	@echo "  make clean                  # remove all Docker images"
+
+# Sequential builds (original behavior)
 $(JS_SUBDIRS):
 	$(MAKE) -C $@
 $(GO_SUBDIRS):
 	$(MAKE) -C $@
 $(RUST_SUBDIRS):
+	$(MAKE) -C $@
+$(RUST_CHROMIUM_SUBDIRS):
 	$(MAKE) -C $@
 $(NIM_SUBDIRS):
 	$(MAKE) -C $@
@@ -18,5 +70,38 @@ $(ZIG_SUBDIRS):
 	$(MAKE) -C $@
 $(JAVA_SUBDIRS):
 	$(MAKE) -C $@
+$(PYTHON_SUBDIRS):
+	$(MAKE) -C $@
 
-.PHONY: $(GO_SUBDIRS) $(JS_SUBDIRS) $(RUST_SUBDIRS) $(NIM_SUBDIRS) $(ZIG_SUBDIRS) $(JAVA_SUBDIRS) all
+# Parallel builds (new behavior) - run subdirectories in parallel
+$(JS_SUBDIRS_PARALLEL):
+	$(MAKE) -C $(subst -parallel,,$@)
+$(GO_SUBDIRS_PARALLEL):
+	$(MAKE) -C $(subst -parallel,,$@)
+$(RUST_SUBDIRS_PARALLEL):
+	$(MAKE) -C $(subst -parallel,,$@)
+$(RUST_CHROMIUM_SUBDIRS_PARALLEL):
+	$(MAKE) -C $(subst -parallel,,$@)
+$(NIM_SUBDIRS_PARALLEL):
+	$(MAKE) -C $(subst -parallel,,$@)
+$(ZIG_SUBDIRS_PARALLEL):
+	$(MAKE) -C $(subst -parallel,,$@)
+$(JAVA_SUBDIRS_PARALLEL):
+	$(MAKE) -C $(subst -parallel,,$@)
+$(PYTHON_SUBDIRS_PARALLEL):
+	$(MAKE) -C $(subst -parallel,,$@)
+
+# Clean target - remove all Docker images and build artifacts
+clean:
+	@echo "Cleaning up Docker images and build artifacts..."
+	@echo "Removing transport-interop Docker images..."
+	@docker images --format "table {{.Repository}}:{{.Tag}}" | grep -E "(transport-interop|python-v0\.2\.9|go-v0\.[0-9]+|js-v[0-9]+|rust-v[0-9]+|nim-v[0-9]+|zig-v[0-9]+|java-v[0-9]+)" | awk '{print $$1}' | xargs -r docker rmi -f 2>/dev/null || true
+	@echo "Removing any remaining containers..."
+	@docker ps -a --format "{{.ID}}" | xargs -r docker rm -f 2>/dev/null || true
+	@echo "Cleaning up build artifacts in subdirectories..."
+	@find impl -name "image.json" -delete 2>/dev/null || true
+	@find impl -name "force-rebuild" -delete 2>/dev/null || true
+	@echo "Cleanup complete!"
+
+.PHONY: $(GO_SUBDIRS) $(JS_SUBDIRS) $(RUST_SUBDIRS) $(RUST_CHROMIUM_SUBDIRS) $(NIM_SUBDIRS) $(ZIG_SUBDIRS) $(JAVA_SUBDIRS) $(PYTHON_SUBDIRS) all all-parallel parallel help clean
+.PHONY: $(GO_SUBDIRS_PARALLEL) $(JS_SUBDIRS_PARALLEL) $(RUST_SUBDIRS_PARALLEL) $(RUST_CHROMIUM_SUBDIRS_PARALLEL) $(NIM_SUBDIRS_PARALLEL) $(ZIG_SUBDIRS_PARALLEL) $(JAVA_SUBDIRS_PARALLEL) $(PYTHON_SUBDIRS_PARALLEL)

--- a/transport-interop/impl/python/v0.2/.gitignore
+++ b/transport-interop/impl/python/v0.2/.gitignore
@@ -1,0 +1,53 @@
+# Python libp2p library source code (downloaded during build)
+py-libp2p-*.zip
+py-libp2p-*/
+
+# Python build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Docker build artifacts
+image.json
+force-rebuild
+
+# Python virtual environments
+venv/
+env/
+ENV/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.temp 
+*.bak

--- a/transport-interop/impl/python/v0.2/Makefile
+++ b/transport-interop/impl/python/v0.2/Makefile
@@ -1,0 +1,32 @@
+image_name := python-v0.2.9-git
+
+all: image.json
+
+image.json: ping_test.py pyproject.toml
+	IMAGE_NAME=${image_name} ../../../dockerBuildWrapper.sh -f PingDockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+# Force rebuild without cache (always downloads fresh packages from git)
+force-rebuild: ping_test.py pyproject.toml
+	IMAGE_NAME=${image_name} ../../../dockerBuildWrapper.sh --no-cache -f PingDockerfile .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  all          - build Docker image using cached layers (fast)"
+	@echo "  force-rebuild - build Docker image without cache (always fresh git packages)"
+	@echo "  clean        - remove generated image.json file"
+	@echo "  help         - show this help message"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make all          # build with cache (recommended for development)"
+	@echo "  make force-rebuild # build without cache (ensures latest git packages)"
+	@echo "  make clean        # remove build artifacts"
+
+.PHONY: clean all force-rebuild help
+
+clean:
+	rm -f image.json 

--- a/transport-interop/impl/python/v0.2/PingDockerfile
+++ b/transport-interop/impl/python/v0.2/PingDockerfile
@@ -1,0 +1,30 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    redis-tools \
+    build-essential \
+    cmake \
+    pkg-config \
+    libgmp-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy pyproject.toml and install Python dependencies
+COPY pyproject.toml .
+RUN pip install --no-cache-dir -e .
+
+# Copy the ping test implementation
+COPY ping_test.py .
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV CI=true
+
+# Set the entrypoint to run the ping test
+ENTRYPOINT ["python", "ping_test.py"]
+
+# The entrypoint will be set by the dockerBuildWrapper.sh script
+# but it should run: python ping_test.py 

--- a/transport-interop/impl/python/v0.2/README.md
+++ b/transport-interop/impl/python/v0.2/README.md
@@ -1,0 +1,156 @@
+# Python libp2p Ping Test Implementation
+
+This directory contains the Python implementation of the libp2p ping test for transport-interop testing.
+
+## Overview
+
+The Python implementation follows the transport-interop test specification and provides:
+- Support for TCP transport
+- Support for Noise and Plaintext security protocols
+- Support for Mplex and Yamux multiplexers
+- Both dialer and listener roles
+- Redis-based coordination
+- JSON output format for test results
+- Integration with py-libp2p's logging system via `LIBP2P_DEBUG` environment variable
+
+## Files
+
+- `ping_test.py` - Main implementation of the ping test
+- `pyproject.toml` - Python project configuration and dependencies
+- `PingDockerfile` - Docker configuration for the test
+- `Makefile` - Build configuration with parallel build support
+- `.gitignore` - Git ignore rules (excludes build artifacts)
+- `doc/` - Documentation directory
+- `README.md` - This file
+
+## Building
+
+To build the Docker image:
+
+```bash
+make
+```
+
+This will:
+1. Install py-libp2p from the specified git commit
+2. Build the Docker image
+3. Generate the `image.json` file with the image ID
+
+### Build Options
+
+```bash
+# Build with cache (fast)
+make all
+
+# Build without cache (ensures latest git packages)
+make force-rebuild
+
+# Clean build artifacts
+make clean
+
+# Show help
+make help
+```
+
+## Running Locally
+
+To run the test locally (for debugging):
+
+1. Start Redis:
+```bash
+docker run --rm -p 6379:6379 redis:7-alpine
+```
+
+2. Run as listener:
+```bash
+transport=tcp muxer=mplex security=noise is_dialer=false ip="0.0.0.0" redis_addr=localhost:6379 python ping_test.py
+```
+
+3. Run as dialer:
+```bash
+transport=tcp muxer=mplex security=noise is_dialer=true redis_addr=localhost:6379 python ping_test.py
+```
+
+**Alternative configurations:**
+
+With Yamux multiplexer:
+```bash
+transport=tcp muxer=yamux security=noise is_dialer=true redis_addr=localhost:6379 python ping_test.py
+```
+
+With Plaintext security:
+```bash
+transport=tcp muxer=mplex security=plaintext is_dialer=true redis_addr=localhost:6379 python ping_test.py
+```
+
+
+
+## Environment Variables
+
+The implementation reads the following environment variables:
+
+- `transport` - Transport protocol (tcp)
+- `muxer` - Multiplexer (mplex, yamux)
+- `security` - Security protocol (noise, plaintext)
+- `is_dialer` - Whether to run as dialer (true) or listener (false)
+- `ip` - IP address to bind to (default: 0.0.0.0)
+- `redis_addr` - Redis server address (default: redis:6379)
+- `test_timeout_seconds` - Test timeout in seconds (default: 180)
+- `LIBP2P_DEBUG` - Enable debug logging (e.g., "DEBUG", "ping_test:DEBUG")
+- `LIBP2P_DEBUG_FILE` - Custom log file path for debug output
+
+## Output Format
+
+The dialer outputs JSON to stdout with the following format:
+```json
+{
+  "handshakePlusOneRTTMillis": 123.45,
+  "pingRTTMilllis": 12.34
+}
+```
+
+All diagnostic output goes to stderr.
+
+## Debugging and Logging
+
+The implementation integrates with py-libp2p's built-in logging system:
+
+### Enable Debug Logging
+```bash
+# Enable all debug output
+export LIBP2P_DEBUG=DEBUG
+python ping_test.py
+
+# Enable debug only for ping_test module
+export LIBP2P_DEBUG=ping_test:DEBUG
+python ping_test.py
+
+# Log to custom file
+export LIBP2P_DEBUG=DEBUG
+export LIBP2P_DEBUG_FILE=/tmp/custom.log
+python ping_test.py
+```
+
+### Debug Features
+- **Automatic Integration**: No manual logging setup required
+- **Thread-Safe**: Uses py-libp2p's queue-based logging system
+- **Automatic File Logging**: Creates timestamped log files in `/tmp/`
+- **Hierarchical Control**: Enable debug for specific modules
+- **Zero Overhead**: No debug output when `LIBP2P_DEBUG` is not set
+
+## Dependencies
+
+### Python Dependencies
+- `libp2p` - Python libp2p implementation (from git commit)
+- `redis` - Redis client for coordination
+- `trio` - Asynchronous I/O support
+- `multiaddr` - Multiaddr parsing and manipulation
+- `typing-extensions` - Type hints support
+
+### Docker System Dependencies
+The Docker image includes the following system packages:
+- `git` - Required for installing py-libp2p from git repository
+- `build-essential` - C/C++ compiler and build tools
+- `cmake` - Build system generator
+- `pkg-config` - Package configuration utility
+- `libgmp-dev` - GNU Multiple Precision Arithmetic Library 

--- a/transport-interop/impl/python/v0.2/doc/AUTOMATED_TESTING.md
+++ b/transport-interop/impl/python/v0.2/doc/AUTOMATED_TESTING.md
@@ -1,0 +1,342 @@
+# Automated Testing Guide for py-libp2p Ping Implementation
+
+This guide covers how to use the transport-interop framework to automatically test the py-libp2p ping implementation against other libp2p implementations.
+
+## Prerequisites
+
+- Node.js (v16 or higher)
+- npm
+- Docker installed and running
+- All required libp2p implementations built and available
+
+## Framework Setup
+
+### 1. Install Dependencies
+```bash
+cd transport-interop
+npm install
+```
+
+### 2. Verify Framework Installation
+```bash
+# Check if the framework is working
+npm test -- --help
+```
+
+## Docker Configuration
+
+### Docker Daemon Network Pool Configuration
+
+If you encounter the error "all predefined address pools have been fully subnetted", Docker has run out of IP address pools. This can be fixed by configuring larger network pools in the Docker daemon.
+
+#### Configure Docker Daemon for Larger Network Pools
+
+Edit `/etc/docker/daemon.json` to add default address pools:
+
+```json
+{
+    
+    "default-address-pools": [
+        {
+            "base": "172.16.0.0/12",
+            "size": 24
+        },
+        {
+            "base": "192.168.0.0/16", 
+            "size": 24
+        },
+        {
+            "base": "10.0.0.0/8",
+            "size": 24
+        }
+    ]
+}
+```
+
+#### Implementation Steps
+
+1. **Backup current configuration:**
+```bash
+sudo cp /etc/docker/daemon.json /etc/docker/daemon.json.backup
+```
+
+2. **Edit the daemon configuration:**
+```bash
+sudo nano /etc/docker/daemon.json
+```
+
+3. **Add the default-address-pools section** to your existing configuration
+
+4. **Restart Docker daemon:**
+```bash
+sudo systemctl restart docker
+```
+
+5. **Verify the configuration:**
+```bash
+docker info | grep -A 10 "Default Address Pools"
+```
+
+#### Configuration Details
+
+- **Base networks**: Uses `/12` networks (4096 subnets) instead of default `/16` (256 subnets)
+- **Size**: Each subnet uses `/24` (256 IP addresses)
+- **Total capacity**: Allows for thousands of concurrent Docker networks
+- **Compatibility**: Works with existing nvidia runtime and btrfs storage driver
+
+### Alternative Solutions (if daemon config is not possible)
+
+#### Solution 1: Clean up existing networks
+```bash
+# Remove unused networks
+docker network prune -f
+
+# Remove all unused Docker resources
+docker system prune -f
+
+# Remove all stopped containers
+docker container prune -f
+```
+
+#### Solution 2: Limit concurrent tests
+```bash
+# Set environment variable to limit concurrent workers
+export WORKER_COUNT=4
+
+# Run tests with limited concurrency
+npm test -- --name-filter="python-v0.2.9 x js-v1.x" --concurrent=4
+```
+
+#### Solution 3: Use host networking (if available)
+```bash
+# Set environment variable to use host networking
+export DOCKER_NETWORK=host
+
+# Run tests with host networking
+npm test -- --name-filter="python-v0.2.9 x js-v1.x"
+```
+
+## Basic Automated Testing
+
+### Test Python Implementation Alone
+```bash
+# Test Python implementation (will fail if no other implementations are available)
+npm test -- --name-filter="python-v0.2.9"
+```
+
+### Test Against Specific Implementation
+```bash
+# Test Python vs JavaScript (one direction)
+npm test -- --name-filter="python-v0.2.9 x js-v1.x"
+
+# Test Python vs Rust (one direction)
+npm test -- --name-filter="python-v0.2.9 x rust-v0.53"
+
+# Test Python vs Go (one direction)
+npm test -- --name-filter="python-v0.2.9 x go-v0.42"
+```
+
+### Test Bidirectional Between Implementations
+```bash
+# Test Python vs JavaScript (both directions)
+npm test -- --name-filter="python-v0.2.9 x js-v1.x|js-v1.x x python-v0.2.9"
+
+# Test Python vs Rust (both directions)
+npm test -- --name-filter="python-v0.2.9 x rust-v0.53|rust-v0.53 x python-v0.2.9"
+
+# Test Python vs Go (both directions)
+npm test -- --name-filter="python-v0.2.9 x go-v0.42|go-v0.42 x python-v0.2.9"
+```
+
+### Test All Compatible Implementations
+```bash
+# Test Python against all implementations that support TCP+Noise+Mplex
+npm test -- --name-filter="python-v0.2.9"
+```
+
+## Advanced Testing Scenarios
+
+### Cross-Implementation Testing
+
+#### Test 1: Python as Dialer vs Other Listeners
+```bash
+# Test Python dialer against various listeners
+npm test -- --name-filter="python-v0.2.9 x js-v1.x|python-v0.2.9 x rust-v0.53|python-v0.2.9 x go-v0.42"
+```
+
+#### Test 2: Python as Listener vs Other Dialers
+```bash
+# Test Python listener against various dialers
+npm test -- --name-filter="js-v1.x x python-v0.2.9|rust-v0.53 x python-v0.2.9|go-v0.42 x python-v0.2.9"
+```
+
+#### Test 3: Round-Robin Testing
+```bash
+# Test all combinations of Python with other implementations
+npm test -- --name-filter="python-v0.2.9 x js-v1.x|js-v1.x x python-v0.2.9|python-v0.2.9 x rust-v0.53|rust-v0.53 x python-v0.2.9|python-v0.2.9 x go-v0.42|go-v0.42 x python-v0.2.9"
+```
+
+## Test Configuration
+
+### Environment Variables
+```bash
+# Set test timeout (in seconds)
+export TIMEOUT=600
+
+# Set worker count for parallel execution
+export WORKER_COUNT=4
+
+# Enable verbose logging
+export VERBOSE=true
+```
+
+## Monitoring and Logging
+
+### Enable Verbose Logging
+```bash
+# Enable verbose logging
+npm test -- --name-filter="python-v0.2.9" --verbose
+```
+
+### Log Analysis
+```bash
+# Save test results to file
+npm test -- --name-filter="python-v0.2.9" > test-results.log 2>&1
+
+# Analyze results
+grep "python-v0.2.9" test-results.log
+grep "ERROR" test-results.log
+```
+
+
+
+## Error Handling and Debugging
+
+### Common Test Failures
+
+#### Issue 1: Implementation Not Found
+**Symptoms:** `Error: ENOENT: no such file or directory, open './impl/python/v0.2/image.json'`
+**Solution:** Ensure Python implementation is built
+```bash
+cd transport-interop/impl/python/v0.2
+make clean && make
+```
+
+#### Issue 2: Docker Image Not Available
+**Symptoms:** `Unable to find image 'python-v0.2.9'`
+**Solution:** Rebuild Docker image
+```bash
+cd transport-interop/impl/python/v0.2
+docker build -f PingDockerfile -t python-v0.2.9 .
+```
+
+#### Issue 3: Redis Connection Failed
+**Symptoms:** `Error connecting to Redis`
+**Solution:** Start Redis server
+```bash
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+```
+
+#### Issue 4: Port Conflicts
+**Symptoms:** `Address already in use`
+**Solution:** Clean up existing containers
+```bash
+docker kill $(docker ps -q)
+docker rm $(docker ps -aq)
+```
+
+### Debug Mode
+```bash
+# Enable comprehensive debugging
+npm test -- --name-filter="python-v0.2.9" --verbose
+```
+
+
+
+
+
+## Continuous Monitoring
+
+### Automated Test Runner
+Create `run-tests.sh`:
+```bash
+#!/bin/bash
+set -e
+
+echo "Starting automated tests for python-v0.2.9"
+
+# Build implementation
+cd transport-interop/impl/python/v0.2
+make
+
+# Run tests
+cd ../..
+npm test -- --name-filter="python-v0.2.9" > results-$(date +%Y%m%d-%H%M%S).log
+
+echo "Tests completed successfully"
+```
+
+### Scheduled Testing
+```bash
+# Add to crontab for daily testing
+0 2 * * * /path/to/transport-interop/run-tests.sh
+```
+
+## Success Criteria
+
+Automated tests should pass when:
+
+1. ✅ **Build Success**: Docker image builds without errors
+2. ✅ **Container Start**: Container starts and runs correctly
+3. ✅ **Redis Connection**: Successfully connects to Redis
+4. ✅ **Address Exchange**: Listener publishes address, dialer retrieves it
+5. ✅ **Connection Establishment**: Dialer connects to listener
+6. ✅ **Protocol Handshake**: Noise handshake completes successfully
+7. ✅ **Ping/Pong Exchange**: Ping messages sent and received
+8. ✅ **Timing Measurements**: Valid RTT measurements returned
+9. ✅ **JSON Output**: Correct JSON format output
+10. ✅ **Clean Shutdown**: Container exits cleanly
+
+## Expected Test Results
+
+### Successful Test Output
+The test framework will output timing results in JSON format:
+```json
+{
+  "handshakePlusOneRTTMillis": 45.2,
+  "pingRTTMilllis": 0.8
+}
+```
+
+### Performance Benchmarks
+- **Connection Time**: < 5 seconds
+- **Handshake Time**: < 100ms
+- **Ping RTT**: < 10ms (localhost)
+- **Test Duration**: < 30 seconds per test
+
+## Cleanup
+
+### Post-Test Cleanup
+```bash
+# Clean up test containers
+docker kill $(docker ps -q --filter ancestor=python-v0.2.9)
+docker rm $(docker ps -aq --filter ancestor=python-v0.2.9)
+
+# Clean up Redis
+docker stop redis-test && docker rm redis-test
+
+# Clean up test artifacts
+rm -f test-results.log metrics.json test-report.*
+```
+
+### Maintenance
+```bash
+# Clean up old images
+docker image prune -f
+
+# Clean up old containers
+docker container prune -f
+
+# Clean up old volumes
+docker volume prune -f
+``` 

--- a/transport-interop/impl/python/v0.2/doc/JS_INTEROP_TESTING.md
+++ b/transport-interop/impl/python/v0.2/doc/JS_INTEROP_TESTING.md
@@ -1,0 +1,400 @@
+# Manual Testing: Python vs JS-libp2p Ping Interoperability
+
+This guide explains how to manually test the Python ping implementation against js-libp2p hosts to verify cross-implementation interoperability.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Test Scenarios](#test-scenarios)
+- [Step-by-Step Testing](#step-by-step-testing)
+- [Configuration Options](#configuration-options)
+- [Troubleshooting](#troubleshooting)
+- [Expected Results](#expected-results)
+- [Advanced Testing](#advanced-testing)
+
+## Overview
+
+The transport-interop framework supports testing between different libp2p implementations. This guide focuses on testing the Python implementation against js-libp2p v2.x to ensure they can successfully communicate using the ping protocol.
+
+### Test Architecture
+
+```
+┌─────────────┐    Redis    ┌─────────────┐
+│ Python      │◄──────────► │ JS-libp2p   │
+│ (Dialer)    │             │ (Listener)  │
+└─────────────┘             └─────────────┘
+```
+
+## Prerequisites
+
+### 1. Build Required Images
+
+```bash
+# Build Python image (if not already built)
+cd transport-interop/impl/python/v0.2
+make image.json
+
+# Build JS-libp2p image
+cd transport-interop/impl/js/v2.x
+make image.json
+```
+
+### 2. Start Redis Server
+
+```bash
+# Start Redis for coordination
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+
+# Verify Redis is running
+docker ps | grep redis
+```
+
+### 3. Verify Images Are Available
+
+```bash
+# Check available images
+docker images | grep -E "(python-v0.2.9|node-js-v2.x)"
+
+# Expected output:
+# python-v0.2.9    latest    <image-id>    <created>    <size>
+# node-js-v2.x     latest    <image-id>    <created>    <size>
+```
+
+## Test Scenarios
+
+### Scenario 1: Python Dialer → JS Listener
+- **Python**: Acts as dialer (client)
+- **JS-libp2p**: Acts as listener (server)
+- **Purpose**: Test Python's ability to connect to and ping JS hosts
+
+### Scenario 2: JS Dialer → Python Listener
+- **JS-libp2p**: Acts as dialer (client)
+- **Python**: Acts as listener (server)
+- **Purpose**: Test JS's ability to connect to and ping Python hosts
+
+### Scenario 3: Cross-Implementation Matrix
+Test all combinations of:
+- **Transports**: TCP
+- **Security**: Noise, Plaintext
+- **Muxers**: Mplex, Yamux
+
+## Step-by-Step Testing
+
+### Test 1: Python Dialer → JS Listener (TCP + Noise + Yamux)
+
+#### Step 1: Start JS Listener
+
+```bash
+# Terminal 1: Start JS listener
+docker run --rm --network host \
+  -e transport=tcp \
+  -e muxer=yamux \
+  -e security=noise \
+  -e is_dialer=false \
+  -e test_timeout_secs=15 \
+  -e redis_addr=localhost:6379 \
+  node-js-v2.x
+```
+
+**Expected Output:**
+```
+Running as listener
+Publishing address to Redis: /ip4/0.0.0.0/tcp/XXXXX/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+Waiting for incoming ping...
+```
+
+#### Step 2: Start Python Dialer
+
+```bash
+# Terminal 2: Start Python dialer
+docker run --rm --network host \
+  -e transport=tcp \
+  -e muxer=yamux \
+  -e security=noise \
+  -e is_dialer=true \
+  -e redis_addr=localhost:6379 \
+  -e test_timeout_seconds=15 \
+  python-v0.2.9 python ping_test.py
+```
+
+**Expected Output:**
+```
+Connected to Redis at localhost:6379
+Running as dialer
+Waiting for listener address from Redis...
+Got listener address: /ip4/0.0.0.0/tcp/XXXXX/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+Connecting to /ip4/0.0.0.0/tcp/XXXXX/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+Creating ping stream
+sending ping to 16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+received pong from 16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+{"handshakePlusOneRTTMillis": 10.88, "pingRTTMilllis": 0.26}
+```
+
+### Test 2: JS Dialer → Python Listener (TCP + Plaintext + Mplex)
+
+#### Step 1: Start Python Listener
+
+```bash
+# Terminal 1: Start Python listener
+docker run --rm --network host \
+  -e transport=tcp \
+  -e muxer=mplex \
+  -e security=plaintext \
+  -e is_dialer=false \
+  -e ip="0.0.0.0" \
+  -e redis_addr=localhost:6379 \
+  -e test_timeout_seconds=15 \
+  python-v0.2.9 python ping_test.py
+```
+
+#### Step 2: Start JS Dialer
+
+```bash
+# Terminal 2: Start JS dialer
+docker run --rm --network host \
+  -e transport=tcp \
+  -e muxer=mplex \
+  -e security=plaintext \
+  -e is_dialer=true \
+  -e test_timeout_secs=15 \
+  -e redis_addr=localhost:6379 \
+  node-js-v2.x
+```
+
+## Configuration Options
+
+### Environment Variables
+
+#### Python Implementation
+```bash
+-e transport=tcp                    # Transport protocol
+-e muxer=yamux|mplex              # Multiplexer
+-e security=noise|plaintext       # Security protocol
+-e is_dialer=true|false           # Role (dialer/listener)
+-e ip="0.0.0.0"                   # Listen IP (listener only)
+-e redis_addr=localhost:6379      # Redis server address
+-e test_timeout_seconds=15        # Test timeout in seconds
+```
+
+#### JS-libp2p Implementation
+```bash
+-e transport=tcp                    # Transport protocol
+-e muxer=yamux|mplex              # Multiplexer
+-e security=noise|plaintext       # Security protocol
+-e is_dialer=true|false           # Role (dialer/listener)
+-e test_timeout_secs=15           # Test timeout in seconds
+-e redis_addr=localhost:6379      # Redis server address
+```
+
+### Supported Combinations
+
+| Transport | Security | Muxer | Python | JS-libp2p | Status |
+|-----------|----------|-------|--------|-----------|--------|
+| TCP       | Noise    | Yamux | ✅     | ✅        | ✅     |
+| TCP       | Noise    | Mplex | ✅     | ✅        | ✅     |
+| TCP       | Plaintext| Yamux | ✅     | ✅        | ✅     |
+| TCP       | Plaintext| Mplex | ✅     | ✅        | ✅     |
+
+## Troubleshooting
+
+### Common Issues
+
+#### Issue 1: Redis Connection Failed
+**Symptoms:**
+```
+Error: Error -2 connecting to redis:6379. Name or service not known.
+```
+
+**Solutions:**
+```bash
+# Check if Redis is running
+docker ps | grep redis
+
+# Start Redis if not running
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+
+# Check Redis logs
+docker logs redis-test
+```
+
+#### Issue 2: Image Not Found
+**Symptoms:**
+```
+Error: Unable to find image 'python-v0.2.9:latest' locally
+```
+
+**Solutions:**
+```bash
+# Build Python image
+cd transport-interop/impl/python/v0.2
+make image.json
+
+# Build JS image
+cd transport-interop/impl/js/v2.x
+make image.json
+
+# Verify images exist
+docker images | grep -E "(python-v0.2.9|node-js-v2.x)"
+```
+
+#### Issue 3: Timeout Waiting for Listener
+**Symptoms:**
+```
+Error: Timeout waiting for listener address
+```
+
+**Solutions:**
+```bash
+# Check if listener is running
+docker ps | grep -E "(python-v0.2.9|node-js-v2.x)"
+
+# Check Redis for listener address
+docker exec redis-test redis-cli LRANGE listenerAddr 0 -1
+
+# Increase timeout
+-e test_timeout_seconds=30
+```
+
+#### Issue 4: Connection Refused
+**Symptoms:**
+```
+Error: Connection refused
+```
+
+**Solutions:**
+```bash
+# Check if both components are using same transport/security/muxer
+# Ensure listener started before dialer
+# Check network connectivity
+docker network ls
+```
+
+### Debugging Commands
+
+#### Monitor Redis Activity
+```bash
+# Monitor Redis in real-time
+docker exec redis-test redis-cli monitor
+
+# Check Redis data
+docker exec redis-test redis-cli LRANGE listenerAddr 0 -1
+```
+
+#### Check Container Logs
+```bash
+# Check Python container logs
+docker logs <python-container-id>
+
+# Check JS container logs
+docker logs <js-container-id>
+```
+
+#### Network Debugging
+```bash
+# Check network connectivity
+docker exec <container-id> ping <target-ip>
+
+# Check listening ports
+docker exec <container-id> netstat -tlnp
+```
+
+## Expected Results
+
+### Successful Test Output
+
+#### Python Dialer Success
+```json
+{
+  "handshakePlusOneRTTMillis": 10.88,
+  "pingRTTMilllis": 0.26
+}
+```
+
+#### JS Dialer Success
+```json
+{
+  "handshakePlusOneRTTMillis": 12.45,
+  "pingRTTMilllis": 0.31
+}
+```
+
+### Performance Benchmarks
+
+| Configuration | Handshake + RTT (ms) | Ping RTT (ms) |
+|---------------|---------------------|---------------|
+| TCP + Noise + Yamux | 10-15 | 0.2-0.5 |
+| TCP + Noise + Mplex | 8-12 | 0.2-0.4 |
+| TCP + Plaintext + Yamux | 5-10 | 0.1-0.3 |
+| TCP + Plaintext + Mplex | 4-8 | 0.1-0.2 |
+
+## Advanced Testing
+
+### Automated Test Matrix
+
+Create a script to test all combinations:
+
+```bash
+#!/bin/bash
+
+# Test matrix
+transports=("tcp")
+securities=("noise" "plaintext")
+muxers=("yamux" "mplex")
+roles=("python_js" "js_python")
+
+for transport in "${transports[@]}"; do
+  for security in "${securities[@]}"; do
+    for muxer in "${muxers[@]}"; do
+      for role in "${roles[@]}"; do
+        echo "Testing: $transport + $security + $muxer ($role)"
+        # Run test with current configuration
+        # Store results
+      done
+    done
+  done
+done
+```
+
+### Load Testing
+
+```bash
+# Test with multiple concurrent connections
+for i in {1..10}; do
+  docker run --rm --network host \
+    -e transport=tcp -e muxer=yamux -e security=noise \
+    -e is_dialer=true -e redis_addr=localhost:6379 \
+    python-v0.2.9 python ping_test.py &
+done
+```
+
+### Stress Testing
+
+```bash
+# Run tests for extended periods
+for i in {1..100}; do
+  echo "Test iteration $i"
+  # Run test
+  sleep 1
+done
+```
+
+## Summary
+
+This guide provides comprehensive instructions for manually testing Python ping interoperability with js-libp2p hosts. The key points are:
+
+1. **Build both images** before testing
+2. **Start Redis** for coordination
+3. **Test both directions** (Python→JS and JS→Python)
+4. **Test all configurations** (transport/security/muxer combinations)
+5. **Monitor Redis** for debugging
+6. **Check logs** for detailed error information
+
+Successful tests demonstrate that the Python implementation can interoperate with js-libp2p, validating the transport-interop framework's cross-implementation compatibility goals.
+
+## References
+
+- [Transport-Interop Framework](../README.md)
+- [Python Implementation](./README.md)
+- [JS-libp2p Implementation](../../js/v2.x/)
+- [Redis Coordination](./REDIS_COORDINATION.md) 

--- a/transport-interop/impl/python/v0.2/doc/MANUAL_TESTING.md
+++ b/transport-interop/impl/python/v0.2/doc/MANUAL_TESTING.md
@@ -1,0 +1,432 @@
+# Manual Testing Guide for py-libp2p Ping Implementation
+
+This guide covers how to manually test the py-libp2p ping implementation for transport-interop tests.
+
+## Prerequisites
+
+- Docker installed and running
+- Network access to pull Docker images
+- Terminal with multiple tabs/windows
+
+## Quick Start Test
+
+### 1. Start Redis Server
+```bash
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+```
+
+### 2. Test Listener (Terminal 1)
+```bash
+docker run --rm --network host \
+  -e transport=tcp \
+  -e muxer=mplex \
+  -e security=noise \
+  -e is_dialer=false \
+  -e ip="0.0.0.0" \
+  -e redis_addr=localhost:6379 \
+  -e test_timeout_seconds=15 \
+  python-v0.2.9-git python ping_test.py
+```
+
+**Expected Output:**
+```
+Connected to Redis at localhost:6379
+Running as listener
+Publishing address to Redis: /ip4/0.0.0.0/tcp/XXXXX/p2p/QmXXXXX...
+Waiting for 15 seconds...
+received ping from QmXXXXX...
+responded with pong to QmXXXXX...
+```
+
+### 3. Test Dialer (Terminal 2)
+```bash
+docker run --rm --network host \
+  -e transport=tcp \
+  -e muxer=mplex \
+  -e security=noise \
+  -e is_dialer=true \
+  -e redis_addr=localhost:6379 \
+  -e test_timeout_seconds=10 \
+  python-v0.2.9-git python ping_test.py
+```
+
+**Expected Output:**
+```
+Connected to Redis at localhost:6379
+Running as dialer
+Waiting for listener address from Redis...
+Got listener address: /ip4/0.0.0.0/tcp/XXXXX/p2p/QmXXXXX...
+Connecting to /ip4/0.0.0.0/tcp/XXXXX/p2p/QmXXXXX...
+Creating ping stream
+sending ping to QmXXXXX...
+received pong from QmXXXXX...
+{"handshakePlusOneRTTMillis": 43.84, "pingRTTMilllis": 0.26}
+```
+
+### 4. Cleanup
+```bash
+docker stop redis-test && docker rm redis-test
+```
+
+## Detailed Testing Scenarios
+
+### Basic Functionality Tests
+
+#### Test 1: Basic Ping/Pong Exchange
+**Purpose:** Verify basic connectivity and ping protocol
+```bash
+# Terminal 1 - Listener
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=false -e ip="0.0.0.0" \
+  -e redis_addr=localhost:6379 -e test_timeout_seconds=20 \
+  python-v0.2.9-git python ping_test.py
+
+# Terminal 2 - Dialer (run after listener starts)
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  -e test_timeout_seconds=10 \
+  python-v0.2.9-git python ping_test.py
+```
+
+#### Test 2: Multiple Ping Tests
+**Purpose:** Verify consistent performance
+```bash
+# Run 5 consecutive tests
+for i in {1..5}; do
+  echo "=== Test $i ==="
+  
+  # Start listener in background
+  docker run --rm --network host \
+    -e transport=tcp -e muxer=mplex -e security=noise \
+    -e is_dialer=false -e ip="0.0.0.0" \
+    -e redis_addr=localhost:6379 -e test_timeout_seconds=10 \
+    python-v0.2.9-git python ping_test.py &
+  
+  sleep 2
+  
+  # Run dialer
+  docker run --rm --network host \
+    -e transport=tcp -e muxer=mplex -e security=noise \
+    -e is_dialer=true -e redis_addr=localhost:6379 \
+    -e test_timeout_seconds=5 \
+    python-v0.2.9-git python ping_test.py
+  
+  sleep 1
+done
+```
+
+### Configuration Tests
+
+#### Test 3: Different IP Addresses
+**Purpose:** Test with various IP configurations
+```bash
+# Test with localhost
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=false -e ip="127.0.0.1" \
+  -e redis_addr=localhost:6379 -e test_timeout_seconds=15 \
+  python-v0.2.9-git python ping_test.py
+
+# Test with specific interface
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=false -e ip="0.0.0.0" \
+  -e redis_addr=localhost:6379 -e test_timeout_seconds=15 \
+  python-v0.2.9-git python ping_test.py
+```
+
+#### Test 4: Different Timeout Values
+**Purpose:** Test timeout handling
+```bash
+# Short timeout
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  -e test_timeout_seconds=2 \
+  python-v0.2.9-git python ping_test.py
+
+# Long timeout
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  -e test_timeout_seconds=30 \
+  python-v0.2.9-git python ping_test.py
+```
+
+### Error Handling Tests
+
+#### Test 5: Redis Connection Failure
+**Purpose:** Test behavior when Redis is unavailable
+```bash
+# Test without Redis running
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  -e test_timeout_seconds=5 \
+  python-v0.2.9-git python ping_test.py
+```
+
+#### Test 6: Invalid Configuration
+**Purpose:** Test error handling for unsupported configurations
+```bash
+# Test unsupported transport
+docker run --rm --network host \
+  -e transport=quic -e muxer=mplex -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  python-v0.2.9-git python ping_test.py
+
+# Test unsupported security
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=tls \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  python-v0.2.9-git python ping_test.py
+
+# Test unsupported muxer
+docker run --rm --network host \
+  -e transport=tcp -e muxer=yamux -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  python-v0.2.9-git python ping_test.py
+```
+
+#### Test 7: Missing Environment Variables
+**Purpose:** Test behavior with missing configuration
+```bash
+# Test with no environment variables
+docker run --rm python-v0.2.9-git python ping_test.py
+
+# Test with partial environment variables
+docker run --rm --network host \
+  -e transport=tcp -e redis_addr=localhost:6379 \
+  python-v0.2.9-git python ping_test.py
+```
+
+### Performance Tests
+
+#### Test 8: Performance Benchmarking
+**Purpose:** Measure consistent performance
+```bash
+# Run performance test
+echo "Performance Test Results:" > performance_results.txt
+for i in {1..10}; do
+  echo "Test $i:" >> performance_results.txt
+  
+  # Start listener
+  docker run --rm --network host \
+    -e transport=tcp -e muxer=mplex -e security=noise \
+    -e is_dialer=false -e ip="0.0.0.0" \
+    -e redis_addr=localhost:6379 -e test_timeout_seconds=10 \
+    python-v0.2.9-git python ping_test.py &
+  
+  sleep 1
+  
+  # Run dialer and capture output
+  result=$(docker run --rm --network host \
+    -e transport=tcp -e muxer=mplex -e security=noise \
+    -e is_dialer=true -e redis_addr=localhost:6379 \
+    -e test_timeout_seconds=5 \
+    python-v0.2.9-git python ping_test.py 2>/dev/null | tail -1)
+  
+  echo "  $result" >> performance_results.txt
+  sleep 1
+done
+
+cat performance_results.txt
+```
+
+### Docker Image Tests
+
+#### Test 9: Docker Image Verification
+**Purpose:** Verify Docker image is built correctly
+```bash
+# Test py-libp2p installation
+docker run --rm python-v0.2.9-git python -c "
+import libp2p
+print('py-libp2p version:', libp2p.__version__)
+print('Installation successful!')
+"
+
+# Test required dependencies
+docker run --rm python-v0.2.9-git python -c "
+import trio
+import redis
+import multiaddr
+print('All dependencies available!')
+"
+
+# Test ping test module
+docker run --rm python-v0.2.9-git python -c "
+import ping_test
+print('Ping test module imported successfully!')
+"
+```
+
+#### Test 10: Container Resource Usage
+**Purpose:** Monitor resource consumption
+```bash
+# Monitor memory and CPU usage
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=false -e ip="0.0.0.0" \
+  -e redis_addr=localhost:6379 -e test_timeout_seconds=30 \
+  python-v0.2.9-git python ping_test.py &
+  
+# In another terminal, monitor the container
+docker stats $(docker ps -q --filter ancestor=python-v0.2.9-git)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### Issue 1: Redis Connection Failed
+**Symptoms:** `Error: Error -2 connecting to redis:6379`
+**Solution:** Ensure Redis is running and accessible
+```bash
+# Check if Redis is running
+docker ps | grep redis
+
+# Restart Redis if needed
+docker stop redis-test && docker rm redis-test
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+```
+
+#### Issue 2: Port Already in Use
+**Symptoms:** `Address already in use` errors
+**Solution:** Wait for previous test to complete or kill processes
+```bash
+# Kill any running containers
+docker kill $(docker ps -q)
+
+# Or wait for timeout
+sleep 20
+```
+
+#### Issue 3: Docker Image Not Found
+**Symptoms:** `Unable to find image 'python-v0.2.9-git'`
+**Solution:** Rebuild the Docker image
+```bash
+cd transport-interop/impl/python/v0.2
+make clean && make
+```
+
+#### Issue 4: Permission Denied
+**Symptoms:** Docker permission errors
+**Solution:** Run with sudo or add user to docker group
+```bash
+# Option 1: Use sudo
+sudo docker run --rm python-v0.2.9-git python ping_test.py
+
+# Option 2: Add user to docker group (requires logout/login)
+sudo usermod -aG docker $USER
+```
+
+### Debug Mode
+
+The implementation integrates with py-libp2p's built-in logging system. Enable debug logging using the `LIBP2P_DEBUG` environment variable:
+
+#### Basic Debug Logging
+```bash
+# Enable all debug output
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  -e LIBP2P_DEBUG=DEBUG \
+  python-v0.2.9-git python ping_test.py
+```
+
+#### Module-Specific Debug Logging
+```bash
+# Enable debug only for ping_test module
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  -e LIBP2P_DEBUG=ping_test:DEBUG \
+  python-v0.2.9-git python ping_test.py
+```
+
+#### Debug with Custom Log File
+```bash
+# Log debug output to specific file
+docker run --rm --network host \
+  -e transport=tcp -e muxer=mplex -e security=noise \
+  -e is_dialer=true -e redis_addr=localhost:6379 \
+  -e LIBP2P_DEBUG=DEBUG \
+  -e LIBP2P_DEBUG_FILE=/tmp/custom_debug.log \
+  python-v0.2.9-git python ping_test.py
+```
+
+#### Debug Logging Examples
+
+**No Debug (Default):**
+```bash
+docker run --rm python-v0.2.9-git python ping_test.py
+# Output: Only regular print statements, no debug logs
+```
+
+**Full Debug Mode:**
+```bash
+docker run --rm -e LIBP2P_DEBUG=DEBUG python-v0.2.9-git python ping_test.py
+# Output: 
+# Logging to: /tmp/py-libp2p_20250725_233931_373335_a208d3d4.log
+# 2025-07-25 23:39:31,374 - libp2p.ping_test - DEBUG - ENV is_dialer=None
+# 2025-07-25 23:39:31,374 - libp2p.ping_test - DEBUG - All environment variables: ...
+```
+
+**Module-Specific Debug:**
+```bash
+docker run --rm -e LIBP2P_DEBUG=ping_test:DEBUG python-v0.2.9-git python ping_test.py
+# Output: Only ping_test module debug logs with timestamps
+```
+
+#### Debug Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `LIBP2P_DEBUG` | Controls debug logging level | `DEBUG`, `ping_test:DEBUG` |
+| `LIBP2P_DEBUG_FILE` | Custom log file path | `/tmp/custom.log` |
+
+#### Debug Log Features
+
+- **Automatic Integration**: No manual logging setup required
+- **Thread-Safe**: Uses py-libp2p's queue-based logging system
+- **Automatic File Logging**: Creates timestamped log files in `/tmp/`
+- **Hierarchical Control**: Enable debug for specific modules
+- **Zero Overhead**: No debug output when `LIBP2P_DEBUG` is not set
+- **Proper Formatting**: Timestamps, module names, log levels
+
+## Success Criteria
+
+A successful test should demonstrate:
+
+1. ✅ **Connection Establishment**: Dialer successfully connects to listener
+2. ✅ **Protocol Handshake**: Noise security handshake completes
+3. ✅ **Ping/Pong Exchange**: Ping messages sent and received correctly
+4. ✅ **Timing Measurements**: Reasonable RTT values (typically < 100ms for localhost)
+5. ✅ **Error Handling**: Graceful handling of connection failures
+6. ✅ **Redis Coordination**: Address exchange via Redis works
+7. ✅ **Docker Integration**: Container runs without issues
+8. ✅ **Resource Usage**: Reasonable memory and CPU consumption
+
+## Expected Performance Metrics
+
+For localhost testing, expect:
+- **handshakePlusOneRTTMillis**: 20-100ms
+- **pingRTTMilllis**: 0.1-5ms
+- **Memory Usage**: < 100MB
+- **CPU Usage**: < 10% during active testing
+
+## Cleanup
+
+After testing, always clean up resources:
+```bash
+# Stop and remove Redis container
+docker stop redis-test && docker rm redis-test
+
+# Kill any remaining containers
+docker kill $(docker ps -q --filter ancestor=python-v0.2.9-git)
+
+# Remove test images (optional)
+docker rmi python-v0.2.9-git
+``` 

--- a/transport-interop/impl/python/v0.2/doc/REDIS_COORDINATION.md
+++ b/transport-interop/impl/python/v0.2/doc/REDIS_COORDINATION.md
@@ -1,0 +1,470 @@
+# Redis Coordination in Transport-Interop Ping Tests
+
+This document explains the role of Redis as a coordination mechanism in the transport-interop ping tests and how it enables communication between dialer and listener components.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Test Architecture](#test-architecture)
+- [Redis Role](#redis-role)
+- [Step-by-Step Process](#step-by-step-process)
+- [Redis Commands Used](#redis-commands-used)
+- [Why Redis is Needed](#why-redis-is-needed)
+- [Data Structure](#data-structure)
+- [Configuration](#configuration)
+- [Alternative Approaches](#alternative-approaches)
+- [Real-World Example](#real-world-example)
+- [Monitoring and Debugging](#monitoring-and-debugging)
+- [Troubleshooting](#troubleshooting)
+- [Best Practices](#best-practices)
+
+## Overview
+
+Redis serves as a **coordination mechanism** between the dialer and listener components in transport-interop ping tests. It acts as a **message broker** that allows the two components to discover each other and exchange connection information in a distributed testing environment.
+
+## Test Architecture
+
+```
+┌─────────────┐    Redis    ┌─────────────┐
+│   Dialer    │◄──────────► │  Listener   │
+│ (Client)    │             │  (Server)   │
+└─────────────┘             └─────────────┘
+```
+
+### Component Roles
+
+- **Listener**: Creates a libp2p host, starts listening, and publishes its address to Redis
+- **Dialer**: Retrieves the listener's address from Redis and establishes a connection
+- **Redis**: Acts as a central coordination point for address exchange
+
+## Redis Role
+
+### Primary Functions
+
+1. **Service Discovery**: Enables the dialer to find the listener's address
+2. **Message Broker**: Provides reliable messaging for address exchange
+3. **Coordination Point**: Centralized location for test components to communicate
+4. **Timeout Handling**: Supports graceful failure when components are unavailable
+
+### Key Benefits
+
+- ✅ **Asynchronous Discovery**: Listener can publish its address before dialer starts
+- ✅ **Reliable Messaging**: Redis ensures the address is delivered
+- ✅ **Timeout Handling**: Dialer can fail gracefully if no listener is available
+- ✅ **Multiple Listeners**: Can support multiple listeners (though typically one per test)
+- ✅ **Distributed Testing**: Enables testing across different machines/containers
+
+## Step-by-Step Process
+
+### Step 1: Listener Starts
+
+```python
+# Listener publishes its address to Redis
+addr_str = str(addrs[0])  # e.g., "/ip4/0.0.0.0/tcp/34827/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF"
+print(f"Publishing address to Redis: {addr_str}", file=sys.stderr)
+self.redis_client.rpush("listenerAddr", addr_str)
+```
+
+**What happens:**
+1. Listener creates a libp2p host and starts listening
+2. Gets its own multiaddr (IP + port + peer ID)
+3. Publishes this address to Redis using `RPUSH` on the `listenerAddr` key
+4. Waits for incoming connections
+
+### Step 2: Dialer Starts
+
+```python
+# Dialer retrieves listener address from Redis
+print("Waiting for listener address from Redis...", file=sys.stderr)
+result = self.redis_client.blpop("listenerAddr", timeout=self.test_timeout_seconds)
+if not result:
+    raise RuntimeError("Timeout waiting for listener address")
+
+listener_addr = result[1]  # Gets the multiaddr from Redis
+print(f"Got listener address: {listener_addr}", file=sys.stderr)
+```
+
+**What happens:**
+1. Dialer starts and connects to Redis
+2. Uses `BLPOP` to wait for a listener address (blocking operation)
+3. Once it gets the address, it can connect to the listener
+
+### Step 3: Connection Establishment
+
+```python
+# Dialer connects to the listener using the retrieved address
+maddr = multiaddr.Multiaddr(listener_addr)
+info = info_from_p2p_addr(maddr)
+await self.host.connect(info)
+```
+
+## Redis Commands Used
+
+### Listener Side
+
+```python
+# Publish address to Redis
+self.redis_client.rpush("listenerAddr", addr_str)
+```
+
+- **`RPUSH`**: Adds the listener's multiaddr to the right end of the `listenerAddr` list
+- This makes the address available for the dialer to consume
+
+### Dialer Side
+
+```python
+# Retrieve address from Redis
+result = self.redis_client.blpop("listenerAddr", timeout=self.test_timeout_seconds)
+```
+
+- **`BLPOP`**: Blocking left pop - waits for an item to become available in the `listenerAddr` list
+- **`timeout`**: Prevents infinite waiting if no listener is available
+- Returns `(key, value)` tuple or `None` if timeout
+
+## Why Redis is Needed
+
+### The Problem
+
+In a distributed test environment, the dialer and listener are typically:
+- **Separate processes/containers**
+- **Running on different machines**
+- **Started independently**
+- **Need to discover each other**
+
+### The Solution
+
+Redis provides a **centralized coordination point** that allows:
+- **Asynchronous discovery**: Listener can publish its address before dialer starts
+- **Reliable messaging**: Redis ensures the address is delivered
+- **Timeout handling**: Dialer can fail gracefully if no listener is available
+- **Multiple listeners**: Can support multiple listeners (though typically one per test)
+
+## Data Structure
+
+```
+Redis Database:
+┌─────────────────┐
+│ listenerAddr    │ ← List containing listener addresses
+│ ├─ "/ip4/0.0.0.0/tcp/34827/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF"
+│ └─ "/ip4/0.0.0.0/tcp/38635/p2p/16Uiu2HAm4dpssgmwrXdXjpgyxNnKoXAfhYD8GnNmaJ315E19N43w"
+└─────────────────┘
+```
+
+### Multiaddr Format
+
+The addresses stored in Redis follow the libp2p multiaddr format:
+```
+/ip4/0.0.0.0/tcp/34827/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+│   │        │   │    │   │
+│   │        │   │    │   └─ Peer ID (libp2p identifier)
+│   │        │   │    └─ Protocol (/p2p)
+│   │        │   └─ Port number
+│   │        └─ Protocol (/tcp)
+│   └─ IP address
+└─ Protocol (/ip4)
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+-e redis_addr=localhost:6379  # Redis server address
+-e test_timeout_seconds=10    # Timeout for waiting for listener
+```
+
+### Redis Connection Setup
+
+```python
+def setup_redis(self) -> None:
+    """Set up Redis connection."""
+    self.redis_client = redis.Redis(
+        host=self.redis_host,      # e.g., "localhost"
+        port=self.redis_port,      # e.g., 6379
+        decode_responses=True      # Return strings instead of bytes
+    )
+    self.redis_client.ping()       # Test connection
+```
+
+### Redis Server Setup
+
+```bash
+# Start Redis server
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+
+# Or using docker-compose
+version: '3.8'
+services:
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+```
+
+## Alternative Approaches
+
+### Other Coordination Methods
+
+1. **Static Configuration**: Hardcode listener address (not flexible)
+2. **DNS**: Use DNS for service discovery (requires infrastructure)
+3. **Service Mesh**: Use Kubernetes services (complex setup)
+4. **Direct Connection**: Dialer connects to known listener (not realistic for testing)
+5. **Message Queues**: Use RabbitMQ, Apache Kafka (overkill for simple coordination)
+6. **Database**: Use PostgreSQL, MySQL (slower, more complex)
+
+### Why Redis is Ideal
+
+- ✅ **Simple**: Easy to set up and use
+- ✅ **Fast**: In-memory, low latency
+- ✅ **Reliable**: Persistence and replication options
+- ✅ **Flexible**: Supports various data structures
+- ✅ **Lightweight**: Minimal resource usage
+- ✅ **Standard**: Widely used in testing scenarios
+- ✅ **Atomic Operations**: Built-in support for atomic list operations
+
+## Real-World Example
+
+### Complete Test Flow
+
+```bash
+# Terminal 1: Start Redis
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+
+# Terminal 2: Start Listener
+docker run --rm --network host \
+  -e transport=tcp -e muxer=yamux -e security=noise \
+  -e is_dialer=false -e ip="0.0.0.0" \
+  -e redis_addr=localhost:6379 \
+  python-v0.2.9 python ping_test.py
+
+# Output:
+# Connected to Redis at localhost:6379
+# Running as listener
+# Publishing address to Redis: /ip4/0.0.0.0/tcp/34827/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+# Waiting for 15 seconds...
+
+# Terminal 3: Start Dialer
+docker run --rm --network host \
+  -e transport=tcp -e muxer=yamux -e security=noise \
+  -e is_dialer=true \
+  -e redis_addr=localhost:6379 \
+  python-v0.2.9 python ping_test.py
+
+# Output:
+# Connected to Redis at localhost:6379
+# Running as dialer
+# Waiting for listener address from Redis...
+# Got listener address: /ip4/0.0.0.0/tcp/34827/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+# Connecting to /ip4/0.0.0.0/tcp/34827/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+# Creating ping stream
+# sending ping to 16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+# received pong from 16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF
+# {"handshakePlusOneRTTMillis": 10.88, "pingRTTMilllis": 0.26}
+```
+
+### Redis Data Flow
+
+```
+Time 0: Redis starts (empty)
+Time 1: Listener starts → RPUSH listenerAddr "/ip4/0.0.0.0/tcp/34827/p2p/16Uiu2HAkvpyXQ1BuqHbLKASmVe5tLZrQKxgKL75crGV2fVNNBcRF"
+Time 2: Dialer starts → BLPOP listenerAddr → Gets address
+Time 3: Dialer connects to listener using retrieved address
+Time 4: Ping/pong exchange occurs
+```
+
+## Monitoring and Debugging
+
+### Redis CLI Commands
+
+```bash
+# Connect to Redis CLI
+docker exec -it redis-test redis-cli
+
+# Monitor Redis commands in real-time
+MONITOR
+
+# Check what's in the listenerAddr list
+LRANGE listenerAddr 0 -1
+
+# Check list length
+LLEN listenerAddr
+
+# Clear the list (for testing)
+DEL listenerAddr
+
+# Check Redis info
+INFO
+
+# Check memory usage
+INFO memory
+```
+
+### Debugging Commands
+
+```bash
+# Check if Redis is running
+docker ps | grep redis
+
+# Check Redis logs
+docker logs redis-test
+
+# Test Redis connection
+docker exec redis-test redis-cli ping
+
+# Monitor Redis activity during test
+docker exec redis-test redis-cli monitor
+```
+
+### Common Redis Operations
+
+```bash
+# List all keys
+KEYS *
+
+# Get value of a key
+GET keyname
+
+# Set a key value
+SET keyname value
+
+# Delete a key
+DEL keyname
+
+# Check if key exists
+EXISTS keyname
+
+# Set key expiration (seconds)
+EXPIRE keyname 60
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### Issue 1: Redis Connection Failed
+**Symptoms:**
+```
+Error: Error -2 connecting to redis:6379. Name or service not known.
+```
+
+**Solutions:**
+```bash
+# Check if Redis is running
+docker ps | grep redis
+
+# Start Redis if not running
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+
+# Check Redis logs
+docker logs redis-test
+```
+
+#### Issue 2: Timeout Waiting for Listener
+**Symptoms:**
+```
+Error: Timeout waiting for listener address
+```
+
+**Solutions:**
+```bash
+# Check if listener is running
+docker ps | grep python-v0.2.9
+
+# Check Redis for listener address
+docker exec redis-test redis-cli LRANGE listenerAddr 0 -1
+
+# Increase timeout
+-e test_timeout_seconds=30
+```
+
+#### Issue 3: Redis Permission Denied
+**Symptoms:**
+```
+Error: Permission denied
+```
+
+**Solutions:**
+```bash
+# Check Redis configuration
+docker exec redis-test redis-cli CONFIG GET bind
+
+# Restart Redis with proper permissions
+docker stop redis-test && docker rm redis-test
+docker run -d --name redis-test -p 6379:6379 redis:alpine
+```
+
+### Performance Issues
+
+#### High Latency
+```bash
+# Check Redis performance
+docker exec redis-test redis-cli INFO stats
+
+# Monitor Redis memory usage
+docker exec redis-test redis-cli INFO memory
+
+# Check Redis connections
+docker exec redis-test redis-cli INFO clients
+```
+
+#### Memory Issues
+```bash
+# Check Redis memory usage
+docker exec redis-test redis-cli INFO memory
+
+# Clear old data
+docker exec redis-test redis-cli FLUSHDB
+
+# Restart Redis
+docker restart redis-test
+```
+
+## Best Practices
+
+### Redis Configuration
+
+1. **Use Appropriate Timeouts**: Set reasonable timeouts for BLPOP operations
+2. **Monitor Memory Usage**: Redis is in-memory, so monitor usage
+3. **Use Connection Pooling**: For high-throughput scenarios
+4. **Enable Persistence**: If data loss is critical
+5. **Set Memory Limits**: Prevent Redis from consuming too much memory
+
+### Test Configuration
+
+1. **Use Unique Keys**: Avoid conflicts between different test runs
+2. **Clean Up After Tests**: Remove test data from Redis
+3. **Handle Timeouts Gracefully**: Implement proper error handling
+4. **Log Redis Operations**: For debugging purposes
+5. **Use Health Checks**: Verify Redis is available before starting tests
+
+### Security Considerations
+
+1. **Network Security**: Restrict Redis access to test network
+2. **Authentication**: Use Redis AUTH if needed
+3. **Encryption**: Use Redis with TLS for sensitive environments
+4. **Access Control**: Limit Redis access to test containers only
+
+### Production Considerations
+
+1. **High Availability**: Use Redis Cluster or Sentinel
+2. **Backup Strategy**: Implement Redis backup procedures
+3. **Monitoring**: Use Redis monitoring tools
+4. **Scaling**: Plan for Redis scaling as test load increases
+
+## Summary
+
+Redis acts as a **service discovery mechanism** that:
+1. **Enables coordination** between independent dialer and listener processes
+2. **Provides reliable messaging** for address exchange
+3. **Supports timeout handling** for robust test execution
+4. **Allows flexible deployment** in various environments
+5. **Enables the transport-interop framework** to orchestrate tests across different libp2p implementations
+
+Without Redis, the dialer wouldn't know where to find the listener, making the ping test impossible to execute in a distributed environment. Redis provides the essential coordination layer that makes distributed testing possible and reliable.
+
+## References
+
+- [Redis Documentation](https://redis.io/documentation)
+- [Redis Commands](https://redis.io/commands)
+- [libp2p Multiaddr Specification](https://github.com/multiformats/multiaddr)
+- [Transport-Interop Framework](https://github.com/libp2p/test-plans) 

--- a/transport-interop/impl/python/v0.2/doc/TRANSPORT-INTEROP-SETUP.md
+++ b/transport-interop/impl/python/v0.2/doc/TRANSPORT-INTEROP-SETUP.md
@@ -1,0 +1,106 @@
+# Transport Interop Setup Guide
+
+This document explains how to build all Docker images, run the interoperability tests, and troubleshoot common issues in the `transport-interop` project.
+
+---
+
+## 1. Building All Docker Images
+
+To build all Docker images for every implementation (Go, JS, Rust, Rust-Chromium, Nim, Zig, Java):
+
+### **Sequential Build (default)**
+```bash
+make all
+```
+
+### **Parallel Build (recommended for multi-core systems)**
+```bash
+make all-parallel -j$(nproc)
+# or
+make parallel -j$(nproc)
+```
+- `$(nproc)` uses all available CPU cores for maximum speed.
+- This will build all images in all subdirectories, including browser and chromium variants.
+
+### **Clean Build Artifacts**
+```bash
+make clean
+```
+- Removes all Docker images created by the transport-interop builds
+- Cleans up build artifacts (`image.json`, `force-rebuild` files)
+- Removes any stopped containers
+- Useful for freeing up disk space or starting fresh
+
+---
+
+## 2. Installing Test Dependencies
+
+Before running the interoperability tests, you need to install the Node.js dependencies:
+
+### **Install Dependencies**
+```bash
+npm install
+```
+
+### **Verify Installation**
+```bash
+# Check if the test framework is working
+npm test -- --help
+```
+
+This will install all required packages including:
+- TypeScript compilation tools
+- Docker Compose utilities
+- Test framework dependencies
+- YAML and JSON processing libraries
+
+---
+
+## 3. Running the Interop Tests
+
+### **To run the full test suite:**
+```bash
+npm test
+```
+
+### **To see what tests would run (without executing them):**
+```bash
+npm run test -- --emit-only
+```
+- The double dash (`--`) is important: it passes `--emit-only` to the test script, not to npm itself.
+
+---
+
+## 4. Troubleshooting: Missing Images
+
+If you see errors about missing Docker images or `image.json` files:
+
+- Make sure you have run the build step for all implementations:
+  ```bash
+  make all-parallel -j$(nproc)
+  # or
+  make all
+  ```
+- To verify all images are present:
+  ```bash
+  find impl -name "image.json"
+  ```
+- If any are missing, go to the relevant subdirectory and run `make` manually.
+- If you need to start fresh, use `make clean` to remove all images and rebuild:
+  ```bash
+  make clean
+  make all-parallel -j$(nproc)
+  ```
+
+---
+
+## 5. Notes
+
+- The Makefile supports both sequential and parallel builds.
+- All implementations, including `rust-chromium`, are now included in the build.
+- Use `make clean` to remove all Docker images and build artifacts.
+- For more granular cleanup, you can still use Docker's own commands (e.g., `docker image prune`).
+
+---
+
+For further help, see the Makefile or ask a maintainer. 

--- a/transport-interop/impl/python/v0.2/ping_test.py
+++ b/transport-interop/impl/python/v0.2/ping_test.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+Python libp2p ping test implementation for transport-interop tests.
+
+This implementation follows the transport-interop test specification:
+- Reads configuration from environment variables
+- Connects to Redis for coordination
+- Implements both dialer and listener roles
+- Measures ping RTT and handshake times
+- Outputs results in JSON format to stdout
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+from typing import Optional
+
+import redis
+import trio
+import multiaddr
+from libp2p import new_host, create_yamux_muxer_option, create_mplex_muxer_option
+from libp2p.custom_types import TProtocol
+from libp2p.network.stream.net_stream import INetStream
+from libp2p.peer.peerinfo import info_from_p2p_addr
+from libp2p.security.noise.transport import PROTOCOL_ID as NOISE_PROTOCOL_ID, Transport as NoiseTransport
+from libp2p.security.insecure.transport import PLAINTEXT_PROTOCOL_ID, InsecureTransport
+
+from libp2p.crypto.secp256k1 import create_new_key_pair
+from libp2p.crypto.x25519 import create_new_key_pair as create_new_x25519_key_pair
+
+PING_PROTOCOL_ID = TProtocol("/ipfs/ping/1.0.0")
+PING_LENGTH = 32
+RESP_TIMEOUT = 60
+
+# Get logger for this module - will automatically use py-libp2p's logging system
+# when LIBP2P_DEBUG is set, otherwise will be disabled
+logger = logging.getLogger("libp2p.ping_test")
+
+
+class PingTest:
+    def __init__(self):
+        # Read environment variables
+        self.transport = os.getenv("transport", "tcp")
+        self.muxer = os.getenv("muxer", "mplex")
+        self.security = os.getenv("security", "noise")
+        self.is_dialer = os.getenv("is_dialer", "false").lower() == "true"
+        self.ip = os.getenv("ip", "0.0.0.0")
+        self.redis_addr = os.getenv("redis_addr", "redis:6379")
+        self.test_timeout_seconds = int(os.getenv("test_timeout_seconds", "180"))
+        
+        # Parse Redis address
+        if ":" in self.redis_addr:
+            self.redis_host, self.redis_port = self.redis_addr.split(":")
+            self.redis_port = int(self.redis_port)
+        else:
+            self.redis_host = self.redis_addr
+            self.redis_port = 6379
+        
+        self.host = None
+        self.redis_client: Optional[redis.Redis] = None
+
+        logger.debug(f"ENV is_dialer={os.getenv('is_dialer')} (type: {type(os.getenv('is_dialer'))})")
+        logger.debug(f"All environment variables: {os.environ}")
+
+    def setup_redis(self) -> None:
+        """Set up Redis connection."""
+        self.redis_client = redis.Redis(
+            host=self.redis_host,
+            port=self.redis_port,
+            decode_responses=True
+        )
+        self.redis_client.ping()
+        print(f"Connected to Redis at {self.redis_host}:{self.redis_port}", file=sys.stderr)
+
+    def validate_configuration(self) -> None:
+        """Validate the configuration parameters."""
+        # Validate transport
+        if self.transport not in ["tcp"]:
+            raise ValueError(f"Unsupported transport: {self.transport}. Supported transports: ['tcp']")
+        
+        # Validate security
+        if self.security not in ["noise", "plaintext"]:
+            raise ValueError(f"Unsupported security: {self.security}. Supported security: ['noise', 'plaintext']")
+        
+        # Validate muxer
+        if self.muxer not in ["mplex", "yamux"]:
+            raise ValueError(f"Unsupported muxer: {self.muxer}. Supported muxers: ['mplex', 'yamux']")
+
+    def create_security_options(self):
+        """Create security options based on configuration."""
+        # Create key pair for libp2p identity
+        key_pair = create_new_key_pair()
+        
+        if self.security == "noise":
+            # Create X25519 key pair for Noise
+            noise_key_pair = create_new_x25519_key_pair()
+            noise_transport = NoiseTransport(
+                libp2p_keypair=key_pair,
+                noise_privkey=noise_key_pair.private_key,
+                early_data=None,
+                with_noise_pipes=False,
+            )
+            return {NOISE_PROTOCOL_ID: noise_transport}, key_pair
+        elif self.security == "plaintext":
+            insecure_transport = InsecureTransport(
+                local_key_pair=key_pair,
+                secure_bytes_provider=None,
+                peerstore=None,
+            )
+            return {PLAINTEXT_PROTOCOL_ID: insecure_transport}, key_pair
+
+        else:
+            raise ValueError(f"Unsupported security: {self.security}")
+
+    def create_muxer_options(self):
+        """Create muxer options based on configuration."""
+        if self.muxer == "yamux":
+            return create_yamux_muxer_option()
+        elif self.muxer == "mplex":
+            return create_mplex_muxer_option()
+        else:
+            raise ValueError(f"Unsupported muxer: {self.muxer}")
+
+    async def handle_ping(self, stream: INetStream) -> None:
+        """Handle incoming ping requests."""
+        while True:
+            try:
+                payload = await stream.read(PING_LENGTH)
+                # Get peer ID safely, suppressing warnings
+                import warnings
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    try:
+                        peer_id = stream.muxed_conn.peer_id
+                    except (AttributeError, Exception):
+                        peer_id = "unknown"
+                if payload is not None:
+                    print(f"received ping from {peer_id}", file=sys.stderr)
+                    await stream.write(payload)
+                    print(f"responded with pong to {peer_id}", file=sys.stderr)
+            except Exception:
+                await stream.reset()
+                break
+
+    async def send_ping(self, stream: INetStream) -> float:
+        """Send ping and measure RTT."""
+        try:
+            payload = b"\x01" * PING_LENGTH
+            # Get peer ID safely, suppressing warnings
+            import warnings
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                try:
+                    peer_id = stream.muxed_conn.peer_id
+                except (AttributeError, Exception):
+                    peer_id = "unknown"
+            print(f"sending ping to {peer_id}", file=sys.stderr)
+            
+            ping_start = time.time()
+            await stream.write(payload)
+            
+            with trio.fail_after(RESP_TIMEOUT):
+                response = await stream.read(PING_LENGTH)
+                ping_end = time.time()
+                
+                if response == payload:
+                    print(f"received pong from {peer_id}", file=sys.stderr)
+                    return (ping_end - ping_start) * 1000  # Convert to milliseconds
+                else:
+                    raise Exception("Invalid ping response")
+        except Exception as e:
+            print(f"error occurred: {e}", file=sys.stderr)
+            raise
+
+    async def run_listener(self) -> None:
+        """Run the listener role."""
+        logger.debug("Entering run_listener")
+        # Validate configuration
+        logger.debug("Validating configuration")
+        self.validate_configuration()
+        # Create listen address
+        logger.debug("Creating listen address")
+        listen_addr = multiaddr.Multiaddr(f"/ip4/{self.ip}/tcp/0")
+        # Create security and muxer options
+        logger.debug("Creating security and muxer options")
+        security_options, key_pair = self.create_security_options()
+        muxer_options = self.create_muxer_options()
+        # Create host with proper configuration
+        logger.debug("Creating host")
+        self.host = new_host(
+            key_pair=key_pair,
+            sec_opt=security_options,
+            muxer_opt=muxer_options,
+            listen_addrs=[listen_addr]
+        )
+        # Set up ping handler
+        logger.debug("Setting stream handler")
+        self.host.set_stream_handler(PING_PROTOCOL_ID, self.handle_ping)
+        # Start the host
+        logger.debug("Starting host")
+        async with self.host.run(listen_addrs=[listen_addr]):
+            # Get the actual listen addresses and publish to Redis
+            logger.debug("Getting listen addresses")
+            listen_addrs = self.host.get_addrs()
+            if not listen_addrs:
+                raise RuntimeError("No listen addresses available")
+            
+            # Replace 0.0.0.0 with the actual container IP
+            actual_addr = None
+            for addr in listen_addrs:
+                if "/ip4/0.0.0.0/" in str(addr):
+                    # Replace 0.0.0.0 with the container's actual IP
+                    actual_ip = self.get_container_ip()
+                    actual_addr = str(addr).replace("/ip4/0.0.0.0/", f"/ip4/{actual_ip}/")
+                    break
+            
+            if not actual_addr:
+                actual_addr = str(listen_addrs[0])
+            
+            logger.debug(f"Publishing address to Redis: {actual_addr}")
+            self.redis_client.rpush("listenerAddr", actual_addr)
+            # Wait for the test timeout - the listener must stay alive
+            print(f"Listener ready, waiting for dialer to connect for {self.test_timeout_seconds} seconds...", file=sys.stderr)
+            await trio.sleep(self.test_timeout_seconds)
+            # If we reach here, the dialer didn't complete within timeout
+            logger.debug("Listener timeout - dialer did not complete within timeout")
+            sys.exit(1)
+
+    async def run_dialer(self) -> None:
+        """Run the dialer role."""
+        print("Running as dialer", file=sys.stderr)
+        
+        try:
+            # Validate configuration
+            self.validate_configuration()
+            
+            # Connect to Redis with retry mechanism
+            print("Connecting to Redis...", file=sys.stderr)
+            max_retries = 10
+            retry_delay = 1.0
+            
+            for attempt in range(max_retries):
+                try:
+                    self.redis_client = redis.Redis(host=self.redis_host, port=self.redis_port, decode_responses=True)
+                    # Test the connection
+                    self.redis_client.ping()
+                    print(f"Successfully connected to Redis on attempt {attempt + 1}", file=sys.stderr)
+                    break
+                except Exception as e:
+                    print(f"Redis connection attempt {attempt + 1} failed: {e}", file=sys.stderr)
+                    if attempt < max_retries - 1:
+                        print(f"Retrying in {retry_delay} seconds...", file=sys.stderr)
+                        await trio.sleep(retry_delay)
+                    else:
+                        raise RuntimeError(f"Failed to connect to Redis after {max_retries} attempts")
+            
+            # Get the listener's address from Redis
+            print("Waiting for listener address from Redis...", file=sys.stderr)
+            result = self.redis_client.blpop("listenerAddr", timeout=self.test_timeout_seconds)
+            if not result:
+                raise RuntimeError("Timeout waiting for listener address")
+            
+            listener_addr = result[1]
+            print(f"Got listener address: {listener_addr}", file=sys.stderr)
+            
+            # Create security and muxer options
+            security_options, key_pair = self.create_security_options()
+            muxer_options = self.create_muxer_options()
+            
+            # Create host with proper configuration
+            self.host = new_host(
+                key_pair=key_pair,
+                sec_opt=security_options,
+                muxer_opt=muxer_options
+            )
+            
+            # Start the host
+            async with self.host.run(listen_addrs=[]):
+                # Record handshake start time
+                handshake_start = time.time()
+                
+                # Parse the multiaddr and connect
+                maddr = multiaddr.Multiaddr(listener_addr)
+                info = info_from_p2p_addr(maddr)
+                
+                print(f"Connecting to {listener_addr}", file=sys.stderr)
+                await self.host.connect(info)
+                print("Connected successfully", file=sys.stderr)
+                
+                # Create ping stream
+                print("Creating ping stream", file=sys.stderr)
+                stream = await self.host.new_stream(info.peer_id, [PING_PROTOCOL_ID])
+                print("Ping stream created successfully", file=sys.stderr)
+                
+                # Perform ping and measure RTT
+                print("Performing ping test", file=sys.stderr)
+                ping_rtt = await self.send_ping(stream)
+                print(f"Ping test completed, RTT: {ping_rtt}ms", file=sys.stderr)
+                
+                # Calculate handshake plus one RTT
+                handshake_plus_one_rtt = (time.time() - handshake_start) * 1000  # Convert to milliseconds
+                
+                # Output results in JSON format
+                result = {
+                    "handshakePlusOneRTTMillis": handshake_plus_one_rtt,
+                    "pingRTTMilllis": ping_rtt
+                }
+                print(f"Outputting results: {result}", file=sys.stderr)
+                print(json.dumps(result))
+                
+                # Close stream
+                await stream.close()
+                print("Stream closed successfully", file=sys.stderr)
+                
+        except Exception as e:
+            print(f"Dialer error: {e}", file=sys.stderr)
+            import traceback
+            traceback.print_exc(file=sys.stderr)
+            sys.exit(1)
+
+    async def run(self) -> None:
+        """Main run method."""
+        try:
+            # Set up Redis connection with retry mechanism
+            print("Setting up Redis connection...", file=sys.stderr)
+            max_retries = 10
+            retry_delay = 1.0
+            
+            for attempt in range(max_retries):
+                try:
+                    self.setup_redis()
+                    print(f"Successfully connected to Redis on attempt {attempt + 1}", file=sys.stderr)
+                    break
+                except Exception as e:
+                    print(f"Redis connection attempt {attempt + 1} failed: {e}", file=sys.stderr)
+                    if attempt < max_retries - 1:
+                        print(f"Retrying in {retry_delay} seconds...", file=sys.stderr)
+                        await trio.sleep(retry_delay)
+                    else:
+                        raise RuntimeError(f"Failed to connect to Redis after {max_retries} attempts")
+            
+            # Run the appropriate role
+            if self.is_dialer:
+                await self.run_dialer()
+            else:
+                await self.run_listener()
+                
+        except Exception as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+        finally:
+            # Cleanup
+            if self.redis_client:
+                self.redis_client.close()
+
+    def get_container_ip(self) -> str:
+        """Get the container's actual IP address."""
+        import socket
+        try:
+            # Get the container's hostname and resolve it to IP
+            hostname = socket.gethostname()
+            ip = socket.gethostbyname(hostname)
+            logger.debug(f"Container IP: {ip} (hostname: {hostname})")
+            return ip
+        except Exception as e:
+            logger.debug(f"Failed to get container IP: {e}")
+            # Fallback to a reasonable default
+            return "172.17.0.1"
+
+
+async def main():
+    """Main entry point."""
+    ping_test = PingTest()
+    await ping_test.run()
+
+
+if __name__ == "__main__":
+    trio.run(main) 

--- a/transport-interop/impl/python/v0.2/pyproject.toml
+++ b/transport-interop/impl/python/v0.2/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "py-libp2p-ping-test"
+version = "0.2.9"
+description = "Python libp2p ping test implementation for transport interoperability"
+authors = [
+    {name = "libp2p", email = "team@libp2p.io"}
+]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "libp2p @ git+https://github.com/libp2p/py-libp2p.git@9b667bd4724b4a984564dfb8622a34b882704a39",
+    "redis>=4.0.0",
+    "typing-extensions>=4.0.0",
+    "trio",
+    "multiaddr",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "black",
+    "flake8",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ping_test*"]
+
+[tool.black]
+line-length = 88
+target-version = ['py38']
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"] 

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -1,5 +1,19 @@
 [
   {
+    "id": "python-v0.2.9",
+    "transports": [
+      "tcp"
+    ],
+    "secureChannels": [
+      "noise",
+      "plaintext"
+    ],
+    "muxers": [
+      "mplex",
+      "yamux"
+    ]
+  },
+  {
     "id": "rust-v0.53",
     "transports": [
       "ws",


### PR DESCRIPTION
# Add Python libp2p Implementation to Transport Interop Tests

## Overview

This PR adds a complete Python libp2p implementation to the transport-interop test suite, enabling interoperability testing between Python and other libp2p implementations.

## Changes

### 1. Enhanced Makefile with Parallel Build Support
- **Added Python subdirectory support** (`PYTHON_SUBDIRS`) to the main Makefile
- **Implemented parallel build capabilities** with `make all-parallel` and `make parallel`
- **Added automatic processor detection** using `$(shell nproc)` for optimal parallel builds
- **Added comprehensive help system** with `make help` target
- **Added clean target** for removing Docker images and build artifacts

### 2. Python Implementation Integration
- **Added Python v0.2.9** to `versionsInput.json` with full protocol support:
  - Transport: TCP
  - Security: Noise, Plaintext
  - Muxers: Mplex, Yamux
- **Complete Python implementation** in `impl/python/v0.2/`:
  - `ping_test.py` - Main implementation following transport-interop spec
  - `pyproject.toml` - Modern Python packaging with git dependency
  - `PingDockerfile` - Docker configuration with all required dependencies
  - `Makefile` - Build system with cache and force-rebuild options
  - Comprehensive documentation in `doc/` directory

### 3. Advanced Features
- **py-libp2p logging integration** via `LIBP2P_DEBUG` environment variable
- **Git-based dependency management** using specific py-libp2p commit
- **Thread-safe logging** with automatic file logging and hierarchical control
- **Comprehensive error handling** with retry mechanisms and timeout management

## Test Results

### ✅ Successful Interoperability Tests (32 tests)
The Python implementation successfully interoperates with:

**Go implementations:**
- go-v0.40, go-v0.41, go-v0.42 (TCP + Noise + Yamux)

**JavaScript implementations:**
- js-v1.x, js-v2.x (TCP + Noise + Mplex/Yamux)

**Java implementations:**
- java-v0.0.1, java-v0.6, java-v0.9 (TCP + Noise + Mplex/Yamux)

**Nim implementation:**
- nim-v1.10.x (TCP + Noise + Mplex/Yamux)

**Self-interoperability:**
- python-v0.2.9 x python-v0.2.9 (TCP + Noise/Plaintext + Mplex/Yamux)

### ❌ Known Issues (8 tests)
**Rust interoperability failures:**
- rust-v0.53, rust-v0.54 (both directions, TCP + Noise + Mplex/Yamux)

*Note: Rust interoperability issues are being investigated and are likely related to protocol implementation differences rather than the Python implementation itself.*

## Build System Improvements

### Parallel Build Performance
```bash
# Sequential build (original)
make all

# Parallel build (new)
make all-parallel -j$(nproc)
make parallel -j$(nproc)
```

### Build Management
```bash
# Clean build artifacts
make clean

# Force rebuild without cache
make force-rebuild

# Show help
make help
```

## Documentation

- **Comprehensive README.md** with build instructions, debugging, and dependency information
- **Automated testing guide** with real command examples and troubleshooting
- **Manual testing guide** with step-by-step procedures
- **Transport interop setup guide** with Docker configuration and parallel build instructions

## Impact

This implementation significantly expands the transport-interop test coverage by adding Python as a first-class citizen in the libp2p ecosystem. The 32 successful interoperability tests demonstrate robust compatibility across multiple implementations, while the parallel build system improves development workflow efficiency.

The Python implementation follows all transport-interop specifications and integrates seamlessly with the existing test infrastructure, providing a solid foundation for future Python libp2p development and testing. 



## Logs
```bash
[luca@TR24 transport-interop]$ cat results.csv | grep python | grep success
"go-v0.40 x python-v0.2.9 (tcp, noise, yamux)",success
"go-v0.41 x python-v0.2.9 (tcp, noise, yamux)",success
"go-v0.42 x python-v0.2.9 (tcp, noise, yamux)",success
"js-v2.x x python-v0.2.9 (tcp, noise, mplex)",success
"js-v2.x x python-v0.2.9 (tcp, noise, yamux)",success
"js-v1.x x python-v0.2.9 (tcp, noise, yamux)",success
"js-v1.x x python-v0.2.9 (tcp, noise, mplex)",success
"java-v0.9 x python-v0.2.9 (tcp, noise, yamux)",success
"java-v0.9 x python-v0.2.9 (tcp, noise, mplex)",success
"java-v0.6 x python-v0.2.9 (tcp, noise, yamux)",success
"java-v0.6 x python-v0.2.9 (tcp, noise, mplex)",success
"java-v0.0.1 x python-v0.2.9 (tcp, noise, yamux)",success
"java-v0.0.1 x python-v0.2.9 (tcp, noise, mplex)",success
"nim-v1.10.x x python-v0.2.9 (tcp, noise, yamux)",success
"nim-v1.10.x x python-v0.2.9 (tcp, noise, mplex)",success
"python-v0.2.9 x python-v0.2.9 (tcp, plaintext, mplex)",success
"python-v0.2.9 x python-v0.2.9 (tcp, noise, mplex)",success
"python-v0.2.9 x nim-v1.10.x (tcp, noise, mplex)",success
"python-v0.2.9 x java-v0.6 (tcp, noise, yamux)",success
"python-v0.2.9 x java-v0.0.1 (tcp, noise, yamux)",success
"python-v0.2.9 x python-v0.2.9 (tcp, noise, yamux)",success
"python-v0.2.9 x python-v0.2.9 (tcp, plaintext, yamux)",success
"python-v0.2.9 x java-v0.6 (tcp, noise, mplex)",success
"python-v0.2.9 x nim-v1.10.x (tcp, noise, yamux)",success
"python-v0.2.9 x java-v0.0.1 (tcp, noise, mplex)",success
"python-v0.2.9 x java-v0.9 (tcp, noise, mplex)",success
"python-v0.2.9 x go-v0.40 (tcp, noise, yamux)",success
"python-v0.2.9 x js-v1.x (tcp, noise, mplex)",success
"python-v0.2.9 x go-v0.41 (tcp, noise, yamux)",success
"python-v0.2.9 x go-v0.42 (tcp, noise, yamux)",success
"python-v0.2.9 x js-v2.x (tcp, noise, yamux)",success
"python-v0.2.9 x java-v0.9 (tcp, noise, yamux)",success
"python-v0.2.9 x js-v2.x (tcp, noise, mplex)",success
"python-v0.2.9 x js-v1.x (tcp, noise, yamux)",success
[luca@TR24 transport-interop]$ cat results.csv | grep python | grep fail
"python-v0.2.9 x rust-v0.53 (tcp, noise, yamux)",failure
"python-v0.2.9 x rust-v0.54 (tcp, noise, yamux)",failure
"python-v0.2.9 x rust-v0.53 (tcp, noise, mplex)",failure
"python-v0.2.9 x rust-v0.54 (tcp, noise, mplex)",failure
"rust-v0.54 x python-v0.2.9 (tcp, noise, mplex)",failure
"rust-v0.54 x python-v0.2.9 (tcp, noise, yamux)",failure
"rust-v0.53 x python-v0.2.9 (tcp, noise, yamux)",failure
"rust-v0.53 x python-v0.2.9 (tcp, noise, mplex)",failure

```