### PR TITLE
fix docker image naming and selection

### DIFF
--- a/hole-punch/lib/generate-tests.sh
+++ b/hole-punch/lib/generate-tests.sh
@@ -13,6 +13,7 @@ trap 'echo "ERROR in generate-tests.sh at line $LINENO: Command exited with stat
 source "${SCRIPT_LIB_DIR}/lib-filter-engine.sh"
 source "${SCRIPT_LIB_DIR}/lib-generate-tests.sh"
 source "${SCRIPT_LIB_DIR}/lib-image-building.sh"
+source "${SCRIPT_LIB_DIR}/lib-image-naming.sh"
 source "${SCRIPT_LIB_DIR}/lib-output-formatting.sh"
 source "${SCRIPT_LIB_DIR}/lib-test-caching.sh"
 source "${SCRIPT_LIB_DIR}/lib-test-filtering.sh"
@@ -575,12 +576,12 @@ generate_tests_worker() {
             local dialer_router_commit="${router_image_commit[${dialer_router_id}]:-}"
             local listener_router_commit="${router_image_commit[${listener_router_id}]:-}"
 
-            # Get the image names 
-            local dialer_image_name=$(get_image_name "implementations" "${dialer_id}")
-            local listener_image_name=$(get_image_name "implementations" "${listener_id}")
-            local relay_image_name=$(get_image_name "relays" "${relay_id}")
-            local dialer_router_image_name=$(get_image_name "routers" "${dialer_router_id}")
-            local listener_router_image_name=$(get_image_name "routers" "${listener_router_id}")
+            # Get the image names
+            local dialer_image_name=$(get_image_name "${TEST_TYPE}" "implementations" "${dialer_id}")
+            local listener_image_name=$(get_image_name "${TEST_TYPE}" "implementations" "${listener_id}")
+            local relay_image_name=$(get_image_name "${TEST_TYPE}" "relays" "${relay_id}")
+            local dialer_router_image_name=$(get_image_name "${TEST_TYPE}" "routers" "${dialer_router_id}")
+            local listener_router_image_name=$(get_image_name "${TEST_TYPE}" "routers" "${listener_router_id}")
 
             # Process each common transport
             for transport in $common_transports; do

--- a/lib/lib-image-naming.sh
+++ b/lib/lib-image-naming.sh
@@ -1,62 +1,46 @@
 #!/bin/bash
 # Common library for Docker image naming conventions
-# Used by both build-images.sh and create-snapshot.sh
+# Used by both image building and snapshot creation
 
-# Get the Docker image name for an implementation
-# Usage: get_impl_image_name <impl_id> <test_type>
-# test_type: "transport", "hole-punch", or "perf"
-get_impl_image_name() {
-    local impl_id="${1}"
-    local test_type="${2}"
+# Get the Docker image name for any entity type
+# Usage: get_image_name <test_type> <section> <id>
+#
+# Parameters:
+#   test_type: "transport", "hole-punch", or "perf"
+#   section: "implementations", "baselines", "relays", "routers"
+#   id: entity identifier (e.g., "rust-v0.56")
+#
+# Returns: <test_type>-<section>-<id>
+#
+# Examples:
+#   get_image_name "perf" "implementations" "rust-v0.56"
+#     → "perf-implementations-rust-v0.56"
+#   get_image_name "hole-punch" "relays" "go-relay"
+#     → "hole-punch-relays-go-relay"
+get_image_name() {
+    local test_type="${1}"
+    local section="${2}"
+    local id="${3}"
 
+    # Validate test_type
     case "${test_type}" in
-        transport)
-            echo "transport-interop-${impl_id}"
-            ;;
-        hole-punch)
-            echo "hole-punch-peer-${impl_id}"
-            ;;
-        perf)
-            echo "perf-${impl_id}"
+        transport|hole-punch|perf)
             ;;
         *)
             echo "Error: Unknown test type: ${test_type}" >&2
             return 1
             ;;
     esac
-}
 
-# Get the Docker image name for a relay
-# Usage: get_relay_image_name <relay_id> <test_type>
-get_relay_image_name() {
-    local relay_id="${1}"
-    local test_type="${2}"
-
-    case "${test_type}" in
-        hole-punch)
-            echo "hole-punch-relay-${relay_id}"
+    # Validate section
+    case "${section}" in
+        implementations|baselines|relays|routers)
             ;;
         *)
