### PR TITLE
fix: remove c-v0.0.1 from failing alias

### DIFF
--- a/transport/impls.yaml
+++ b/transport/impls.yaml
@@ -31,7 +31,7 @@ test-aliases:
   - alias: "eth-p2p"
     value: "eth-p2p-z-v0.0.1"
   - alias: "failing"
-    value: "c-v0.0.1"
+    value: ""
 
 implementations:
   # Rust implementations


### PR DESCRIPTION
## Summary

Removes `c-v0.0.1` from the failing test alias in `transport/impls.yaml` since all self-tests are now passing.

## Changes

- Updated `transport/impls.yaml` line 34: changed failing alias value from `"c-v0.0.1"` to `""` (empty string)

## Test Results

All c-v0.0.1 self-tests are passing:
- ✓ c-v0.0.1 x c-v0.0.1 (tcp, noise, mplex)
- ✓ c-v0.0.1 x c-v0.0.1 (tcp, noise, yamux)
- ✓ c-v0.0.1 x c-v0.0.1 (quic-v1)

The implementation was fixed by PR #761 which added proper git submodule handling for implementations that require submodules.

## Related

Fixes #763