### PR TITLE
Add jvm-libp2p to protocol interop suite

### DIFF
--- a/transport-interop/impl/jvm/.gitignore
+++ b/transport-interop/impl/jvm/.gitignore
@@ -1,0 +1,1 @@
+jvm-libp2p-*

--- a/transport-interop/impl/jvm/v1.2/Makefile
+++ b/transport-interop/impl/jvm/v1.2/Makefile
@@ -1,0 +1,15 @@
+image_name := jvm-libp2p-v1.2
+commitSha := bd921bafd9dedcf9ea5f7978da4bac39fddb3bd3
+
+all: image.json
+
+image.json:
+	wget -O jvm-libp2p-${commitSha}.zip "https://github.com/libp2p/jvm-libp2p/archive/${commitSha}.zip"
+	unzip -o jvm-libp2p-${commitSha}.zip
+	cd jvm-libp2p-${commitSha} && \
+	    docker build -t ${image_name} -f Dockerfile . 
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+clean:
+	rm -rf image.json jvm-libp2p-*.zip jvm-libp2p-*

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -308,5 +308,20 @@
     ],
     "secureChannels": ["tls", "noise"],
     "muxers": ["yamux"]
+  },
+  {
+    "id": "jvm-v1.2",
+    "transports": [
+      "tcp",
+      "quic-v1"
+    ],
+    "secureChannels": [
+      "tls",
+      "noise"
+    ],
+    "muxers": [
+      "mplex",
+      "yamux"
+    ]
   }
 ]


### PR DESCRIPTION
Adding the standard jvm-libp2p (https://github.com/libp2p/jvm-libp2p) to the test suite.

For now, I am only adding a subset of transport and muxers to validate that we are properly running the tests. Once we are happy with it, I'll add other options.

