### PR TITLE
feat: expose known errors input in run-transport-interop-test action

### DIFF
--- a/.github/actions/run-transport-interop-test/action.yml
+++ b/.github/actions/run-transport-interop-test/action.yml
@@ -45,7 +45,7 @@ inputs:
     required: false
     default: false
   known-errors:
-    description: "Regex pattern matching known/expected test failures. Matched failures show as yellow (warning) instead of red (error) and won't fail the workflow."
+    description: "Regex for known test failures. Matched failures show as yellow instead of red and won't fail the workflow. Merged with knownErrors.json if present."
     required: false
     default: ""
 runs:


### PR DESCRIPTION
Add `known-errors` input to the transport interop test action. This lets repos that use the action pass a regex of their own expected failures. The pattern gets merged with `knownErrors.json` if one exists, so both sources work together.

Tested with: https://github.com/vacp2p/nim-libp2p/actions/runs/23485588939?pr=2185 (https://github.com/vacp2p/nim-libp2p/pull/2185)

