### PR TITLE
feat(transport-interop): add Haskell (libp2p-hs) implementation

### DIFF
--- a/transport-interop/impl/haskell/v0.1/.gitignore
+++ b/transport-interop/impl/haskell/v0.1/.gitignore
@@ -1,0 +1,3 @@
+libp2p-hs-*
+*.zip
+image.json

--- a/transport-interop/impl/haskell/v0.1/Makefile
+++ b/transport-interop/impl/haskell/v0.1/Makefile
@@ -1,0 +1,25 @@
+image_name := haskell-v0.1
+commitSha := 574acdc43f824090f8d397e4e36ea8a5d2fb8317
+
+all: image.json
+
+# Build the image from libp2p-hs's own root Dockerfile, which compiles the
+# libp2p-interop daemon. dockerBuildWrapper.sh runs:
+#   docker buildx build --load -t $(image_name) .
+image.json: libp2p-hs-${commitSha}
+	cd libp2p-hs-${commitSha} && IMAGE_NAME=${image_name} ../../../../dockerBuildWrapper.sh .
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+libp2p-hs-${commitSha}: libp2p-hs-${commitSha}.zip
+	unzip -o libp2p-hs-${commitSha}.zip
+
+libp2p-hs-${commitSha}.zip:
+	wget -O $@ "https://github.com/adust09/libp2p-hs/archive/${commitSha}.zip"
+
+.PHONY: clean all
+
+clean:
+	rm -f image.json
+	rm -f libp2p-hs-*.zip
+	rm -rf libp2p-hs-*

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -472,6 +472,7 @@
   },
   {
     "id": "haskell-v0.1",
+    "containerImageID": "ghcr.io/libp2p/test-plans/transport-interop/haskell-v0.1",
     "transports": [
       "tcp"
     ],

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -469,5 +469,17 @@
     ],
     "secureChannels": [],
     "muxers": []
+  },
+  {
+    "id": "haskell-v0.1",
+    "transports": [
+      "tcp"
+    ],
+    "secureChannels": [
+      "noise"
+    ],
+    "muxers": [
+      "yamux"
+    ]
   }
 ]


### PR DESCRIPTION
Register libp2p-hs as a transport-interop implementation (haskell-v0.1), supporting TCP + Noise + Yamux.

- impl/haskell/v0.1/Makefile: fetches libp2p-hs at a pinned commit and builds its root Dockerfile (which produces the libp2p-interop daemon) via dockerBuildWrapper.sh, writing image.json.
- versionsInput.json: add haskell-v0.1 (transports: tcp, secureChannels: noise, muxers: yamux). containerImageID is omitted so the canonical image.json lookup is used.