### PR TITLE
set up for self-hosted runner with local cache

### DIFF
--- a/.github/actions/run-transport-interop-test-selfhosted/action.yml
+++ b/.github/actions/run-transport-interop-test-selfhosted/action.yml
@@ -1,0 +1,149 @@
+name: "libp2p transport interop test (self-hosted)"
+description: "Run the libp2p transport interoperability test suite on self-hosted runner with local disk cache"
+inputs:
+  test-filter:
+    description: "Filter which tests to run out of the created matrix"
+    required: false
+    default: ""
+  upload-results:
+    description: "Upload the test results as an artifact"
+    required: false
+    default: "true"
+  test-results-suffix:
+    description: "Suffix to add to the test results artifact name"
+    required: false
+    default: ""
+  test-ignore:
+    description: "Exclude tests from the created matrix that include this string in their name"
+    required: false
+    default: ""
+  extra-versions:
+    description: "Space-separated paths to JSON files describing additional images"
+    required: false
+    default: ""
+  worker-count:
+    description: "How many workers to use for the test"
+    required: false
+    default: "2"
+  timeout:
+    description: "How many seconds to let each test run for"
+    required: false
+  verbose:
+    description: "Enable verbose output"
+    required: false
+    default: false
+  cache-dir:
+    description: "Local directory to use for build cache"
+    required: false
+    default: "/srv/cache"
+runs:
+  using: "composite"
+  steps:
+    # This depends on where this file is within this repository. This walks up
+    # from here to the transport-interop folder
+    - run: |
+        WORK_DIR=$(realpath "$GITHUB_ACTION_PATH/../../../transport-interop")
+        echo "WORK_DIR=$WORK_DIR" >> $GITHUB_OUTPUT
+      shell: bash
+      id: find-workdir
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+
+    # Existence of /etc/buildkit/buildkitd.toml indicates that this is a
+    # self-hosted runner. If so, we need to pass the config to the buildx
+    # action. The config enables docker.io proxy which is required to
+    # work around docker hub rate limiting.
+    - run: |
+        if test -f /etc/buildkit/buildkitd.toml; then
+          echo "config=/etc/buildkit/buildkitd.toml" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+      id: buildkit
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        config: ${{ steps.buildkit.outputs.config }}
+
+    - name: Create cache directories
+      run: |
+        mkdir -p ${{ inputs.cache-dir }}/buildCache
+        mkdir -p ${{ inputs.cache-dir }}/imageCache
+      shell: bash
+
+    - name: Install deps
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      run: npm ci
+      shell: bash
+
+    - name: Load cache and build
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      env:
+        CACHE_DIR: ${{ inputs.cache-dir }}
+      run: npm run cache -- load
+      shell: bash
+
+    - name: Assert Git tree is clean.
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      shell: bash
+      run: |
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo "Git tree is dirty. This means that building an impl generated something that should probably be .gitignore'd"
+          git status
+          exit 1
+        fi
+
+    - name: Push the image cache
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      env:
+        CACHE_DIR: ${{ inputs.cache-dir }}
+      run: npm run cache -- push
+      shell: bash
+
+    - name: Run the test
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      env:
+        WORKER_COUNT: ${{ inputs.worker-count }}
+        EXTRA_VERSION: ${{ inputs.extra-versions }}
+        NAME_FILTER: ${{ inputs.test-filter }}
+        NAME_IGNORE: ${{ inputs.test-ignore }}
+        TIMEOUT: ${{ inputs.timeout }}
+        VERBOSE: ${{ inputs.verbose }}
+      run: npm run test -- --extra-version=$EXTRA_VERSION --name-filter="$NAME_FILTER" --name-ignore="$NAME_IGNORE" --verbose="$VERBOSE"
+      shell: bash
+
+    - name: Print the results
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      run: cat results.csv
+      shell: bash
+
+    - name: Render results
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      run: npm run renderResults > ./dashboard.md
+      shell: bash
+
+    - name: Show Dashboard Output
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      run: cat ./dashboard.md >> $GITHUB_STEP_SUMMARY
+      shell: bash
+
+    - name: Exit with Error
+      working-directory: ${{ steps.find-workdir.outputs.WORK_DIR }}
+      run: |
+        if grep -q ":red_circle:" ./dashboard.md; then
+          exit 1
+        else
+          exit 0
+        fi
+      shell: bash
+    - name: Upload test results
+      if: ${{ inputs.upload-results == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.test-results-suffix && format('test-plans-output-{0}', inputs.test-results-suffix) || 'test-plans-output' }}
+        path: |
+          ${{ steps.find-workdir.outputs.WORK_DIR }}/results.csv
+          ${{ steps.find-workdir.outputs.WORK_DIR }}/dashboard.md

--- a/transport-interop/dockerBuildWrapper.sh
+++ b/transport-interop/dockerBuildWrapper.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env /bin/bash
 
 CACHING_OPTIONS=""
-# If in CI and we have a defined cache bucket, use caching
-if [[ -n "${CI}" ]] && [[ -n "${AWS_BUCKET}" ]]; then
+# Use local cache if CACHE_DIR is set, otherwise fall back to S3 if AWS_BUCKET is set
+if [[ -n "${CACHE_DIR}" ]]; then
+    # Create the buildCache directory if it doesn't exist
+    mkdir -p "${CACHE_DIR}/buildCache/${IMAGE_NAME}"
+    CACHING_OPTIONS="\
+        --cache-to   type=local,mode=max,dest=${CACHE_DIR}/buildCache/${IMAGE_NAME} \
+        --cache-from type=local,src=${CACHE_DIR}/buildCache/${IMAGE_NAME}"
+elif [[ -n "${CI}" ]] && [[ -n "${AWS_BUCKET}" ]]; then
     CACHING_OPTIONS="\
         --cache-to   type=s3,mode=max,bucket=$AWS_BUCKET,region=$AWS_REGION,prefix=buildCache,name=$IMAGE_NAME \
         --cache-from type=s3,mode=max,bucket=$AWS_BUCKET,region=$AWS_REGION,prefix=buildCache,name=$IMAGE_NAME"


### PR DESCRIPTION
This makes minimal changes to the existing transport interop testing framework to support using a local cache when defined. This also defines a GH action to use a self-hosted runner to run the tests with a local cache.

Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>
