### PR TITLE
ci: remove usage of self-hosted runners

### DIFF
--- a/.github/workflows/hole-punch-interop.yml
+++ b/.github/workflows/hole-punch-interop.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   run-hole-punch-interop:
-    runs-on: ['self-hosted', 'linux', 'x64', '4xlarge'] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
+    runs-on: ubuntu-latest
 # Uncomment to test for flakiness.
 #    strategy:
 #      matrix:

--- a/.github/workflows/transport-interop.yml
+++ b/.github/workflows/transport-interop.yml
@@ -15,7 +15,7 @@ name: libp2p transport interop test
 
 jobs:
   run-transport-interop:
-    runs-on: ["self-hosted", "linux", "x64", "4xlarge"] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/run-transport-interop-test
@@ -26,7 +26,7 @@ jobs:
           worker-count: 16
           test-ignore: "jvm-v1.2 x zig-v0.0.1 (quic-v1)|zig-v0.0.1 x jvm-v1.2 (quic-v1)|rust-chromium-v0.53 x jvm-v1.2 (ws)|js-v1.x x jvm-v1.2 (ws, noise, yamux)|js-v1.x x jvm-v1.2 (ws, noise, mplex)|rust-chromium-v0.53 x jvm-v1.2 (ws, noise, mplex)"
   build-without-secrets:
-    runs-on: ["self-hosted", "linux", "x64", "4xlarge"] # https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       # Purposely not using secrets to replicate how forks will behave.


### PR DESCRIPTION
This PR removes usage of self-hosted runners from the test-interop job.

It is part of libp2p DX services offboarding initiative.

