### PR TITLE
chore: update jvm-libp2p to 1.3.6

### DIFF
--- a/gossipsub-interop/jvm-libp2p/build.gradle.kts
+++ b/gossipsub-interop/jvm-libp2p/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.libp2p:jvm-libp2p:1.3.0-RELEASE")
+    implementation("io.libp2p:jvm-libp2p:1.3.6-RELEASE")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.3")
 
     testImplementation(kotlin("test"))

--- a/transport-interop/impl/jvm/v1.3/Makefile
+++ b/transport-interop/impl/jvm/v1.3/Makefile
@@ -1,5 +1,5 @@
 image_name := jvm-libp2p-v1.3
-commitSha := c34cc114950a7af352d30ea63c70d98795fd9aaa
+commitSha := d0668fd56338d3618ccb19eb4b7bfeede888c27d
 
 all: image.json
 


### PR DESCRIPTION
Update gossipsub-interop dependency to 1.3.6-RELEASE and transport-interop Makefile to commit d0668fd56338d3618ccb19eb4b7bfeede888c27d.