### PR TITLE
Disable Zig in transport-interop

### DIFF
--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -192,14 +192,6 @@
     ]
   },
   {
-    "id": "zig-v0.0.1",
-    "transports": [
-      "quic-v1"
-    ],
-    "secureChannels": [],
-    "muxers": []
-  },
-  {
     "id": "java-v0.0.1",
     "transports": [
       "tcp"


### PR DESCRIPTION
It's causing an issue with jvm-libp2p. I need to debug it more, but don't want to block getting jvm-libp2p in the transport interop tester.