### PR TITLE
fixing the c transport test

### DIFF
--- a/hole-punch/scripts/build-images.sh
+++ b/hole-punch/scripts/build-images.sh
@@ -86,6 +86,7 @@ EOF
                 local commit=$(yq eval ".${yaml_section}[$i].source.commit" impls.yaml)
                 local dockerfile=$(yq eval ".${yaml_section}[$i].source.dockerfile" impls.yaml)
                 local build_context=$(yq eval ".${yaml_section}[$i].source.buildContext // \".\"" impls.yaml)
+                local requires_submodules=$(yq eval ".${yaml_section}[$i].source.requiresSubmodules // false" impls.yaml)
 
                 cat >> "$yaml_file" <<EOF
 
@@ -94,6 +95,8 @@ github:
   commit: $commit
   dockerfile: $dockerfile
   buildContext: $build_context
+
+requiresSubmodules: $requires_submodules
 EOF
                 ;;
 

--- a/perf/scripts/build-images.sh
+++ b/perf/scripts/build-images.sh
@@ -107,6 +107,7 @@ EOF
                 local commit=$(yq eval ".${section}[$i].source.commit" impls.yaml)
                 local dockerfile=$(yq eval ".${section}[$i].source.dockerfile" impls.yaml)
                 local build_context=$(yq eval ".${section}[$i].source.buildContext // \".\"" impls.yaml)
+                local requires_submodules=$(yq eval ".${section}[$i].source.requiresSubmodules // false" impls.yaml)
 
                 cat >> "$yaml_file" <<EOF
 
@@ -115,6 +116,8 @@ github:
   commit: $commit
   dockerfile: $dockerfile
   buildContext: $build_context
+
+requiresSubmodules: $requires_submodules
 EOF
                 ;;
 

--- a/scripts/build-single-image.sh
+++ b/scripts/build-single-image.sh
@@ -30,6 +30,7 @@ sourceType=$(yq eval '.sourceType' "$YAML_FILE")
 forceRebuild=$(yq eval '.forceRebuild' "$YAML_FILE")
 outputStyle=$(yq eval '.outputStyle' "$YAML_FILE")
 cacheDir=$(yq eval '.cacheDir' "$YAML_FILE")
+requiresSubmodules=$(yq eval '.requiresSubmodules // false' "$YAML_FILE")
 
 # Validate required parameters
 if [ -z "$imageName" ] || [ "$imageName" = "null" ]; then
@@ -62,7 +63,13 @@ OUTPUT_FILTER=$(get_output_filter "$outputStyle")
 # Build based on source type
 case "$sourceType" in
     github)
-        build_from_github "$YAML_FILE" "$OUTPUT_FILTER" || exit 1
+        # Check if submodules are required
+        if [ "$requiresSubmodules" = "true" ]; then
+            echo "→ Submodules: required"
+            build_from_github_with_submodules "$YAML_FILE" "$OUTPUT_FILTER" || exit 1
+        else
+            build_from_github "$YAML_FILE" "$OUTPUT_FILTER" || exit 1
+        fi
         ;;
     local)
         build_from_local "$YAML_FILE" "$OUTPUT_FILTER" || exit 1

--- a/scripts/lib-image-building.sh
+++ b/scripts/lib-image-building.sh
@@ -49,6 +49,84 @@ extract_github_snapshot() {
     echo "$work_dir"  # Caller must clean up with: rm -rf "$work_dir"
 }
 
