### PR TITLE
update readme execution

### DIFF
--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -177,7 +177,7 @@ runs:
         npm run renderResults > "${{ inputs.test-root }}/dashboard.md"
 
     - name: Update README.md with dashboard.md
-      if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+      if: ${{ !github.event.pull_request.head.repo.fork }}
       shell: bash
       run: |
         DASHBOARD="${{ inputs.test-root }}/dashboard.md"


### PR DESCRIPTION
Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>

The update readme step now executes on 'workflow_dispatch', 'schedule', 'push', and 'pull_request'.