-            echo "Error: Relays not supported for test type: ${test_type}" >&2
+            echo "Error: Unknown section: ${section}" >&2
             return 1
             ;;
     esac
+
+    echo "${test_type}-${section}-${id}"
 }
-
-# Get the Docker image name for a router
-# Usage: get_router_image_name <router_id> <test_type>
-get_router_image_name() {
-    local router_id="${1}"
-    local test_type="${2}"
-
-    case "${test_type}" in
-        hole-punch)
-            echo "hole-punch-router-${router_id}"
-            ;;
-        *)
-            echo "Error: Routers not supported for test type: ${test_type}" >&2
-            return 1
-            ;;
-    esac
-}
-

--- a/perf/lib/generate-tests.sh
+++ b/perf/lib/generate-tests.sh
@@ -13,6 +13,7 @@ trap 'echo "ERROR in generate-tests.sh at line $LINENO: Command exited with stat
 source "${SCRIPT_LIB_DIR}/lib-filter-engine.sh"
 source "${SCRIPT_LIB_DIR}/lib-generate-tests.sh"
 source "${SCRIPT_LIB_DIR}/lib-image-building.sh"
+source "${SCRIPT_LIB_DIR}/lib-image-naming.sh"
 source "${SCRIPT_LIB_DIR}/lib-output-formatting.sh"
 source "${SCRIPT_LIB_DIR}/lib-test-caching.sh"
 source "${SCRIPT_LIB_DIR}/lib-test-filtering.sh"
@@ -559,9 +560,9 @@ EOF
 
     # Get commits, if they exist
     local dialer_commit=$(get_source_commit "${entity_type}" "${dialer}")
-    local dialer_image_name=$(get_image_name "${entity_type}" "${dialer}")
+    local dialer_image_name=$(get_image_name "${TEST_TYPE}" "${entity_type}" "${dialer}")
     local listener_commit=$(get_source_commit "${entity_type}" "${listener}")
-    local listener_image_name=$(get_image_name "${entity_type}" "${dialer}")
+    local listener_image_name=$(get_image_name "${TEST_TYPE}" "${entity_type}" "${listener}")
 
     cat >> "${TEST_PASS_DIR}/test-matrix.yaml" <<EOF
   - id: "${id}"

--- a/transport/lib/generate-tests.sh
+++ b/transport/lib/generate-tests.sh
@@ -13,6 +13,7 @@ trap 'echo "ERROR in generate-tests.sh at line $LINENO: Command exited with stat
 source "${SCRIPT_LIB_DIR}/lib-filter-engine.sh"
 source "${SCRIPT_LIB_DIR}/lib-generate-tests.sh"
 source "${SCRIPT_LIB_DIR}/lib-image-building.sh"
+source "${SCRIPT_LIB_DIR}/lib-image-naming.sh"
 source "${SCRIPT_LIB_DIR}/lib-output-formatting.sh"
 source "${SCRIPT_LIB_DIR}/lib-test-caching.sh"
 source "${SCRIPT_LIB_DIR}/lib-test-filtering.sh"
@@ -348,9 +349,9 @@ generate_tests_worker() {
       local dialer_commit="${image_commit[${dialer_id}]:-}"
       local listener_commit="${image_commit[${listener_id}]:-}"
 
-      # Get the image names 
-      local dialer_image_name=$(get_image_name "implementations" "${dialer_id}")
-      local listener_image_name=$(get_image_name "implementations" "${listener_id}")
+      # Get the image names
+      local dialer_image_name=$(get_image_name "${TEST_TYPE}" "implementations" "${dialer_id}")
+      local listener_image_name=$(get_image_name "${TEST_TYPE}" "implementations" "${listener_id}")
 
       # Process each common transport
       for transport in ${common_transports}; do


### PR DESCRIPTION
This addresses the browser image type and the naming of base images so they build correctly. This also corrects an issue with docker image naming in general so that the snapshot building uses the correct image naming when exporting images into the snapshot.

Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>
