### PR TITLE
fix: remove token requirement

### DIFF
--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -1,9 +1,6 @@
 name: "libp2p transport interop test (self-hosted)"
 description: "Run the libp2p transport interoperability test suite on self-hosted runner with local disk cache"
 inputs:
-  gh-token:
-    description: "GitHub token to use for pushing README updates"
-    required: true
   test-filter:
     description: "Filter which tests to run out of the created matrix"
     required: false
@@ -179,44 +176,6 @@ runs:
       shell: bash
       run: |
         npm run renderResults > "${{ inputs.test-root }}/dashboard.md"
-
-    - name: Update README.md with dashboard.md
-      if: ${{ !github.event.pull_request.head.repo.fork  && inputs.update-readme == 'true' }}
-      shell: bash
-      run: |
-        DASHBOARD="${{ inputs.test-root }}/dashboard.md"
-        README="${{ inputs.test-root }}/README.md"
-
-        # Ensure both files exist
-        [ -f "$DASHBOARD" ] || { echo "Error: $DASHBOARD not found"; exit 1; }
-        [ -f "$README" ] || { echo "Error: $README not found"; exit 1; }
-
-        # Remove the first 4 lines
-        TMP_DASHBOARD=$(mktemp)
-        tail -n +5 "$DASHBOARD" > "$TMP_DASHBOARD"
-
-        # Escape forward slashes and newlines in dashboard content
-        ESCAPED_CONTENT=$(cat "$TMP_DASHBOARD" | sed 's/[\/&]/\\&/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-
-        # Replace content between markers
-        sed -i '/<!--INTEROP_DASHBOARD_START-->/,/<!--INTEROP_DASHBOARD_END-->/c\<!--INTEROP_DASHBOARD_START-->\n'"$ESCAPED_CONTENT"'\n<!--INTEROP_DASHBOARD_END-->' "$README"
-
-        # Set up git
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-
-        # Stage both files
-        git add "$DASHBOARD" "$README"
-
-        # Commit only if there are changes
-        git commit -m "chore: update dashboard and README [skip ci]" || echo "No changes to commit"
-
-        # Figure out which branch to push to
-        BRANCH="${{ github.head_ref || github.ref_name }}"
-
-        # Push
-        git remote set-url origin "https://x-access-token:${{ inputs.gh-token }}@github.com/${{ github.repository }}.git"
-        git push origin HEAD:"$BRANCH"
 
     - name: Show Dashboard Output
       shell: bash

--- a/.github/workflows/transport-interop-c.yml
+++ b/.github/workflows/transport-interop-c.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/c/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-dotnet.yml
+++ b/.github/workflows/transport-interop-dotnet.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/dotnet/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-eth-p2p.yml
+++ b/.github/workflows/transport-interop-eth-p2p.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/eth-p2p-z/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-full.yml
+++ b/.github/workflows/transport-interop-full.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -64,7 +63,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -97,4 +95,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-go.yml
+++ b/.github/workflows/transport-interop-go.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/go/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-js.yml
+++ b/.github/workflows/transport-interop-js.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/js/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-jvm.yml
+++ b/.github/workflows/transport-interop-jvm.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/jvm/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-nim.yml
+++ b/.github/workflows/transport-interop-nim.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/nim/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-py.yml
+++ b/.github/workflows/transport-interop-py.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/python/README.md with results?'
-        required: false
-        default: true
-        type: boolean
 
   pull_request:
     paths:
@@ -26,9 +21,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.pull_request.head.repo.full_name != '' && github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.ref != '' && github.event.pull_request.head.ref || github.ref_name }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
 
       # Build test-filter by scanning the transport-interop/impl/python/ subdirs
@@ -90,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/transport-interop-rust.yml
+++ b/.github/workflows/transport-interop-rust.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/rust/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}

--- a/.github/workflows/transport-interop-zig.yml
+++ b/.github/workflows/transport-interop-zig.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: ''
         type: string
-      update-readme:
-        description: 'Update impl/zig/README.md with results?'
-        required: false
-        default: 'true'
-        type: boolean
 
   pull_request:
     paths:
@@ -26,7 +21,6 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WRITE_README_AND_DASHBOARD }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -89,4 +83,3 @@ jobs:
           test-ignore: ${{ steps.test-ignore.outputs.test-ignore }}
           test-root: ${{ steps.build-test-root.outputs.test-root }}
           update-readme: ${{ inputs.update-readme }}
-          gh-token: ${{ secrets.WRITE_README_AND_DASHBOARD }}


### PR DESCRIPTION
Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>

This removes the write token required to run the CI/CD passes on the transport interopt tests.