+# Clone GitHub repo with submodules
+# Returns path to work directory (caller must clean up)
+clone_github_repo_with_submodules() {
+    local repo="$1"
+    local commit="$2"
+    local cache_dir="$3"
+
+    local repo_name=$(basename "$repo")
+    local cache_key="${repo_name}-${commit}"
+    local cached_clone="$cache_dir/git-repos/$cache_key"
+
+    # Check if already cloned and cached
+    if [ -d "$cached_clone" ]; then
+        echo "  ✓ [HIT] Using cached git clone: ${commit:0:8}" >&2
+
+        # Copy to temp directory (avoid modifying cache)
+        local work_dir=$(mktemp -d)
+        cp -r "$cached_clone" "$work_dir/$repo_name"
+        echo "$work_dir"
+        return 0
+    fi
+
+    echo "  → [MISS] Cloning repo with submodules..." >&2
+
+    # Create work directory
+    local work_dir=$(mktemp -d)
+    local clone_dir="$work_dir/$repo_name"
+
+    # Clone the repository
+    echo "  → Cloning $repo..." >&2
+    if ! git clone --depth 1 "https://github.com/$repo.git" "$clone_dir" 2>&1 | sed 's/^/    /' >&2; then
+        echo "✗ Failed to clone repository" >&2
+        rm -rf "$work_dir"
+        return 1
+    fi
+
+    # Checkout specific commit (need to unshallow for specific commit)
+    echo "  → Fetching commit ${commit:0:8}..." >&2
+    cd "$clone_dir"
+
+    # First, try to checkout directly (might already have it from shallow clone)
+    if ! git checkout "$commit" 2>/dev/null; then
+        # If not, fetch the specific commit
+        if ! git fetch --depth 1 origin "$commit" 2>&1 | sed 's/^/    /' >&2; then
+            echo "✗ Failed to fetch commit" >&2
+            cd - > /dev/null
+            rm -rf "$work_dir"
+            return 1
+        fi
+
+        if ! git checkout "$commit" 2>&1 | sed 's/^/    /' >&2; then
+            echo "✗ Failed to checkout commit" >&2
+            cd - > /dev/null
+            rm -rf "$work_dir"
+            return 1
+        fi
+    fi
+
+    # Initialize and update submodules
+    echo "  → Initializing submodules..." >&2
+    if ! git submodule update --init --recursive --depth 1 2>&1 | sed 's/^/    /' >&2; then
+        echo "✗ Failed to initialize submodules" >&2
+        cd - > /dev/null
+        rm -rf "$work_dir"
+        return 1
+    fi
+
+    cd - > /dev/null
+
+    # Cache the clone for future use
+    echo "  → Caching git clone..." >&2
+    mkdir -p "$cache_dir/git-repos"
+    cp -r "$clone_dir" "$cached_clone"
+    echo "  ✓ Added to cache: $cache_key" >&2
+
+    echo "$work_dir"  # Return work_dir (caller must clean up)
+}
+
 # Build from GitHub source
 build_from_github() {
     local yaml_file="$1"
@@ -93,6 +171,58 @@ build_from_github() {
     else
         # Use filtering for indented/filtered styles
         if ! eval "docker build -f \"$extracted_dir/$dockerfile\" -t \"$image_name\" \"$context_dir\" 2>&1 | $output_filter"; then
+            echo "✗ Docker build failed"
+            rm -rf "$work_dir"
+            return 1
+        fi
+    fi
+
+    rm -rf "$work_dir"
+    return 0
+}
+
+# Build from GitHub source with submodules support
+build_from_github_with_submodules() {
+    local yaml_file="$1"
+    local output_filter="$2"
+
+    local image_name=$(yq eval '.imageName' "$yaml_file")
+    local repo=$(yq eval '.github.repo' "$yaml_file")
+    local commit=$(yq eval '.github.commit' "$yaml_file")
+    local dockerfile=$(yq eval '.github.dockerfile' "$yaml_file")
+    local build_context=$(yq eval '.github.buildContext' "$yaml_file")
+    local cache_dir=$(yq eval '.cacheDir' "$yaml_file")
+
+    echo "→ Repo: $repo"
+    echo "→ Commit: ${commit:0:8}"
+    echo "→ Method: git clone (submodules enabled)"
+
+    # Clone with submodules
+    local work_dir=$(clone_github_repo_with_submodules "$repo" "$commit" "$cache_dir") || return 1
+    local repo_name=$(basename "$repo")
+    local cloned_dir="$work_dir/$repo_name"
+
+    # Determine build context
+    local context_dir
+    if [ "$build_context" = "." ]; then
+        context_dir="$cloned_dir"
+    else
+        context_dir="$cloned_dir/$build_context"
+    fi
+
+    # Build
+    echo "→ Building Docker image..."
+
+    # Run docker directly (no eval/pipe) for clean output to preserve aesthetic
+    if [ "$output_filter" = "cat" ]; then
+        if ! docker build -f "$cloned_dir/$dockerfile" -t "$image_name" "$context_dir"; then
+            echo "✗ Docker build failed"
+            rm -rf "$work_dir"
+            return 1
+        fi
+    else
+        # Use filtering for indented/filtered styles
+        if ! eval "docker build -f \"$cloned_dir/$dockerfile\" -t \"$image_name\" \"$context_dir\" 2>&1 | $output_filter"; then
             echo "✗ Docker build failed"
             rm -rf "$work_dir"
             return 1

--- a/transport/scripts/build-images.sh
+++ b/transport/scripts/build-images.sh
@@ -85,6 +85,7 @@ EOF
             commit=$(yq eval ".implementations[$i].source.commit" impls.yaml)
             dockerfile=$(yq eval ".implementations[$i].source.dockerfile" impls.yaml)
             build_context=$(yq eval ".implementations[$i].source.buildContext // \".\"" impls.yaml)
+            requires_submodules=$(yq eval ".implementations[$i].source.requiresSubmodules // false" impls.yaml)
 
             cat >> "$yaml_file" <<EOF
 
@@ -93,6 +94,8 @@ github:
   commit: $commit
   dockerfile: $dockerfile
   buildContext: $build_context
+
+requiresSubmodules: $requires_submodules
 EOF
             ;;
 


### PR DESCRIPTION
This adds functions for using git clone and git submodule to check out implementation repos and their submodules when requiresSubmodule is true in the source definition of the implementation. Downloading git zip snapshots doesn't work when a repo has submodules.

Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>
