### PR TITLE
feat(transport-interop): add nim-libp2p v2.0.0

### DIFF
--- a/transport-interop/impl/nim/v2.0/Dockerfile
+++ b/transport-interop/impl/nim/v2.0/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.5-labs
+FROM nimlang/nim:2.2.10 as builder
+
+WORKDIR /app
+
+COPY .pinned libp2p.nimble nim-libp2p/
+
+RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y --no-install-recommends ca-certificates binutils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd nim-libp2p && nimble install -y redis && nimble install_pinned
+
+COPY . nim-libp2p/
+
+RUN \
+  cd nim-libp2p && \
+  nim c -d:release --skipProjCfg --skipParentCfg --NimblePath:./nimbledeps/pkgs2 --mm:refc -d:chronicles_log_level=WARN -d:chronicles_default_output_device=stderr --threads:on -o:/app/interop ./interop/transport/main.nim
+
+
+FROM debian:trixie-slim AS runtime
+
+COPY --from=builder /app/interop /app/interop
+
+ENTRYPOINT ["/app/interop"]

--- a/transport-interop/impl/nim/v2.0/Makefile
+++ b/transport-interop/impl/nim/v2.0/Makefile
@@ -1,0 +1,22 @@
+image_name := nim-v2.0
+commitSha := c43199378f46d0aaf61be1cad1ee1d63e8f665d6
+
+all: image.json
+
+image.json: nim-libp2p-${commitSha}
+	IMAGE_NAME=${image_name} ../../../dockerBuildWrapper.sh -f Dockerfile nim-libp2p-${commitSha}
+	docker image inspect ${image_name} -f "{{.Id}}" | \
+		xargs -I {} echo "{\"imageID\": \"{}\"}" > $@
+
+nim-libp2p-${commitSha}: nim-libp2p-${commitSha}.zip
+	unzip -o nim-libp2p-${commitSha}.zip
+
+nim-libp2p-${commitSha}.zip:
+	wget -O $@ "https://github.com/status-im/nim-libp2p/archive/${commitSha}.zip"
+
+clean:
+	rm image.json
+	rm nim-libp2p-*.zip
+	rm -rf nim-libp2p-*
+
+.PHONY: clean all

--- a/transport-interop/versionsInput.json
+++ b/transport-interop/versionsInput.json
@@ -303,6 +303,22 @@
     ]
   },
   {
+    "id": "nim-v2.0.0",
+    "containerImageID": "ghcr.io/libp2p/test-plans/transport-interop/nim-v2.0",
+    "transports": [
+      "tcp",
+      "ws",
+      "quic-v1"
+    ],
+    "secureChannels": [
+      "noise"
+    ],
+    "muxers": [
+      "mplex",
+      "yamux"
+    ]
+  },
+  {
     "id": "js-v1.x",
     "containerImageID": "ghcr.io/libp2p/test-plans/transport-interop/js-v1.x",
     "transports": [


### PR DESCRIPTION
Adds nim-libp2p 2.0 to the list of possible transport-interop tests