### PR TITLE
ignore failing rust webrtc-direct perf

### DIFF
--- a/perf/images.yaml
+++ b/perf/images.yaml
@@ -21,7 +21,7 @@ test-aliases:
   - alias: "dotnet"
     value: "dotnet-v1.0"
   - alias: "failing" # as of 20 Jan 2026
-    value: "go-v0.45|js-v3.x|dotnet-v1.0"
+    value: "go-v0.45|js-v3.x|dotnet-v1.0|rust-v0.56 x rust-v0.56 (webrtc-direct)"
 
 # Baseline implementations - Separate from main tests
 # These measure raw network/protocol performance for comparison


### PR DESCRIPTION
The rust-v0.56 webrtc-direct perf test is failing. This adds it to the failing list.

Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>
